### PR TITLE
fix: failing installation due to missing stripe-setup function

### DIFF
--- a/packages/sync-engine/src/supabase/supabase.ts
+++ b/packages/sync-engine/src/supabase/supabase.ts
@@ -1,5 +1,6 @@
 import { SupabaseManagementAPI } from 'supabase-management-js'
 import {
+  setupFunctionCode,
   webhookFunctionCode,
   workerFunctionCode,
   sigmaWorkerFunctionCode,
@@ -538,6 +539,9 @@ export class SupabaseSetupClient {
         secrets.push({ name: 'SYNC_INTERVAL', value: String(syncIntervalSeconds) })
       }
       await this.setSecrets(secrets)
+
+      const versionedSetup = this.injectPackageVersion(setupFunctionCode, version)
+      await this.deployFunction('stripe-setup', versionedSetup, false)
 
       // Run setup (migrations + webhook creation)
       // Use accessToken for Management API validation


### PR DESCRIPTION
During one of the recent commits there was a regression in the install flow in which the `stripe-setup` edge function was not being deployed, resulting in install failures.