### PR TITLE
Publish Docker Hub without waiting for e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,11 +281,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ---------------------------------------------------------------------------
-  # Docker Hub — promote the tested GHCR image to Docker Hub tags
+  # Docker Hub — promote the built GHCR image to Docker Hub tags
   # ---------------------------------------------------------------------------
   publish_dockerhub:
     name: Publish Docker Hub
-    needs: [test, build, e2e]
+    needs: [build]
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-24.04
 
@@ -311,7 +311,7 @@ jobs:
         id: tag
         run: echo "name=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
-      - name: Promote tested image to Docker Hub
+      - name: Promote built image to Docker Hub
         run: bash scripts/promote-to-dockerhub.sh
         env:
           GHCR_IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/docs/pages/local-registries.md
+++ b/docs/pages/local-registries.md
@@ -38,7 +38,7 @@ The publish script (`tests/e2e-publish.sh`) publishes every workspace package, t
 
 ## Docker
 
-Docker images are built locally with `docker build`. In CI, pushes to `main` and `v2` first publish a multi-arch image to `ghcr.io`, then the same tested image is promoted to Docker Hub (`stripe/sync-engine`) with the branch tag and `latest`.
+Docker images are built locally with `docker build`. In CI, pushes to `main` and `v2` first publish a multi-arch image to `ghcr.io`, then the same built image is promoted to Docker Hub (`stripe/sync-engine`) with the branch tag and `latest`.
 
 ```sh
 # Build and test locally


### PR DESCRIPTION
## Summary
- publish Docker Hub after the `build` job instead of waiting for the full `e2e` job
- keep using the already-built multi-arch GHCR image as the Docker Hub source image
- update the Docker docs to match the new behavior

## Motivation
- `latest` should still move even if the service e2e check is flaky
- the previous version of the workflow skipped Docker Hub publication when `Service → Engine e2e` failed

## Test plan
- `pnpm format:check`
- `ruby -e "require '"'"'yaml'"'"'; YAML.load_file('"'"'.github/workflows/ci.yml'"'"')"`
