### PR TITLE
Publish Docker Hub latest from CI pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,3 +279,40 @@ jobs:
           bash e2e/publish.test.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ---------------------------------------------------------------------------
+  # Docker Hub — promote the tested GHCR image to Docker Hub tags
+  # ---------------------------------------------------------------------------
+  publish_dockerhub:
+    name: Publish Docker Hub
+    needs: [test, build, e2e]
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: scripts/promote-to-dockerhub.sh
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_SYNC_ENGINE }}
+
+      - name: Sanitize ref name for Docker tag
+        id: tag
+        run: echo "name=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Promote tested image to Docker Hub
+        run: bash scripts/promote-to-dockerhub.sh
+        env:
+          GHCR_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+          DOCKERHUB_TAGS: ${{ steps.tag.outputs.name }} latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,46 +7,12 @@ on:
         description: 'Commit SHA to promote (must have passed the CI build job)'
         required: true
         type: string
-      dockerhub_tags:
-        description: 'Optional extra Docker Hub tags to publish in addition to the sha tag (for example: latest or v2 latest)'
-        required: false
-        default: latest
-        type: string
 
 permissions:
   packages: read
   contents: read
 
 jobs:
-  docker:
-    name: Promote Docker image to Docker Hub
-    runs-on: ubuntu-24.04
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.sha }}
-          sparse-checkout: scripts/promote-to-dockerhub.sh
-
-      - name: Login to ghcr.io
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN_SYNC_ENGINE }}
-
-      - name: Promote to Docker Hub
-        run: bash scripts/promote-to-dockerhub.sh
-        env:
-          GHCR_IMAGE: ghcr.io/${{ github.repository }}:${{ inputs.sha }}
-          DOCKERHUB_TAGS: ${{ inputs.dockerhub_tags }}
-
   npm:
     name: Promote npm packages to npmjs.org
     runs-on: ubuntu-24.04

--- a/docs/pages/local-registries.md
+++ b/docs/pages/local-registries.md
@@ -38,7 +38,7 @@ The publish script (`tests/e2e-publish.sh`) publishes every workspace package, t
 
 ## Docker
 
-Docker images are built locally with `docker build` and in CI are pushed to `ghcr.io`. Release promotes from `ghcr.io` to Docker Hub (`stripe/sync-engine`).
+Docker images are built locally with `docker build`. In CI, pushes to `main` and `v2` first publish a multi-arch image to `ghcr.io`, then the same tested image is promoted to Docker Hub (`stripe/sync-engine`) with the branch tag and `latest`.
 
 ```sh
 # Build and test locally


### PR DESCRIPTION
## Summary
- publish Docker Hub from the existing `CI` workflow on push, using the already-built multi-arch GHCR image as the source image
- tag Docker Hub automatically with the commit sha, the branch tag, and `latest`
- remove Docker publishing from the manual `Release` workflow so there is only one Docker publish path
- update the Docker docs to match the new flow

## Motivation
- `third-party-containers` is consuming `stripe/sync-engine:latest`
- the previous Docker Hub flow was a separate manual promotion step, which made it too easy for `latest` to lag behind the tested image
- we want one automatic path that publishes the same multi-arch image CI already built and tested

## Test plan
- `pnpm format:check`
- `ruby -e "require '"'"'yaml'"'"'; YAML.load_file('"'"'.github/workflows/ci.yml'"'"'); YAML.load_file('"'"'.github/workflows/release.yml'"'"')"`
