### PR TITLE
fix: clear stale skip secret during install

### DIFF
--- a/packages/sync-engine/src/supabase/supabase.ts
+++ b/packages/sync-engine/src/supabase/supabase.ts
@@ -148,6 +148,7 @@ export class SupabaseSetupClient {
       -- Store unique worker secret in vault for pg_cron to use
       -- Delete existing secret if it exists, then create new one
       DELETE FROM vault.secrets WHERE name = 'stripe_sync_worker_secret';
+      DELETE FROM vault.secrets WHERE name = 'stripe_sync_skip_until';
       SELECT vault.create_secret('${escapedWorkerSecret}', 'stripe_sync_worker_secret');
 
       -- Delete existing jobs if they exist

--- a/packages/sync-engine/src/tests/unit/supabase.test.ts
+++ b/packages/sync-engine/src/tests/unit/supabase.test.ts
@@ -157,6 +157,10 @@ describe('SupabaseDeployClient', () => {
       // Get the SQL that was executed (runAQuery(projectRef, { query }))
       const executedSQL = (mockRunQuery.mock.calls[0][1] as { query: string }).query
 
+      expect(executedSQL).toContain(
+        "DELETE FROM vault.secrets WHERE name = 'stripe_sync_skip_until';"
+      )
+
       // Verify it contains the custom base URL
       expect(executedSQL).toContain(
         `https://${mockProjectRef}.test-domain.com/functions/v1/stripe-worker`


### PR DESCRIPTION
## Summary

- clear any stale `stripe_sync_skip_until` secret when setting up the worker cron job
- keep the fix in the install path so a fresh install cannot inherit a paused worker state
- assert the generated pg_cron SQL includes that cleanup

## Testing

- `pnpm --filter @stripe/sync-engine test --run src/tests/unit/supabase.test.ts`

Refs supabase/stripe-sync-engine#299
