### PR TITLE
Update management api secret name to not violate Supabase secret naming requirements

### DIFF
--- a/packages/sync-engine/src/supabase/edge-functions/stripe-setup.ts
+++ b/packages/sync-engine/src/supabase/edge-functions/stripe-setup.ts
@@ -3,7 +3,7 @@ import postgres from 'npm:postgres'
 
 // Get management API base URL from environment variable (for testing against localhost/staging)
 // Caller should provide full URL with protocol (e.g., http://localhost:54323 or https://api.supabase.com)
-const MGMT_API_BASE_RAW = Deno.env.get('SUPABASE_MANAGEMENT_URL') || 'https://api.supabase.com'
+const MGMT_API_BASE_RAW = Deno.env.get('MANAGEMENT_API_URL') || 'https://api.supabase.com'
 const MGMT_API_BASE = MGMT_API_BASE_RAW.match(/^https?:\/\//)
   ? MGMT_API_BASE_RAW
   : `https://${MGMT_API_BASE_RAW}`

--- a/packages/sync-engine/src/supabase/supabase.test.ts
+++ b/packages/sync-engine/src/supabase/supabase.test.ts
@@ -559,10 +559,10 @@ describe('SupabaseDeployClient', () => {
 
       await client.install('sk_test_key')
 
-      // Should set both STRIPE_SECRET_KEY and SUPABASE_MANAGEMENT_URL
+      // Should set both STRIPE_SECRET_KEY and MANAGEMENT_API_URL
       expect(mockSetSecrets).toHaveBeenCalledWith([
         { name: 'STRIPE_SECRET_KEY', value: 'sk_test_key' },
-        { name: 'SUPABASE_MANAGEMENT_URL', value: 'http://localhost:54323' },
+        { name: 'MANAGEMENT_API_URL', value: 'http://localhost:54323' },
       ])
     })
 

--- a/packages/sync-engine/src/supabase/supabase.ts
+++ b/packages/sync-engine/src/supabase/supabase.ts
@@ -437,9 +437,9 @@ export class SupabaseSetupClient {
 
       // Set secrets (Note: "secrets" is Supabase's mechanism for passing environment variables to edge functions)
       const secrets = [{ name: 'STRIPE_SECRET_KEY', value: trimmedStripeKey }]
-      // Add SUPABASE_MANAGEMENT_URL if custom URL provided (for localhost/staging testing)
+      // Add MANAGEMENT_API_URL if custom URL provided (for localhost/staging testing)
       if (this.supabaseManagementUrl) {
-        secrets.push({ name: 'SUPABASE_MANAGEMENT_URL', value: this.supabaseManagementUrl })
+        secrets.push({ name: 'MANAGEMENT_API_URL', value: this.supabaseManagementUrl })
       }
       await this.setSecrets(secrets)
 


### PR DESCRIPTION
Basically it can't start with `SUPABASE_`