### PR TITLE
[supabase deploy] add proper authentication to edge functions

### DIFF
--- a/packages/sync-engine/scripts/cleanup-deploy.sh
+++ b/packages/sync-engine/scripts/cleanup-deploy.sh
@@ -149,7 +149,7 @@ echo "   Deleting vault secret..."
 curl -s --max-time 10 -X POST "https://api.supabase.com/v1/projects/$SUPABASE_PROJECT_REF/database/query" \
     -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
     -H "Content-Type: application/json" \
-    -d '{"query": "DELETE FROM vault.secrets WHERE name = '"'"'stripe_sync_service_role_key'"'"'"}' > /dev/null 2>&1 || true
+    -d '{"query": "DELETE FROM vault.secrets WHERE name = '"'"'stripe_sync_worker_secret'"'"'"}' > /dev/null 2>&1 || true
 
 # Drop stripe schema
 echo "   Dropping stripe schema..."

--- a/packages/sync-engine/scripts/test-integration-deploy.sh
+++ b/packages/sync-engine/scripts/test-integration-deploy.sh
@@ -568,7 +568,7 @@ fi
 
 # Test 2: GET with auth should return status
 echo "   Testing GET with auth (should return 200)..."
-STATUS_RESPONSE=$(curl -s -H "Authorization: Bearer $SERVICE_ROLE_KEY" \
+STATUS_RESPONSE=$(curl -s -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
     "https://$SUPABASE_PROJECT_REF.$SUPABASE_BASE_URL/functions/v1/stripe-setup")
 
 # Verify response has package_version field

--- a/packages/sync-engine/src/supabase/edge-functions/stripe-setup.ts
+++ b/packages/sync-engine/src/supabase/edge-functions/stripe-setup.ts
@@ -224,7 +224,7 @@ Deno.serve(async (req) => {
       try {
         await stripeSync.postgresClient.query(`
           DELETE FROM vault.secrets
-          WHERE name = 'stripe_sync_service_role_key'
+          WHERE name = 'stripe_sync_worker_secret'
         `)
       } catch (err) {
         console.warn('Could not delete vault secret:', err)


### PR DESCRIPTION
`stripe-setup`: Validates accessToken against Management API (instead of jwt_verify) to ensure only authorized users can install/uninstall                                      
                                                                                                                                                                                
`stripe-worker`: Validates incoming token matches the exact a secret stored in vault to ensure only pg_cron can invoke it. this PR also removes service_role_key previously used

`stripe-webhook`: stays as-is and uses stripe webhook secret validation