### PR TITLE
Disable Next telemetry during Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . ./
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 ENV NODE_OPTIONS="--max-old-space-size=4096"
-RUN pnpm build
+RUN NEXT_TELEMETRY_DISABLED=1 pnpm build
 
 # Create standalone deployment with lockfile-pinned deps
 FROM build AS deploy


### PR DESCRIPTION
## Summary
- disable Next.js telemetry during Docker builds by setting `NEXT_TELEMETRY_DISABLED=1` for the `pnpm build` step in the Dockerfile

## Motivation
- keep Docker build logs cleaner
- avoid shipping the telemetry notice in image build output
- scope the change to Docker builds only

## Test plan
- `NEXT_TELEMETRY_DISABLED=1 pnpm --filter @stripe/sync-visualizer build`
