### PR TITLE
fix: add type to a variable

### DIFF
--- a/packages/sync-engine/src/supabase/edge-functions/stripe-setup.ts
+++ b/packages/sync-engine/src/supabase/edge-functions/stripe-setup.ts
@@ -105,7 +105,7 @@ Deno.serve(async (req) => {
       })
     }
 
-    let sql
+    let sql: ReturnType<typeof postgres> | undefined
 
     try {
       sql = postgres(dbUrl, { max: 1, prepare: false })


### PR DESCRIPTION
Add explicit type to fix a warning about `any` type in vscode.