### PR TITLE
fix: constructed webhook url was invalid

### DIFF
--- a/packages/sync-engine/src/supabase/edge-functions/stripe-setup.ts
+++ b/packages/sync-engine/src/supabase/edge-functions/stripe-setup.ts
@@ -388,7 +388,7 @@ Deno.serve(async (req) => {
     if (!supabaseUrl) {
       throw new Error('SUPABASE_URL environment variable is not set')
     }
-    const webhookUrl = `'${supabaseUrl}/functions/v1/stripe-webhook`
+    const webhookUrl = `${supabaseUrl}/functions/v1/stripe-webhook`
 
     const webhook = await stripeSync.webhook.findOrCreateManagedWebhook(webhookUrl)
 


### PR DESCRIPTION
During one of the last PRs the way webhook URL was constructed was changed to use string interpolation instead of string concatenation, but the new method left a quote in front of the URL, making it invalid and failing the installation. This PR fixes that bug.