### PR TITLE
Deno is caching old keys (sync failure)

### DIFF
--- a/packages/sync-engine/src/stripeSyncWorker.ts
+++ b/packages/sync-engine/src/stripeSyncWorker.ts
@@ -77,8 +77,18 @@ export class StripeSyncWorker {
             }
           )
         }
-        this.config.logger?.error({ err }, 'Task processing failed; sleeping 1s before retry')
-        await new Promise((r) => setTimeout(r, 100))
+        const errStr = String(err).toLowerCase()
+        if (errStr.includes('expired')) {
+          // wait out the key rotation edge case
+          this.config.logger?.error(
+            { err },
+            'Task processing failed (expired); sleeping 60s before retry'
+          )
+          await new Promise((r) => setTimeout(r, 60_000))
+        } else {
+          this.config.logger?.error({ err }, 'Task processing failed; sleeping 100ms before retry')
+          await new Promise((r) => setTimeout(r, 100))
+        }
       }
     }
   }

--- a/packages/sync-engine/src/supabase/edge-functions/stripe-worker.ts
+++ b/packages/sync-engine/src/supabase/edge-functions/stripe-worker.ts
@@ -24,20 +24,20 @@ const schemaName = Deno.env.get('SYNC_SCHEMA_NAME') ?? 'stripe'
 const syncTablesSchemaName = Deno.env.get('SYNC_TABLES_SCHEMA_NAME') ?? schemaName
 
 const sql = postgres(dbUrl, { max: 1, prepare: false })
-const stripeSync = await StripeSync.create({
-  poolConfig: { connectionString: dbUrl, max: 1 },
-  stripeSecretKey: Deno.env.get('STRIPE_SECRET_KEY')!,
-  enableSigma: false,
-  partnerId: 'pp_supabase',
-  schemaName,
-  syncTablesSchemaName,
-})
-const objects = stripeSync.getSupportedSyncObjects()
-const tableNames = objects.map(
-  (obj: keyof typeof stripeSync.resourceRegistry) => stripeSync.resourceRegistry[obj].tableName
-)
 
 Deno.serve(async (req) => {
+  const stripeSync = await StripeSync.create({
+    poolConfig: { connectionString: dbUrl, max: 1 },
+    stripeSecretKey: Deno.env.get('STRIPE_SECRET_KEY')!,
+    enableSigma: false,
+    partnerId: 'pp_supabase',
+    schemaName,
+    syncTablesSchemaName,
+  })
+  const objects = stripeSync.getSupportedSyncObjects()
+  const tableNames = objects.map(
+    (obj: keyof typeof stripeSync.resourceRegistry) => stripeSync.resourceRegistry[obj].tableName
+  )
   const authHeader = req.headers.get('Authorization')
   if (!authHeader?.startsWith('Bearer ')) {
     return new Response('Unauthorized', { status: 401 })


### PR DESCRIPTION
## Summary
Stripe app key rotation is causing a sync failure due to invalidated api key being cached in the edge function. 
To mitigate this StripeSync initialization is moved inside deno.serve.

## How to test (optional)

Tested in production


