### PR TITLE
fix: reduce chances of install timing out

### DIFF
--- a/packages/sync-engine/src/supabase/supabase.ts
+++ b/packages/sync-engine/src/supabase/supabase.ts
@@ -560,9 +560,14 @@ export class SupabaseSetupClient {
       // This is done after marking the installation as completed in the comment because
       // running the `stripe-worker` might take some time and timeout the actual installation
       // if done before. This is fine because even if this invocation fails for some reason
-      // the installation is still completed and this is invoked on a a best effort basis
+      // the installation is still completed and this is invoked on a best effort basis
       // to improve UX.
-      await this.invokeFunction('stripe-worker', 'POST', this.workerSecret)
+      try {
+        await this.invokeFunction('stripe-worker', 'POST', this.workerSecret)
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        console.warn(`Failed to invoke stripe-worker: ${errorMessage}`)
+      }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error)
       try {


### PR DESCRIPTION
Moved the code to mark installation done before invoking the `stripe-worker` edge function to reduce chances of the installation timing out. This is fine because invoking the `stripe-worker` edge function is only done to improve the user experience and is not required strictly to complete the installation.