### PR TITLE
chore: deprecate package and point to new repo

### DIFF
--- a/packages/sync-engine/package.json
+++ b/packages/sync-engine/package.json
@@ -1,8 +1,8 @@
 {
   "name": "stripe-experiment-sync",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "private": false,
-  "description": "Stripe Sync Engine to sync Stripe data to Postgres",
+  "description": "DEPRECATED - This package has moved to https://github.com/stripe/sync-engine",
   "type": "module",
   "main": "./dist/index.cjs",
   "bin": "./dist/cli/index.js",
@@ -69,11 +69,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/stripe-experiments/sync-engine.git"
+    "url": "https://github.com/stripe/sync-engine.git"
   },
-  "homepage": "https://github.com/stripe-experiments/sync-engine#readme",
+  "homepage": "https://github.com/stripe/sync-engine#readme",
   "bugs": {
-    "url": "https://github.com/stripe-experiments/sync-engine/issues"
+    "url": "https://github.com/stripe/sync-engine/issues"
   },
   "keywords": [
     "stripe",


### PR DESCRIPTION
Bump version to 1.0.25, mark as deprecated, and update URLs to https://github.com/stripe/sync-engine.