### PR TITLE
Migration to remove sigma tables from stripe schema

### DIFF
--- a/packages/sync-engine/src/database/migrations/0063_drop_sigma_subscription_item_and_exchange_rate_tables.sql
+++ b/packages/sync-engine/src/database/migrations/0063_drop_sigma_subscription_item_and_exchange_rate_tables.sql
@@ -1,0 +1,3 @@
+-- Drop unused sigma beta tables if they exist.
+DROP TABLE IF EXISTS "stripe"."subscription_item_change_events_v2_beta";
+DROP TABLE IF EXISTS "stripe"."exchange_rates_from_usd";

--- a/packages/sync-engine/src/database/postgres.ts
+++ b/packages/sync-engine/src/database/postgres.ts
@@ -15,9 +15,7 @@ type PostgresConfig = {
  * using the `order` field, since deletion order != creation order.
  */
 const ORDERED_STRIPE_TABLES = [
-  'exchange_rates_from_usd',
   'subscription_items',
-  'subscription_item_change_events_v2_beta',
   'subscriptions',
   'subscription_schedules',
   'checkout_session_line_items',


### PR DESCRIPTION
These 2 were added as the first prototype for syncing reporting datasets. The package now supports full reporting dataset sync, auto-gened from the Stripe Reporting data schema. Adding a migration to drop these tables from "stripe" schema