### PR TITLE
do not specify postgres user as owner in migrations

### DIFF
--- a/packages/sync-engine/src/database/migrations/0012_add_updated_at.sql
+++ b/packages/sync-engine/src/database/migrations/0012_add_updated_at.sql
@@ -8,8 +8,6 @@ begin
 end;
 $$;
 
-alter function set_updated_at() owner to postgres;
-
 alter table stripe.subscriptions
     add updated_at timestamptz default timezone('utc'::text, now()) not null;
 


### PR DESCRIPTION
Problem:
- Migration `0012_add_updated_at.sql` line 11 has: `alter function set_updated_at() owner to postgres;`
- This fails on Neon and other managed databases that don't have a postgres role

Solution:
- Since you don't need backwards compatibility (fresh databases only), we'll simply remove the problematic line.

Changes:
- Edit /packages/sync-engine/src/database/migrations/0012_add_updated_at.sql
- Remove line 11: alter function set_updated_at() owner to postgres;
- The function will automatically be owned by the role executing the migration (the desired behavior)

Why this works:
- When you create a function in PostgreSQL, it's automatically owned by the user/role that created it
- Explicitly setting the owner is unnecessary and causes portability issues
- This is the only migration file with hardcoded role references (verified via grep)

Impact:
- Works on Neon and any other managed PostgreSQL service
- No backwards compatibility issues since you're using fresh databases
- The function will work identically, just with the correct owner