### PR TITLE
test smokescreen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,17 @@ jobs:
           GOOGLE_REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}
           GOOGLE_SPREADSHEET_ID: ${{ vars.GOOGLE_SPREADSHEET_ID }}
 
+      - name: Smokescreen proxy e2e
+        run: |
+          if [ -z "${STRIPE_API_KEY:-}" ]; then
+            echo "::warning::smokescreen.test.sh skipped — STRIPE_API_KEY not available"
+            exit 0
+          fi
+          bash e2e/smokescreen.test.sh
+        env:
+          STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
+          ENGINE_IMAGE: 'ghcr.io/${{ github.repository }}:${{ github.sha }}'
+
       # --- Connector loading test ---
 
       - name: Connector loading test

--- a/docker/smokescreen/Dockerfile
+++ b/docker/smokescreen/Dockerfile
@@ -1,0 +1,18 @@
+# Pinned release: v0.0.4 — https://github.com/stripe/smokescreen/releases/tag/v0.0.4
+ARG SMOKESCREEN_SHA=e196cd61a007e1cdbde5579fe2dac95e7154190c
+
+FROM golang:1.23 AS builder
+ARG SMOKESCREEN_SHA
+WORKDIR /app
+RUN set -eu; \
+  git init; \
+  git remote add origin https://github.com/stripe/smokescreen.git; \
+  git fetch --depth 1 origin "${SMOKESCREEN_SHA}"; \
+  git checkout FETCH_HEAD; \
+  test "$(git rev-parse HEAD)" = "${SMOKESCREEN_SHA}"
+RUN CGO_ENABLED=0 GOOS=linux go build -o smokescreen -ldflags="-s -w" .
+
+FROM alpine:3.19
+RUN apk add --no-cache netcat-openbsd
+COPY --from=builder /app/smokescreen /usr/local/bin/smokescreen
+ENTRYPOINT ["smokescreen"]

--- a/e2e/smokescreen.test.sh
+++ b/e2e/smokescreen.test.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 # Stripe read through smokescreen (HTTP CONNECT) with Docker network isolation.
-# Engine has no default route on the internal network; outbound HTTPS to Stripe
-# must use HTTPS_PROXY → smokescreen (also connected to bridge for internet).
-# Postgres runs on the same internal network (TCP, no proxy).
+# Engine has no default route on the --internal network; outbound HTTPS to Stripe
+# must use HTTPS_PROXY → smokescreen (bridged to default network for internet).
+# Postgres runs on the same internal network (direct TCP, no proxy).
+#
+# Because --internal blocks host ↔ container traffic (including -p port publish),
+# all curl commands run inside a test-runner container on the internal network.
 #
 # Required: STRIPE_API_KEY
 # Optional: ENGINE_IMAGE (CI: pre-built image; skips local docker build)
@@ -22,13 +25,25 @@ NET="smokescreen-isolated-${S}"
 SMOKESCREEN_CONTAINER="smokescreen-${S}"
 ENGINE_CONTAINER="engine-smokescreen-${S}"
 PG_CONTAINER="pg-smokescreen-${S}"
-ENGINE_PORT="${PORT:-3399}"
+CURL_CONTAINER="curl-smokescreen-${S}"
+ENGINE_URL="http://${ENGINE_CONTAINER}:3000"
+
+dump_logs() {
+  echo "--- smokescreen logs ---"
+  docker logs "$SMOKESCREEN_CONTAINER" 2>&1 | tail -40 || true
+  echo "--- engine logs ---"
+  docker logs "$ENGINE_CONTAINER" 2>&1 | tail -40 || true
+}
 
 cleanup() {
-  docker rm -f "$ENGINE_CONTAINER" "$SMOKESCREEN_CONTAINER" "$PG_CONTAINER" >/dev/null 2>&1 || true
+  local rc=$?
+  [ "$rc" -ne 0 ] && dump_logs
+  docker rm -f "$ENGINE_CONTAINER" "$SMOKESCREEN_CONTAINER" "$PG_CONTAINER" "$CURL_CONTAINER" >/dev/null 2>&1 || true
   docker network rm "$NET" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
+
+# ── Build images ────────────────────────────────────────────────────────────
 
 echo "==> Building smokescreen image"
 docker build -t "$SMOKESCREEN_IMAGE" "$REPO_ROOT/docker/smokescreen"
@@ -38,8 +53,24 @@ if $BUILD_ENGINE; then
   docker build -t "$ENGINE_IMAGE" "$REPO_ROOT"
 fi
 
+# ── Isolated network ─────────────────────────────────────────────────────────
+# --internal: no default gateway → containers cannot reach the internet directly.
+
 echo "==> Creating isolated Docker network: $NET"
 docker network create --internal "$NET"
+
+# ── Test runner (on isolated network, used to curl the engine) ───────────────
+
+CURL_IMAGE="curlimages/curl:8.11.1"
+
+echo "==> Starting test runner"
+docker run -d --name "$CURL_CONTAINER" --network "$NET" \
+  --entrypoint sleep "$CURL_IMAGE" infinity
+
+# Helper: run curl inside the isolated network
+ecurl() { docker exec -i "$CURL_CONTAINER" curl "$@"; }
+
+# ── Postgres (isolated network — reachable by engine, not internet-exposed) ──
 
 echo "==> Starting Postgres"
 docker run -d --name "$PG_CONTAINER" \
@@ -49,6 +80,8 @@ docker run -d --name "$PG_CONTAINER" \
   -e POSTGRES_DB=postgres \
   postgres:18
 PG_URL="postgres://postgres:postgres@${PG_CONTAINER}:5432/postgres"
+
+# ── Smokescreen (isolated net + bridge → has internet, proxies for engine) ───
 
 echo "==> Starting smokescreen"
 docker run -d --name "$SMOKESCREEN_CONTAINER" \
@@ -63,20 +96,26 @@ for i in $(seq 1 20); do
 done
 echo "    Smokescreen ready"
 
+# ── Engine (isolated network ONLY — HTTPS must route through smokescreen) ────
+
 echo "==> Starting engine (HTTPS_PROXY=http://${SMOKESCREEN_CONTAINER}:4750)"
 docker run -d --name "$ENGINE_CONTAINER" \
   --network "$NET" \
-  -p "${ENGINE_PORT}:3000" \
   -e PORT=3000 \
   -e HTTPS_PROXY="http://${SMOKESCREEN_CONTAINER}:4750" \
   "$ENGINE_IMAGE"
 
-for i in $(seq 1 20); do
-  curl -sf "http://localhost:${ENGINE_PORT}/health" >/dev/null && break
-  [ "$i" -eq 20 ] && { echo "FAIL: engine health check timed out"; exit 1; }
+for i in $(seq 1 40); do
+  ecurl -sf "${ENGINE_URL}/health" >/dev/null 2>&1 && break
+  [ "$i" -eq 40 ] && {
+    echo "FAIL: engine health check timed out"
+    docker ps -a --filter "name=$ENGINE_CONTAINER" || true
+    docker logs "$ENGINE_CONTAINER" 2>&1 | tail -80 || true
+    exit 1
+  }
   sleep 0.5
 done
-echo "    Engine ready on :${ENGINE_PORT}"
+echo "    Engine ready"
 
 for i in $(seq 1 20); do
   docker exec "$PG_CONTAINER" pg_isready -U postgres >/dev/null 2>&1 && break
@@ -85,28 +124,37 @@ for i in $(seq 1 20); do
 done
 echo "    Postgres ready"
 
-# --- Stripe read (HTTPS via proxy) — same shape as e2e/docker.test.sh ---
+# ── 1) Read from Stripe (HTTPS → smokescreen → api.stripe.com) ───────────────
+
 echo "==> src-stripe: read through smokescreen"
 READ_PARAMS=$(printf \
   '{"source":{"name":"stripe","api_key":"%s","backfill_limit":5},"destination":{"name":"postgres","url":"postgres://unused:5432/db","schema":"stripe"},"streams":[{"name":"products"}]}' \
   "$STRIPE_API_KEY")
-OUTPUT=$(curl -sf --max-time 90 -X POST "http://localhost:${ENGINE_PORT}/read" \
+OUTPUT=$(ecurl -s --max-time 90 -w '\n%{http_code}' -X POST "${ENGINE_URL}/read" \
   -H "X-Pipeline: $READ_PARAMS")
+HTTP_CODE=$(echo "$OUTPUT" | tail -1)
+OUTPUT=$(echo "$OUTPUT" | sed '$d')
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "FAIL: /read returned HTTP $HTTP_CODE"
+  echo "$OUTPUT" | tail -20
+  exit 1
+fi
 RECORD_COUNT=$(echo "$OUTPUT" | grep -c '"type":"record"' || true)
 echo "    Got $RECORD_COUNT record(s)"
 [ "$RECORD_COUNT" -gt 0 ] || { echo "FAIL: no records from Stripe"; exit 1; }
 
-# --- Postgres (direct on internal network) ---
+# ── 2) Write to Postgres (direct TCP on isolated network) ─────────────────────
+
 echo "==> dest-pg: setup + write"
 PG_PARAMS=$(printf \
   '{"source":{"name":"stripe","api_key":"%s"},"destination":{"name":"postgres","url":"%s","schema":"stripe_smokescreen_test"}}' \
   "$STRIPE_API_KEY" "$PG_URL")
-curl -sf --max-time 30 -X POST "http://localhost:${ENGINE_PORT}/setup" \
+ecurl -sf --max-time 30 -X POST "${ENGINE_URL}/setup" \
   -H "X-Pipeline: $PG_PARAMS" && echo "    setup OK" || echo "    setup returned non-204 (may be fine)"
-echo "$OUTPUT" | curl -sf --max-time 90 -X POST "http://localhost:${ENGINE_PORT}/write" \
+echo "$OUTPUT" | ecurl -sf --max-time 90 -X POST "${ENGINE_URL}/write" \
   -H "X-Pipeline: $PG_PARAMS" \
   -H "Content-Type: application/x-ndjson" \
   --data-binary @- | head -3 || true
 echo "    dest-pg OK"
 
-echo "==> Smokescreen e2e passed"
+echo "==> All smokescreen tests passed"

--- a/e2e/smokescreen.test.sh
+++ b/e2e/smokescreen.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Stripe read through smokescreen (HTTP CONNECT) with Docker network isolation.
+# Engine has no default route on the internal network; outbound HTTPS to Stripe
+# must use HTTPS_PROXY → smokescreen (also connected to bridge for internet).
+# Postgres runs on the same internal network (TCP, no proxy).
+#
+# Required: STRIPE_API_KEY
+# Optional: ENGINE_IMAGE (CI: pre-built image; skips local docker build)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+BUILD_ENGINE=false
+if [ -z "${ENGINE_IMAGE:-}" ]; then
+  ENGINE_IMAGE="sync-engine:smokescreen-test"
+  BUILD_ENGINE=true
+fi
+
+SMOKESCREEN_IMAGE="sync-engine-smokescreen:test"
+S="$$"
+NET="smokescreen-isolated-${S}"
+SMOKESCREEN_CONTAINER="smokescreen-${S}"
+ENGINE_CONTAINER="engine-smokescreen-${S}"
+PG_CONTAINER="pg-smokescreen-${S}"
+ENGINE_PORT="${PORT:-3399}"
+
+cleanup() {
+  docker rm -f "$ENGINE_CONTAINER" "$SMOKESCREEN_CONTAINER" "$PG_CONTAINER" >/dev/null 2>&1 || true
+  docker network rm "$NET" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> Building smokescreen image"
+docker build -t "$SMOKESCREEN_IMAGE" "$REPO_ROOT/docker/smokescreen"
+
+if $BUILD_ENGINE; then
+  echo "==> Building engine image"
+  docker build -t "$ENGINE_IMAGE" "$REPO_ROOT"
+fi
+
+echo "==> Creating isolated Docker network: $NET"
+docker network create --internal "$NET"
+
+echo "==> Starting Postgres"
+docker run -d --name "$PG_CONTAINER" \
+  --network "$NET" \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=postgres \
+  postgres:18
+PG_URL="postgres://postgres:postgres@${PG_CONTAINER}:5432/postgres"
+
+echo "==> Starting smokescreen"
+docker run -d --name "$SMOKESCREEN_CONTAINER" \
+  --network "$NET" \
+  "$SMOKESCREEN_IMAGE"
+docker network connect bridge "$SMOKESCREEN_CONTAINER"
+
+for i in $(seq 1 20); do
+  docker exec "$SMOKESCREEN_CONTAINER" nc -z localhost 4750 >/dev/null 2>&1 && break
+  [ "$i" -eq 20 ] && { echo "FAIL: smokescreen health check timed out"; exit 1; }
+  sleep 0.5
+done
+echo "    Smokescreen ready"
+
+echo "==> Starting engine (HTTPS_PROXY=http://${SMOKESCREEN_CONTAINER}:4750)"
+docker run -d --name "$ENGINE_CONTAINER" \
+  --network "$NET" \
+  -p "${ENGINE_PORT}:3000" \
+  -e PORT=3000 \
+  -e HTTPS_PROXY="http://${SMOKESCREEN_CONTAINER}:4750" \
+  "$ENGINE_IMAGE"
+
+for i in $(seq 1 20); do
+  curl -sf "http://localhost:${ENGINE_PORT}/health" >/dev/null && break
+  [ "$i" -eq 20 ] && { echo "FAIL: engine health check timed out"; exit 1; }
+  sleep 0.5
+done
+echo "    Engine ready on :${ENGINE_PORT}"
+
+for i in $(seq 1 20); do
+  docker exec "$PG_CONTAINER" pg_isready -U postgres >/dev/null 2>&1 && break
+  [ "$i" -eq 20 ] && { echo "FAIL: postgres health check timed out"; exit 1; }
+  sleep 0.5
+done
+echo "    Postgres ready"
+
+# --- Stripe read (HTTPS via proxy) — same shape as e2e/docker.test.sh ---
+echo "==> src-stripe: read through smokescreen"
+READ_PARAMS=$(printf \
+  '{"source":{"name":"stripe","api_key":"%s","backfill_limit":5},"destination":{"name":"postgres","url":"postgres://unused:5432/db","schema":"stripe"},"streams":[{"name":"products"}]}' \
+  "$STRIPE_API_KEY")
+OUTPUT=$(curl -sf --max-time 90 -X POST "http://localhost:${ENGINE_PORT}/read" \
+  -H "X-Pipeline: $READ_PARAMS")
+RECORD_COUNT=$(echo "$OUTPUT" | grep -c '"type":"record"' || true)
+echo "    Got $RECORD_COUNT record(s)"
+[ "$RECORD_COUNT" -gt 0 ] || { echo "FAIL: no records from Stripe"; exit 1; }
+
+# --- Postgres (direct on internal network) ---
+echo "==> dest-pg: setup + write"
+PG_PARAMS=$(printf \
+  '{"source":{"name":"stripe","api_key":"%s"},"destination":{"name":"postgres","url":"%s","schema":"stripe_smokescreen_test"}}' \
+  "$STRIPE_API_KEY" "$PG_URL")
+curl -sf --max-time 30 -X POST "http://localhost:${ENGINE_PORT}/setup" \
+  -H "X-Pipeline: $PG_PARAMS" && echo "    setup OK" || echo "    setup returned non-204 (may be fine)"
+echo "$OUTPUT" | curl -sf --max-time 90 -X POST "http://localhost:${ENGINE_PORT}/write" \
+  -H "X-Pipeline: $PG_PARAMS" \
+  -H "Content-Type: application/x-ndjson" \
+  --data-binary @- | head -3 || true
+echo "    dest-pg OK"
+
+echo "==> Smokescreen e2e passed"

--- a/e2e/smokescreen.test.sh
+++ b/e2e/smokescreen.test.sh
@@ -124,6 +124,15 @@ for i in $(seq 1 20); do
 done
 echo "    Postgres ready"
 
+# ── 0) Negative test: direct internet access must be blocked ─────────────────
+
+echo "==> Negative test: direct HTTPS must fail on isolated network"
+if ecurl -sf --max-time 10 https://api.stripe.com 2>/dev/null; then
+  echo "FAIL: curl container reached the internet directly (network isolation broken)"
+  exit 1
+fi
+echo "    Confirmed: no direct internet access from isolated network"
+
 # ── 1) Read from Stripe (HTTPS → smokescreen → api.stripe.com) ───────────────
 
 echo "==> src-stripe: read through smokescreen"


### PR DESCRIPTION
## Summary

Creates an internal network, starts Postgres + Smokescreen + the engine container with HTTPS_PROXY pointing at Smokescreen, then hits /read, /setup, /write on http://localhost:3399 (override with PORT).

## How to test (optional)

Test included.