### PR TITLE
fix: remove validateProject

### DIFF
--- a/packages/sync-engine/src/supabase/supabase.ts
+++ b/packages/sync-engine/src/supabase/supabase.ts
@@ -42,30 +42,6 @@ export class SupabaseSetupClient {
   }
 
   /**
-   * Validate that the project exists and we have access.
-   * Fetches the project directly by ref instead of listing all projects,
-   * because some org-level tokens lack the list-all permission.
-   */
-  async validateProject(): Promise<ProjectInfo> {
-    const baseUrl = this.supabaseManagementUrl || 'https://api.supabase.com'
-    const response = await fetch(`${baseUrl}/v1/projects/${this.projectRef}`, {
-      headers: { Authorization: `Bearer ${this.accessToken}` },
-    })
-    if (!response.ok) {
-      const body = await response.text()
-      throw new Error(
-        `Project ${this.projectRef} not found or you don't have access (${response.status}: ${body})`
-      )
-    }
-    const project = await response.json()
-    return {
-      id: project.ref,
-      name: project.name,
-      region: project.region,
-    }
-  }
-
-  /**
    * Deploy an Edge Function
    */
   async deployFunction(name: string, code: string, verifyJwt = false): Promise<void> {
@@ -524,9 +500,6 @@ export class SupabaseSetupClient {
     const version = packageVersion || 'latest'
 
     try {
-      // Validate project
-      await this.validateProject()
-
       // Create schema if it doesn't exist (before we can comment on it)
       await this.runSQL(`CREATE SCHEMA IF NOT EXISTS stripe`)
 


### PR DESCRIPTION
Calling `validateProject` failed on branch projects because the /projects api doesn't return branch projects. While it was possible to get branch projects by getting other api endpoints, it's needlessly complex to just verify if a project exists or not. Instead we omit this call and let the other api calls fail during installation if the project doesn't exist or there are permission issues. Ideally we'd have a token introspection api which can tell us which permissions the current token has, but we don't have such an api endpoint exposed currently.

Removing this call fixes a bug in which users were not able to install the stripe sync engine on their Supabase branch projects.
