### PR TITLE
fix: remove validateAccessToken and check stripe key is set

### DIFF
--- a/packages/sync-engine/src/supabase/edge-functions/sigma-data-worker.ts
+++ b/packages/sync-engine/src/supabase/edge-functions/sigma-data-worker.ts
@@ -5,8 +5,8 @@
  * Progress persists in _sync_runs and _sync_obj_runs across invocations.
  */
 
-import { StripeSync } from '../../index.ts'
 import postgres from 'postgres'
+import { StripeSync } from '../../index.ts'
 
 const BATCH_SIZE = 1
 const MAX_RUN_AGE_MS = 6 * 60 * 60 * 1000
@@ -68,9 +68,14 @@ Deno.serve(async (req) => {
       return new Response('Forbidden: Invalid sigma worker secret', { status: 403 })
     }
 
+    const stripeSecretKey = Deno.env.get('STRIPE_SECRET_KEY')
+    if (!stripeSecretKey) {
+      return jsonResponse({ error: 'STRIPE_SECRET_KEY not set' }, 500)
+    }
+
     stripeSync = await StripeSync.create({
       poolConfig: { connectionString: dbUrl, max: 1 },
-      stripeSecretKey: Deno.env.get('STRIPE_SECRET_KEY')!,
+      stripeSecretKey,
       enableSigma: true,
       sigmaPageSizeOverride: 1000,
       schemaName,

--- a/packages/sync-engine/src/supabase/edge-functions/stripe-setup.ts
+++ b/packages/sync-engine/src/supabase/edge-functions/stripe-setup.ts
@@ -12,23 +12,6 @@ const MGMT_API_BASE = MGMT_API_BASE_RAW.match(/^https?:\/\//)
   ? MGMT_API_BASE_RAW
   : `https://${MGMT_API_BASE_RAW}`
 
-// Helper to validate accessToken against Management API
-async function validateAccessToken(projectRef: string, accessToken: string): Promise<boolean> {
-  // Try to fetch project details using the access token
-  // This validates that the token is valid for the management API
-  const url = `${MGMT_API_BASE}/v1/projects/${projectRef}`
-  const response = await fetch(url, {
-    method: 'GET',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-    },
-  })
-
-  // If we can successfully get the project, the token is valid
-  return response.ok
-}
-
 // Helper to delete edge function via Management API
 async function deleteEdgeFunction(
   projectRef: string,
@@ -90,10 +73,6 @@ Deno.serve(async (req) => {
   }
 
   const accessToken = authHeader.substring(7) // Remove 'Bearer '
-  const isValid = await validateAccessToken(projectRef, accessToken)
-  if (!isValid) {
-    return new Response('Forbidden: Invalid access token for this project', { status: 403 })
-  }
 
   // Handle GET requests for status
   if (req.method === 'GET') {
@@ -409,7 +388,7 @@ Deno.serve(async (req) => {
     if (!supabaseUrl) {
       throw new Error('SUPABASE_URL environment variable is not set')
     }
-    const webhookUrl = supabaseUrl + '/functions/v1/stripe-webhook'
+    const webhookUrl = `'${supabaseUrl}/functions/v1/stripe-webhook`
 
     const webhook = await stripeSync.webhook.findOrCreateManagedWebhook(webhookUrl)
 


### PR DESCRIPTION
This PR:

* Removes call to the `validateAccessToken` function for the same reasons as in https://github.com/stripe/sync-engine/pull/134
* Checks that `STRIPE_SECRET_KEY` is set in `sigma-data-worker.ts` and returns an error if not set instead of using a non-null assertion.