### PR TITLE
Parallel sync & rate limit

### DIFF
--- a/apps/engine/package.json
+++ b/apps/engine/package.json
@@ -42,6 +42,7 @@
     "@stripe/sync-source-stripe": "workspace:*",
     "@stripe/sync-state-postgres": "workspace:*",
     "@stripe/sync-ts-cli": "workspace:*",
+    "@stripe/sync-util-postgres": "workspace:*",
     "citty": "^0.1.6",
     "dotenv": "^16.4.7",
     "googleapis": "^148.0.0",

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -3,8 +3,10 @@ import { z } from 'zod'
 import { createDocument } from 'zod-openapi'
 import { apiReference } from '@scalar/hono-api-reference'
 import { HTTPException } from 'hono/http-exception'
+import pg from 'pg'
 import type { Message, DestinationOutput, ConnectorResolver, SyncParams } from '../lib/index.js'
 import {
+  createEngine,
   createEngineFromParams,
   noopStateStore,
   parseNdjsonStream,
@@ -12,18 +14,15 @@ import {
   PipelineConfig,
 } from '../lib/index.js'
 import {
-  RecordMessage,
-  StateMessage,
-  CatalogMessage,
-  LogMessage,
-  ErrorMessage,
-  StreamStatusMessage,
   Message as MessageSchema,
   DestinationOutput as DestinationOutputSchema,
 } from '@stripe/sync-protocol'
 import { takeStateCheckpoints } from '../lib/pipeline.js'
 import { ndjsonResponse } from '@stripe/sync-ts-cli/ndjson'
 import { logger } from '../logger.js'
+import { createStripeSource } from '@stripe/sync-source-stripe'
+import type { RateLimiter } from '@stripe/sync-source-stripe'
+import { acquire, createRateLimiterTable } from '@stripe/sync-util-postgres'
 
 // ── Helpers ─────────────────────────────────────────────────────
 
@@ -44,6 +43,38 @@ function syncRequestContext(params: SyncParams) {
     configuredStreamCount: params.pipeline.streams?.length ?? 0,
     configuredStreams: params.pipeline.streams?.map((stream) => stream.name) ?? [],
   }
+}
+
+const DEFAULT_MAX_RPS = 25
+
+/**
+ * When the destination is Postgres, create a distributed rate limiter backed
+ * by a `_rate_limit_buckets` table so multiple workers share a single bucket.
+ * Returns `undefined` for non-Postgres destinations.
+ */
+async function createPgRateLimiter(
+  pipeline: PipelineConfig
+): Promise<{ rateLimiter: RateLimiter; close(): Promise<void> } | undefined> {
+  if (pipeline.destination.name !== 'postgres') return undefined
+
+  const destConfig = pipeline.destination as Record<string, unknown>
+  const connStr = destConfig.connection_string as string | undefined
+  if (!connStr) return undefined
+
+  const pool = new pg.Pool({ connectionString: connStr })
+  const schema = destConfig.schema as string | undefined
+  if (schema) {
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+  }
+  await createRateLimiterTable(pool, schema)
+
+  const srcConfig = pipeline.source as Record<string, unknown>
+  const apiKey = srcConfig.api_key as string
+  const maxRps = (srcConfig.rate_limit as number | undefined) ?? DEFAULT_MAX_RPS
+  const opts = { key: `stripe:${apiKey}`, max_rps: maxRps, schema }
+  const rateLimiter: RateLimiter = async (cost = 1) => acquire(pool, opts, cost)
+
+  return { rateLimiter, close: () => pool.end() }
 }
 
 async function* logApiStream<T>(
@@ -175,18 +206,31 @@ export function createApp(resolver: ConnectorResolver) {
     const context = { path: '/read', inputPresent, ...syncRequestContext(params) }
     const startedAt = Date.now()
     logger.info(context, 'Engine API /read started')
-    const engine = await createEngineFromParams(
+    const rl = await createPgRateLimiter(params.pipeline)
+
+    const sourceName = params.pipeline.source.name
+    const destName = params.pipeline.destination.name
+    const [resolvedSource, destination] = await Promise.all([
+      resolver.resolveSource(sourceName),
+      resolver.resolveDestination(destName),
+    ])
+    const source = rl ? createStripeSource({ rateLimiter: rl.rateLimiter }) : resolvedSource
+    const engine = createEngine(
       params.pipeline,
-      resolver,
+      { source, destination },
       noopStateStore(),
+      { sourceName, destinationName: destName },
       params.state
     )
+
     const input = inputPresent ? parseNdjsonStream(c.req.raw.body!) : undefined
     let output: AsyncIterable<Message> = engine.read(input)
     if (params.stateCheckpointLimit) {
       output = takeStateCheckpoints<Message>(params.stateCheckpointLimit)(output)
     }
-    return ndjsonResponse(logApiStream('Engine API /read', output, context, startedAt))
+    return ndjsonResponse(
+      closeAfter(logApiStream('Engine API /read', output, context, startedAt), () => rl?.close())
+    )
   })
 
   app.post('/write', async (c) => {
@@ -212,13 +256,34 @@ export function createApp(resolver: ConnectorResolver) {
   app.post('/sync', async (c) => {
     const params = parseSyncParams(c)
     const stateStore = await selectStateStore(params.pipeline)
-    const engine = await createEngineFromParams(params.pipeline, resolver, stateStore, params.state)
+    const rl = await createPgRateLimiter(params.pipeline)
+
+    const sourceName = params.pipeline.source.name
+    const destName = params.pipeline.destination.name
+    const [resolvedSource, destination] = await Promise.all([
+      resolver.resolveSource(sourceName),
+      resolver.resolveDestination(destName),
+    ])
+    const source = rl ? createStripeSource({ rateLimiter: rl.rateLimiter }) : resolvedSource
+    const engine = createEngine(
+      params.pipeline,
+      { source, destination },
+      stateStore,
+      { sourceName, destinationName: destName },
+      params.state
+    )
+
     const input = hasBody(c) ? parseNdjsonStream(c.req.raw.body!) : undefined
     let output: AsyncIterable<DestinationOutput> = engine.sync(input)
     if (params.stateCheckpointLimit) {
       output = takeStateCheckpoints<DestinationOutput>(params.stateCheckpointLimit)(output)
     }
-    return ndjsonResponse(closeAfter(output, () => stateStore.close?.()))
+    return ndjsonResponse(
+      closeAfter(output, async () => {
+        await stateStore.close?.()
+        await rl?.close()
+      })
+    )
   })
 
   app.get('/connectors', (c) => {

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -20,7 +20,7 @@ import {
 import { takeStateCheckpoints } from '../lib/pipeline.js'
 import { ndjsonResponse } from '@stripe/sync-ts-cli/ndjson'
 import { logger } from '../logger.js'
-import { createStripeSource } from '@stripe/sync-source-stripe'
+import { createStripeSource, DEFAULT_MAX_RPS } from '@stripe/sync-source-stripe'
 import type { RateLimiter } from '@stripe/sync-source-stripe'
 import { acquire, createRateLimiterTable } from '@stripe/sync-util-postgres'
 
@@ -44,8 +44,6 @@ function syncRequestContext(params: SyncParams) {
     configuredStreams: params.pipeline.streams?.map((stream) => stream.name) ?? [],
   }
 }
-
-const DEFAULT_MAX_RPS = 25
 
 /**
  * When the destination is Postgres, create a distributed rate limiter backed
@@ -163,6 +161,32 @@ export function createApp(resolver: ConnectorResolver) {
     }
   }
 
+  /** Resolve connectors, optionally wrapping the source with a Postgres-backed rate limiter. */
+  async function resolveEngineWithRateLimiter(
+    pipeline: PipelineConfig,
+    stateStore: Parameters<typeof createEngine>[2],
+    state?: Record<string, unknown>
+  ) {
+    const rl = await createPgRateLimiter(pipeline)
+
+    const sourceName = pipeline.source.name
+    const destName = pipeline.destination.name
+    const [resolvedSource, destination] = await Promise.all([
+      resolver.resolveSource(sourceName),
+      resolver.resolveDestination(destName),
+    ])
+    const source = rl ? createStripeSource({ rateLimiter: rl.rateLimiter }) : resolvedSource
+    const engine = createEngine(
+      pipeline,
+      { source, destination },
+      stateStore,
+      { sourceName, destinationName: destName },
+      state
+    )
+
+    return { engine, close: () => rl?.close() }
+  }
+
   // ── Routes ─────────────────────────────────────────────────────
 
   app.get('/health', (c) => c.json({ ok: true }))
@@ -206,20 +230,9 @@ export function createApp(resolver: ConnectorResolver) {
     const context = { path: '/read', inputPresent, ...syncRequestContext(params) }
     const startedAt = Date.now()
     logger.info(context, 'Engine API /read started')
-    const rl = await createPgRateLimiter(params.pipeline)
-
-    const sourceName = params.pipeline.source.name
-    const destName = params.pipeline.destination.name
-    const [resolvedSource, destination] = await Promise.all([
-      resolver.resolveSource(sourceName),
-      resolver.resolveDestination(destName),
-    ])
-    const source = rl ? createStripeSource({ rateLimiter: rl.rateLimiter }) : resolvedSource
-    const engine = createEngine(
+    const { engine, close } = await resolveEngineWithRateLimiter(
       params.pipeline,
-      { source, destination },
       noopStateStore(),
-      { sourceName, destinationName: destName },
       params.state
     )
 
@@ -229,7 +242,7 @@ export function createApp(resolver: ConnectorResolver) {
       output = takeStateCheckpoints<Message>(params.stateCheckpointLimit)(output)
     }
     return ndjsonResponse(
-      closeAfter(logApiStream('Engine API /read', output, context, startedAt), () => rl?.close())
+      closeAfter(logApiStream('Engine API /read', output, context, startedAt), () => close())
     )
   })
 
@@ -256,20 +269,9 @@ export function createApp(resolver: ConnectorResolver) {
   app.post('/sync', async (c) => {
     const params = parseSyncParams(c)
     const stateStore = await selectStateStore(params.pipeline)
-    const rl = await createPgRateLimiter(params.pipeline)
-
-    const sourceName = params.pipeline.source.name
-    const destName = params.pipeline.destination.name
-    const [resolvedSource, destination] = await Promise.all([
-      resolver.resolveSource(sourceName),
-      resolver.resolveDestination(destName),
-    ])
-    const source = rl ? createStripeSource({ rateLimiter: rl.rateLimiter }) : resolvedSource
-    const engine = createEngine(
+    const { engine, close } = await resolveEngineWithRateLimiter(
       params.pipeline,
-      { source, destination },
       stateStore,
-      { sourceName, destinationName: destName },
       params.state
     )
 
@@ -281,7 +283,7 @@ export function createApp(resolver: ConnectorResolver) {
     return ndjsonResponse(
       closeAfter(output, async () => {
         await stateStore.close?.()
-        await rl?.close()
+        await close()
       })
     )
   })

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -22,7 +22,8 @@ import { ndjsonResponse } from '@stripe/sync-ts-cli/ndjson'
 import { logger } from '../logger.js'
 import { createStripeSource, DEFAULT_MAX_RPS } from '@stripe/sync-source-stripe'
 import type { RateLimiter } from '@stripe/sync-source-stripe'
-import { acquire, createRateLimiterTable } from '@stripe/sync-util-postgres'
+import { acquire, createRateLimiterTable, ident } from '@stripe/sync-util-postgres'
+import { createHash } from 'node:crypto'
 
 // ── Helpers ─────────────────────────────────────────────────────
 
@@ -53,6 +54,7 @@ function syncRequestContext(params: SyncParams) {
 async function createPgRateLimiter(
   pipeline: PipelineConfig
 ): Promise<{ rateLimiter: RateLimiter; close(): Promise<void> } | undefined> {
+  if (pipeline.source.name !== 'stripe') return undefined
   if (pipeline.destination.name !== 'postgres') return undefined
 
   const destConfig = pipeline.destination as Record<string, unknown>
@@ -62,14 +64,15 @@ async function createPgRateLimiter(
   const pool = new pg.Pool({ connectionString: connStr })
   const schema = destConfig.schema as string | undefined
   if (schema) {
-    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS ${ident(schema)}`)
   }
   await createRateLimiterTable(pool, schema)
 
   const srcConfig = pipeline.source as Record<string, unknown>
   const apiKey = srcConfig.api_key as string
   const maxRps = (srcConfig.rate_limit as number | undefined) ?? DEFAULT_MAX_RPS
-  const opts = { key: `stripe:${apiKey}`, max_rps: maxRps, schema }
+  const keyHash = createHash('sha256').update(apiKey).digest('hex').slice(0, 16)
+  const opts = { key: `stripe:${keyHash}`, max_rps: maxRps, schema }
   const rateLimiter: RateLimiter = async (cost = 1) => acquire(pool, opts, cost)
 
   return { rateLimiter, close: () => pool.end() }

--- a/packages/source-stripe/src/index.test.ts
+++ b/packages/source-stripe/src/index.test.ts
@@ -45,7 +45,7 @@ function makeConfig(
   overrides: Partial<ResourceConfig> & { order: number; tableName: string }
 ): ResourceConfig {
   return {
-    supportsCreatedFilter: true,
+    supportsCreatedFilter: false,
     listFn: (() => Promise.resolve({ data: [], has_more: false })) as ResourceConfig['listFn'],
     retrieveFn: (() => Promise.resolve({})) as ResourceConfig['retrieveFn'],
     ...overrides,

--- a/packages/source-stripe/src/index.test.ts
+++ b/packages/source-stripe/src/index.test.ts
@@ -10,11 +10,15 @@ import type {
   StateMessage,
   StreamStatusMessage,
 } from '@stripe/sync-protocol'
-import source from './index.js'
+import source, { createStripeSource } from './index.js'
 import { fromWebhookEvent } from './process-event.js'
 import { buildResourceRegistry } from './resourceRegistry.js'
 import type { ResourceConfig } from './types.js'
 import type { StripeWebhookEvent, StripeWebSocketClient } from './src-websocket.js'
+import type { SegmentState, StripeStreamState } from './index.js'
+import { listApiBackfill } from './src-list-api.js'
+import { createInMemoryRateLimiter } from './rate-limiter.js'
+import type { RateLimiter } from './rate-limiter.js'
 
 // Mock the WebSocket module
 const mockClose = vi.fn()
@@ -1590,6 +1594,303 @@ describe('StripeSource', () => {
         .filter((m): m is StateMessage => m.type === 'state')
         .filter((s) => (s.data as { events_cursor?: number }).events_cursor != null)
       expect(statesWithCursor).toHaveLength(0)
+    })
+  })
+
+  describe('read() — parallel backfill (segment checkpoint/resume)', () => {
+    it('resumes only incomplete segments from prior segment state', async () => {
+      const listFn = vi.fn().mockResolvedValue({
+        data: [{ id: 'cus_resumed', name: 'Resumed' }],
+        has_more: false,
+      })
+
+      const registry: Record<string, ResourceConfig> = {
+        customers: makeConfig({
+          order: 1,
+          tableName: 'customers',
+          supportsCreatedFilter: true,
+          listFn: listFn as ResourceConfig['listFn'],
+        }),
+      }
+
+      const priorSegments: SegmentState[] = [
+        { index: 0, gte: 1000000, lt: 1100000, pageCursor: null, status: 'complete' },
+        { index: 1, gte: 1100000, lt: 1200000, pageCursor: 'cus_halfway', status: 'pending' },
+        { index: 2, gte: 1200000, lt: 1300001, pageCursor: null, status: 'complete' },
+      ]
+
+      const mockStripe = {} as unknown as Stripe
+      const rateLimiter: RateLimiter = async () => 0
+
+      const messages = await collect(
+        listApiBackfill({
+          catalog: catalog({ name: 'customers' }),
+          state: {
+            customers: { pageCursor: null, status: 'pending', segments: priorSegments },
+          },
+          registry,
+          stripe: mockStripe,
+          rateLimiter,
+          backfillConcurrency: 3,
+        })
+      )
+
+      expect(listFn).toHaveBeenCalledTimes(1)
+      expect(listFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          created: { gte: 1100000, lt: 1200000 },
+          starting_after: 'cus_halfway',
+          limit: 100,
+        })
+      )
+
+      const records = messages.filter((m): m is RecordMessage => m.type === 'record')
+      expect(records).toHaveLength(1)
+      expect(records[0].data).toMatchObject({ id: 'cus_resumed' })
+
+      const states = messages.filter((m): m is StateMessage => m.type === 'state')
+      const lastState = states[states.length - 1]
+      expect(lastState.data).toMatchObject({ status: 'complete' })
+      const segments = (lastState.data as StripeStreamState).segments!
+      expect(segments.every((s) => s.status === 'complete')).toBe(true)
+    })
+
+    it('emits state with full segment snapshots after each page for resumability', async () => {
+      const listFn = vi.fn().mockResolvedValue({
+        data: [{ id: 'item_1' }],
+        has_more: false,
+      })
+
+      const registry: Record<string, ResourceConfig> = {
+        customers: makeConfig({
+          order: 1,
+          tableName: 'customers',
+          supportsCreatedFilter: true,
+          listFn: listFn as ResourceConfig['listFn'],
+        }),
+      }
+
+      const mockStripe = {
+        accounts: { retrieve: vi.fn().mockResolvedValue({ created: 1000000 }) },
+      } as unknown as Stripe
+      const rateLimiter: RateLimiter = async () => 0
+
+      const messages = await collect(
+        listApiBackfill({
+          catalog: catalog({ name: 'customers' }),
+          state: undefined,
+          registry,
+          stripe: mockStripe,
+          rateLimiter,
+          backfillConcurrency: 3,
+        })
+      )
+
+      const states = messages.filter((m): m is StateMessage => m.type === 'state')
+      expect(states.length).toBeGreaterThan(0)
+
+      for (const state of states) {
+        const data = state.data as StripeStreamState
+        expect(data.segments).toBeDefined()
+        expect(data.segments!.length).toBeGreaterThan(0)
+      }
+
+      const lastData = states[states.length - 1].data as StripeStreamState
+      expect(lastData.status).toBe('complete')
+      expect(lastData.segments!.every((s) => s.status === 'complete')).toBe(true)
+    })
+  })
+
+  describe('read() — streams without supportsCreatedFilter sync sequentially', () => {
+    it('uses sequential pagination (no created filter) for non-parallel streams', async () => {
+      const listFn = vi.fn().mockResolvedValue({
+        data: [{ id: 'item_1', name: 'Sequential' }],
+        has_more: false,
+      })
+
+      const registry: Record<string, ResourceConfig> = {
+        tax_ids: makeConfig({
+          order: 1,
+          tableName: 'tax_ids',
+          supportsCreatedFilter: false,
+          listFn: listFn as ResourceConfig['listFn'],
+        }),
+      }
+
+      const mockStripe = {} as unknown as Stripe
+      const rateLimiter: RateLimiter = async () => 0
+
+      const messages = await collect(
+        listApiBackfill({
+          catalog: catalog({ name: 'tax_ids' }),
+          state: undefined,
+          registry,
+          stripe: mockStripe,
+          rateLimiter,
+        })
+      )
+
+      expect(listFn).toHaveBeenCalledTimes(1)
+      expect(listFn).toHaveBeenCalledWith({ limit: 100 })
+
+      const states = messages.filter((m): m is StateMessage => m.type === 'state')
+      for (const state of states) {
+        expect((state.data as StripeStreamState).segments).toBeUndefined()
+      }
+    })
+
+    it('parallel and sequential streams coexist in the same catalog', async () => {
+      const parallelListFn = vi.fn().mockResolvedValue({
+        data: [{ id: 'cus_1' }],
+        has_more: false,
+      })
+      const sequentialListFn = vi.fn().mockResolvedValue({
+        data: [{ id: 'tax_1' }],
+        has_more: false,
+      })
+
+      const registry: Record<string, ResourceConfig> = {
+        customers: makeConfig({
+          order: 1,
+          tableName: 'customers',
+          supportsCreatedFilter: true,
+          listFn: parallelListFn as ResourceConfig['listFn'],
+        }),
+        tax_ids: makeConfig({
+          order: 2,
+          tableName: 'tax_ids',
+          supportsCreatedFilter: false,
+          listFn: sequentialListFn as ResourceConfig['listFn'],
+        }),
+      }
+
+      const mockStripe = {
+        accounts: { retrieve: vi.fn().mockResolvedValue({ created: 1000000 }) },
+      } as unknown as Stripe
+      const rateLimiter: RateLimiter = async () => 0
+
+      const messages = await collect(
+        listApiBackfill({
+          catalog: {
+            streams: [{ stream: { name: 'customers' } }, { stream: { name: 'tax_ids' } }],
+          },
+          state: undefined,
+          registry,
+          stripe: mockStripe,
+          rateLimiter,
+          backfillConcurrency: 3,
+        })
+      )
+
+      for (const call of parallelListFn.mock.calls) {
+        expect(call[0]).toHaveProperty('created')
+      }
+
+      for (const call of sequentialListFn.mock.calls) {
+        expect(call[0]).not.toHaveProperty('created')
+      }
+
+      const statusMsgs = messages.filter(
+        (m): m is StreamStatusMessage => m.type === 'stream_status'
+      )
+      const completes = statusMsgs.filter((m) => m.status === 'complete')
+      expect(completes).toHaveLength(2)
+    })
+  })
+
+  describe('rate limiting', () => {
+    describe('createInMemoryRateLimiter', () => {
+      it('returns 0 (no wait) when tokens are available', async () => {
+        const limiter = createInMemoryRateLimiter(10)
+        const wait = await limiter()
+        expect(wait).toBe(0)
+      })
+
+      it('returns positive wait time when tokens are depleted', async () => {
+        const limiter = createInMemoryRateLimiter(2)
+        await limiter()
+        await limiter()
+        const wait = await limiter()
+        expect(wait).toBeGreaterThan(0)
+      })
+
+      it('wait time scales inversely with RPS', async () => {
+        const fastLimiter = createInMemoryRateLimiter(100)
+        const slowLimiter = createInMemoryRateLimiter(1)
+
+        for (let i = 0; i < 100; i++) await fastLimiter()
+        const fastWait = await fastLimiter()
+
+        await slowLimiter()
+        const slowWait = await slowLimiter()
+
+        expect(slowWait).toBeGreaterThan(fastWait)
+      })
+    })
+
+    it('rate limiter is called before each list API page during backfill', async () => {
+      const rateLimiterSpy = vi.fn().mockResolvedValue(0) as unknown as RateLimiter
+
+      const listFn = vi
+        .fn()
+        .mockResolvedValueOnce({
+          data: [{ id: 'item_1' }],
+          has_more: true,
+        })
+        .mockResolvedValueOnce({
+          data: [{ id: 'item_2' }],
+          has_more: false,
+        })
+
+      const registry: Record<string, ResourceConfig> = {
+        items: makeConfig({
+          order: 1,
+          tableName: 'items',
+          supportsCreatedFilter: false,
+          listFn: listFn as ResourceConfig['listFn'],
+        }),
+      }
+
+      await collect(
+        listApiBackfill({
+          catalog: catalog({ name: 'items' }),
+          state: undefined,
+          registry,
+          stripe: {} as unknown as Stripe,
+          rateLimiter: rateLimiterSpy,
+        })
+      )
+
+      expect(rateLimiterSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('createStripeSource uses external rate limiter when provided via deps', async () => {
+      const externalLimiter = vi.fn().mockResolvedValue(0) as unknown as RateLimiter
+      const customSource = createStripeSource({ rateLimiter: externalLimiter })
+
+      const listFn = vi.fn().mockResolvedValue({
+        data: [{ id: 'cus_1' }],
+        has_more: false,
+      })
+
+      const registry: Record<string, ResourceConfig> = {
+        customers: makeConfig({
+          order: 1,
+          tableName: 'customers',
+          listFn: listFn as ResourceConfig['listFn'],
+        }),
+      }
+
+      vi.mocked(buildResourceRegistry).mockReturnValue(registry as any)
+
+      await collect(
+        customSource.read({
+          config: { api_key: 'sk_test_fake' },
+          catalog: catalog({ name: 'customers', primary_key: [['id']] }),
+        })
+      )
+
+      expect(externalLimiter).toHaveBeenCalled()
     })
   })
 

--- a/packages/source-stripe/src/index.ts
+++ b/packages/source-stripe/src/index.ts
@@ -74,16 +74,34 @@ export type WebhookInput = {
 
 // MARK: - Stream state
 
+export type SegmentState = {
+  index: number
+  gte: number
+  lt: number
+  pageCursor: string | null
+  status: 'pending' | 'complete'
+}
+
 export type StripeStreamState = {
   pageCursor: string | null
   status: 'pending' | 'complete'
   events_cursor?: number
+  segments?: SegmentState[]
 }
+
+const segmentStateSpec = z.object({
+  index: z.number(),
+  gte: z.number(),
+  lt: z.number(),
+  pageCursor: z.string().nullable(),
+  status: z.enum(['pending', 'complete']),
+})
 
 const streamStateSpec = z.object({
   pageCursor: z.string().nullable(),
   status: z.enum(['pending', 'complete']),
   events_cursor: z.number().optional(),
+  segments: z.array(segmentStateSpec).optional(),
 })
 
 // MARK: - Source
@@ -227,6 +245,7 @@ const source = {
         catalog,
         state,
         registry,
+        stripe,
         backfillLimit: config.backfill_limit,
         drainQueue: wsClient
           ? () => inputQueue.drain(config, stripe, catalog, registry, streamNames)

--- a/packages/source-stripe/src/index.ts
+++ b/packages/source-stripe/src/index.ts
@@ -21,6 +21,10 @@ import type { StripeWebSocketClient, StripeWebhookEvent } from './src-websocket.
 import { createStripeWebSocketClient } from './src-websocket.js'
 import type { ResourceConfig } from './types.js'
 import { makeClient } from './client.js'
+import type { RateLimiter } from './rate-limiter.js'
+import { createInMemoryRateLimiter } from './rate-limiter.js'
+
+const DEFAULT_REQUESTS_PER_SECOND = 25
 
 // MARK: - Spec
 
@@ -62,6 +66,12 @@ export const spec = z.object({
     .positive()
     .optional()
     .describe('Max objects to backfill per stream (useful for testing)'),
+  rate_limit: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Max Stripe API requests per second (default: 25)'),
 })
 
 export type Config = z.infer<typeof spec>
@@ -106,201 +116,222 @@ const streamStateSpec = z.object({
 
 // MARK: - Source
 
-const source = {
-  spec(): ConnectorSpecification {
-    return {
-      config: z.toJSONSchema(spec),
-      stream_state: z.toJSONSchema(streamStateSpec),
-    }
-  },
+export type StripeSourceDeps = {
+  rateLimiter?: RateLimiter
+}
 
-  async check({ config }) {
-    try {
-      const s = makeClient(config)
-      await s.accounts.retrieve()
-      return { status: 'succeeded' }
-    } catch (err: any) {
-      return { status: 'failed', message: err.message }
-    }
-  },
+export function createStripeSource(
+  deps?: StripeSourceDeps
+): Source<Config, StripeStreamState, WebhookInput | Stripe.Event> {
+  const externalRateLimiter = deps?.rateLimiter
 
-  async discover({ config }) {
-    const resolved = await resolveOpenApiSpec({
-      apiVersion: config.api_version ?? '2020-08-27',
-    })
-    const registry = buildResourceRegistry(
-      resolved.spec,
-      config.api_key,
-      resolved.apiVersion,
-      config.base_url
-    )
-    try {
-      const parser = new SpecParser()
-      const parsed = parser.parse(resolved.spec, {
-        resourceAliases: OPENAPI_RESOURCE_TABLE_ALIASES,
+  return {
+    spec(): ConnectorSpecification {
+      return {
+        config: z.toJSONSchema(spec),
+        stream_state: z.toJSONSchema(streamStateSpec),
+      }
+    },
+
+    async check({ config }) {
+      try {
+        const s = makeClient(config)
+        await s.accounts.retrieve()
+        return { status: 'succeeded' }
+      } catch (err: any) {
+        return { status: 'failed', message: err.message }
+      }
+    },
+
+    async discover({ config }) {
+      const resolved = await resolveOpenApiSpec({
+        apiVersion: config.api_version ?? '2020-08-27',
       })
-      return catalogFromOpenApi(parsed.tables, registry)
-    } catch {
-      return catalogFromRegistry(registry)
-    }
-  },
-
-  async setup({ config, catalog }) {
-    if (config.webhook_url) {
-      const stripe = makeClient(config)
-      const existing = await stripe.webhookEndpoints.list({ limit: 100 })
-      const managed = existing.data.find(
-        (wh) => wh.url === config.webhook_url && wh.metadata?.managed_by === 'stripe-sync'
+      const registry = buildResourceRegistry(
+        resolved.spec,
+        config.api_key,
+        resolved.apiVersion,
+        config.base_url
       )
-      if (!(managed && managed.status === 'enabled')) {
-        // Tradeoff: we subscribe to all events ('*') rather than only the
-        // events needed by this sync's catalog. This is not ideal — Stripe
-        // will send events we don't need, adding unnecessary network traffic.
-        // However, Stripe accounts have a hard limit on webhook endpoints
-        // (~16 per account), and scoping events per-sync would require one
-        // endpoint per sync. By sharing a single endpoint across all syncs
-        // for the same account, each sync filters events by its own catalog
-        // inside processStripeEvent(), keeping endpoint usage constant
-        // regardless of how many syncs are configured.
-        await stripe.webhookEndpoints.create({
-          url: config.webhook_url,
-          enabled_events: ['*'],
-          metadata: { managed_by: 'stripe-sync' },
+      try {
+        const parser = new SpecParser()
+        const parsed = parser.parse(resolved.spec, {
+          resourceAliases: OPENAPI_RESOURCE_TABLE_ALIASES,
         })
+        return catalogFromOpenApi(parsed.tables, registry)
+      } catch {
+        return catalogFromRegistry(registry)
       }
-    }
-  },
+    },
 
-  async teardown({ config }) {
-    if (config.webhook_url) {
-      const stripe = makeClient(config)
-      const existing = await stripe.webhookEndpoints.list({ limit: 100 })
-      for (const wh of existing.data) {
-        if (wh.metadata?.managed_by === 'stripe-sync') {
-          await stripe.webhookEndpoints.del(wh.id)
+    async setup({ config, catalog }) {
+      if (config.webhook_url) {
+        const stripe = makeClient(config)
+        const existing = await stripe.webhookEndpoints.list({ limit: 100 })
+        const managed = existing.data.find(
+          (wh) => wh.url === config.webhook_url && wh.metadata?.managed_by === 'stripe-sync'
+        )
+        if (!(managed && managed.status === 'enabled')) {
+          // Tradeoff: we subscribe to all events ('*') rather than only the
+          // events needed by this sync's catalog. This is not ideal — Stripe
+          // will send events we don't need, adding unnecessary network traffic.
+          // However, Stripe accounts have a hard limit on webhook endpoints
+          // (~16 per account), and scoping events per-sync would require one
+          // endpoint per sync. By sharing a single endpoint across all syncs
+          // for the same account, each sync filters events by its own catalog
+          // inside processStripeEvent(), keeping endpoint usage constant
+          // regardless of how many syncs are configured.
+          await stripe.webhookEndpoints.create({
+            url: config.webhook_url,
+            enabled_events: ['*'],
+            metadata: { managed_by: 'stripe-sync' },
+          })
         }
       }
-    }
-  },
+    },
 
-  async *read({ config, catalog, state }, $stdin?) {
-    const stripe = makeClient(config)
-    const resolved = await resolveOpenApiSpec({
-      apiVersion: config.api_version ?? '2020-08-27',
-    })
-    const registry = buildResourceRegistry(
-      resolved.spec,
-      config.api_key,
-      resolved.apiVersion,
-      config.base_url
-    )
-    const streamNames = new Set(catalog.streams.map((s) => s.stream.name))
-
-    // Event-driven mode: iterate over incoming webhook inputs
-    if ($stdin) {
-      for await (const input of $stdin) {
-        if ('body' in (input as object)) {
-          yield* processWebhookInput(
-            input as WebhookInput,
-            config,
-            stripe,
-            catalog,
-            registry,
-            streamNames
-          )
-        } else {
-          yield* processStripeEvent(
-            input as Stripe.Event,
-            config,
-            stripe,
-            catalog,
-            registry,
-            streamNames
-          )
-        }
-      }
-      return
-    }
-
-    const inputQueue = createInputQueue()
-
-    let wsClient: StripeWebSocketClient | null = null
-    if (config.websocket) {
-      wsClient = await createStripeWebSocketClient({
-        stripeApiKey: config.api_key,
-        onEvent: (wsEvent: StripeWebhookEvent) => {
-          const event = JSON.parse(wsEvent.event_payload) as Stripe.Event
-          inputQueue.push({ data: event })
-        },
-      })
-    }
-
-    let httpServer: ReturnType<typeof startWebhookServer> | null = null
-
-    try {
-      const startTimestamp = Math.floor(Date.now() / 1000)
-
-      // Backfill: paginate through each configured stream
-      yield* listApiBackfill({
-        catalog,
-        state,
-        registry,
-        stripe,
-        backfillLimit: config.backfill_limit,
-        drainQueue: wsClient
-          ? () => inputQueue.drain(config, stripe, catalog, registry, streamNames)
-          : undefined,
-      })
-
-      // Events polling: incremental sync via /v1/events after backfill
-      yield* pollEvents({ config, stripe, catalog, registry, streamNames, state, startTimestamp })
-
-      // Start HTTP server for live mode if configured
-      if (config.webhook_port) {
-        httpServer = startWebhookServer(config.webhook_port, inputQueue.push)
-      }
-
-      // After backfill: stream live events from WebSocket and/or HTTP
-      if (wsClient || httpServer) {
-        // Drain anything that arrived during backfill
-        yield* inputQueue.drain(config, stripe, catalog, registry, streamNames)
-
-        // Block on new events (infinite loop until all live sources close)
-        while (wsClient || httpServer) {
-          const queued = await inputQueue.wait()
-          try {
-            if ('body' in queued.data) {
-              yield* processWebhookInput(
-                queued.data,
-                config,
-                stripe,
-                catalog,
-                registry,
-                streamNames
-              )
-            } else {
-              yield* processStripeEvent(queued.data, config, stripe, catalog, registry, streamNames)
-            }
-            queued.resolve?.()
-          } catch (err) {
-            queued.reject?.(err instanceof Error ? err : new Error(String(err)))
+    async teardown({ config }) {
+      if (config.webhook_url) {
+        const stripe = makeClient(config)
+        const existing = await stripe.webhookEndpoints.list({ limit: 100 })
+        for (const wh of existing.data) {
+          if (wh.metadata?.managed_by === 'stripe-sync') {
+            await stripe.webhookEndpoints.del(wh.id)
           }
         }
       }
-    } finally {
-      if (wsClient) {
-        wsClient.close()
-        wsClient = null
-      }
-      if (httpServer) {
-        httpServer.close()
-        httpServer = null
-      }
-    }
-  },
-} satisfies Source<Config, StripeStreamState, WebhookInput | Stripe.Event>
+    },
 
-export default source
+    async *read({ config, catalog, state }, $stdin?) {
+      const rateLimiter =
+        externalRateLimiter ??
+        createInMemoryRateLimiter(config.rate_limit ?? DEFAULT_REQUESTS_PER_SECOND)
+      const stripe = makeClient(config)
+      const resolved = await resolveOpenApiSpec({
+        apiVersion: config.api_version ?? '2020-08-27',
+      })
+      const registry = buildResourceRegistry(
+        resolved.spec,
+        config.api_key,
+        resolved.apiVersion,
+        config.base_url
+      )
+      const streamNames = new Set(catalog.streams.map((s) => s.stream.name))
+
+      // Event-driven mode: iterate over incoming webhook inputs
+      if ($stdin) {
+        for await (const input of $stdin) {
+          if ('body' in (input as object)) {
+            yield* processWebhookInput(
+              input as WebhookInput,
+              config,
+              stripe,
+              catalog,
+              registry,
+              streamNames
+            )
+          } else {
+            yield* processStripeEvent(
+              input as Stripe.Event,
+              config,
+              stripe,
+              catalog,
+              registry,
+              streamNames
+            )
+          }
+        }
+        return
+      }
+
+      const inputQueue = createInputQueue()
+
+      let wsClient: StripeWebSocketClient | null = null
+      if (config.websocket) {
+        wsClient = await createStripeWebSocketClient({
+          stripeApiKey: config.api_key,
+          onEvent: (wsEvent: StripeWebhookEvent) => {
+            const event = JSON.parse(wsEvent.event_payload) as Stripe.Event
+            inputQueue.push({ data: event })
+          },
+        })
+      }
+
+      let httpServer: ReturnType<typeof startWebhookServer> | null = null
+
+      try {
+        const startTimestamp = Math.floor(Date.now() / 1000)
+
+        // Backfill: paginate through each configured stream
+        yield* listApiBackfill({
+          catalog,
+          state,
+          registry,
+          stripe,
+          rateLimiter,
+          backfillLimit: config.backfill_limit,
+          drainQueue: wsClient
+            ? () => inputQueue.drain(config, stripe, catalog, registry, streamNames)
+            : undefined,
+        })
+
+        // Events polling: incremental sync via /v1/events after backfill
+        yield* pollEvents({ config, stripe, catalog, registry, streamNames, state, startTimestamp })
+
+        // Start HTTP server for live mode if configured
+        if (config.webhook_port) {
+          httpServer = startWebhookServer(config.webhook_port, inputQueue.push)
+        }
+
+        // After backfill: stream live events from WebSocket and/or HTTP
+        if (wsClient || httpServer) {
+          // Drain anything that arrived during backfill
+          yield* inputQueue.drain(config, stripe, catalog, registry, streamNames)
+
+          // Block on new events (infinite loop until all live sources close)
+          while (wsClient || httpServer) {
+            const queued = await inputQueue.wait()
+            try {
+              if ('body' in queued.data) {
+                yield* processWebhookInput(
+                  queued.data,
+                  config,
+                  stripe,
+                  catalog,
+                  registry,
+                  streamNames
+                )
+              } else {
+                yield* processStripeEvent(
+                  queued.data,
+                  config,
+                  stripe,
+                  catalog,
+                  registry,
+                  streamNames
+                )
+              }
+              queued.resolve?.()
+            } catch (err) {
+              queued.reject?.(err instanceof Error ? err : new Error(String(err)))
+            }
+          }
+        }
+      } finally {
+        if (wsClient) {
+          wsClient.close()
+          wsClient = null
+        }
+        if (httpServer) {
+          httpServer.close()
+          httpServer = null
+        }
+      }
+    },
+  }
+}
+
+export default createStripeSource()
 
 // MARK: - Re-exports
 
@@ -308,3 +339,5 @@ export { buildResourceRegistry } from './resourceRegistry.js'
 export { catalogFromRegistry } from './catalog.js'
 export { SpecParser, OPENAPI_RESOURCE_TABLE_ALIASES } from './openapi/specParser.js'
 export type { ParsedResourceTable, ParsedOpenApiSpec } from './openapi/types.js'
+export type { RateLimiter } from './rate-limiter.js'
+export { createInMemoryRateLimiter } from './rate-limiter.js'

--- a/packages/source-stripe/src/index.ts
+++ b/packages/source-stripe/src/index.ts
@@ -22,9 +22,7 @@ import { createStripeWebSocketClient } from './src-websocket.js'
 import type { ResourceConfig } from './types.js'
 import { makeClient } from './client.js'
 import type { RateLimiter } from './rate-limiter.js'
-import { createInMemoryRateLimiter } from './rate-limiter.js'
-
-const DEFAULT_REQUESTS_PER_SECOND = 25
+import { createInMemoryRateLimiter, DEFAULT_MAX_RPS } from './rate-limiter.js'
 
 // MARK: - Spec
 
@@ -72,6 +70,12 @@ export const spec = z.object({
     .positive()
     .optional()
     .describe('Max Stripe API requests per second (default: 25)'),
+  backfill_concurrency: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Number of time-range segments for parallel backfill (default: 200)'),
 })
 
 export type Config = z.infer<typeof spec>
@@ -204,8 +208,7 @@ export function createStripeSource(
 
     async *read({ config, catalog, state }, $stdin?) {
       const rateLimiter =
-        externalRateLimiter ??
-        createInMemoryRateLimiter(config.rate_limit ?? DEFAULT_REQUESTS_PER_SECOND)
+        externalRateLimiter ?? createInMemoryRateLimiter(config.rate_limit ?? DEFAULT_MAX_RPS)
       const stripe = makeClient(config)
       const resolved = await resolveOpenApiSpec({
         apiVersion: config.api_version ?? '2020-08-27',
@@ -270,6 +273,7 @@ export function createStripeSource(
           stripe,
           rateLimiter,
           backfillLimit: config.backfill_limit,
+          backfillConcurrency: config.backfill_concurrency,
           drainQueue: wsClient
             ? () => inputQueue.drain(config, stripe, catalog, registry, streamNames)
             : undefined,
@@ -340,4 +344,4 @@ export { catalogFromRegistry } from './catalog.js'
 export { SpecParser, OPENAPI_RESOURCE_TABLE_ALIASES } from './openapi/specParser.js'
 export type { ParsedResourceTable, ParsedOpenApiSpec } from './openapi/types.js'
 export type { RateLimiter } from './rate-limiter.js'
-export { createInMemoryRateLimiter } from './rate-limiter.js'
+export { createInMemoryRateLimiter, DEFAULT_MAX_RPS } from './rate-limiter.js'

--- a/packages/source-stripe/src/rate-limiter.ts
+++ b/packages/source-stripe/src/rate-limiter.ts
@@ -1,0 +1,29 @@
+/**
+ * A rate limiter returns the number of seconds the caller should wait
+ * before proceeding.  0 means the token was available immediately.
+ *
+ * This contract matches `util-postgres`'s `acquire()` return value so a
+ * Postgres-backed implementation can be used as a drop-in replacement.
+ */
+export type RateLimiter = (cost?: number) => Promise<number>
+
+/**
+ * In-memory token-bucket rate limiter.
+ *
+ * Uses the same algorithm as the Postgres-backed limiter in `util-postgres`:
+ * continuous proportional refill, tokens can go negative (borrowing against
+ * future refills), and the caller gets back the exact wait time.
+ */
+export function createInMemoryRateLimiter(maxRps: number): RateLimiter {
+  let tokens = maxRps
+  let lastRefill = Date.now()
+
+  return async (cost = 1) => {
+    const elapsed = (Date.now() - lastRefill) / 1000
+    tokens = Math.min(maxRps, tokens + elapsed * maxRps)
+    lastRefill = Date.now()
+    tokens -= cost
+    if (tokens >= 0) return 0
+    return -tokens / maxRps
+  }
+}

--- a/packages/source-stripe/src/rate-limiter.ts
+++ b/packages/source-stripe/src/rate-limiter.ts
@@ -5,6 +5,8 @@
  * This contract matches `util-postgres`'s `acquire()` return value so a
  * Postgres-backed implementation can be used as a drop-in replacement.
  */
+export const DEFAULT_MAX_RPS = 25
+
 export type RateLimiter = (cost?: number) => Promise<number>
 
 /**

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -7,6 +7,7 @@ import type {
 import { toRecordMessage } from '@stripe/sync-protocol'
 import type { ResourceConfig } from './types.js'
 import type { SegmentState } from './index.js'
+import type { RateLimiter } from './rate-limiter.js'
 import type Stripe from 'stripe'
 
 const SKIPPABLE_ERROR_PATTERNS = [
@@ -18,48 +19,6 @@ const SKIPPABLE_ERROR_PATTERNS = [
 ]
 
 const NUM_SEGMENTS = 200
-const DEFAULT_REQUESTS_PER_SECOND = 25
-
-function getMaxRequestsPerSecond(): number {
-  const env = process.env.RATE_LIMIT
-  if (env) {
-    const parsed = parseInt(env, 10)
-    if (Number.isFinite(parsed) && parsed > 0) return parsed
-  }
-  return DEFAULT_REQUESTS_PER_SECOND
-}
-
-// MARK: - Token-bucket rate limiter
-
-function createRateLimiter(rps: number) {
-  let tokens = rps
-  let lastRefill = Date.now()
-
-  return async function acquire(): Promise<void> {
-    while (true) {
-      const now = Date.now()
-      const elapsed = now - lastRefill
-      if (elapsed >= 1000) {
-        tokens = rps
-        lastRefill = now
-      } else {
-        const refill = Math.floor((elapsed / 1000) * rps)
-        if (refill > 0) {
-          tokens = Math.min(rps, tokens + refill)
-          lastRefill = now
-        }
-      }
-
-      if (tokens > 0) {
-        tokens--
-        return
-      }
-
-      const waitMs = Math.ceil(((1 - tokens / rps) * 1000) / rps)
-      await new Promise((r) => setTimeout(r, Math.max(waitMs, 10)))
-    }
-  }
-}
 
 function isSkippableError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err)
@@ -147,7 +106,7 @@ async function* paginateSegment(opts: {
   supportsLimit: boolean
   backfillLimit?: number
   totalEmitted: { count: number }
-  acquireToken: () => Promise<void>
+  rateLimiter: RateLimiter
 }): AsyncGenerator<Message> {
   const {
     listFn,
@@ -157,7 +116,7 @@ async function* paginateSegment(opts: {
     supportsLimit,
     backfillLimit,
     totalEmitted,
-    acquireToken,
+    rateLimiter,
   } = opts
 
   let pageCursor: string | null = segment.pageCursor
@@ -174,7 +133,8 @@ async function* paginateSegment(opts: {
       params.starting_after = pageCursor
     }
 
-    await acquireToken()
+    const wait = await rateLimiter()
+    if (wait > 0) await new Promise((r) => setTimeout(r, wait * 1000))
     console.error({
       msg: 'Starting Stripe list page',
       stream: streamName,
@@ -302,13 +262,13 @@ export async function* listApiBackfill(opts: {
     | undefined
   registry: Record<string, ResourceConfig>
   stripe: Stripe
+  rateLimiter: RateLimiter
   backfillLimit?: number
   drainQueue?: () => AsyncGenerator<Message>
 }): AsyncGenerator<Message> {
-  const { catalog, state, registry, stripe, backfillLimit, drainQueue } = opts
+  const { catalog, state, registry, stripe, rateLimiter, backfillLimit, drainQueue } = opts
 
   let accountCreated: number | null = null
-  const acquireToken = createRateLimiter(getMaxRequestsPerSecond())
 
   for (const configuredStream of catalog.streams) {
     const stream = configuredStream.stream
@@ -363,7 +323,7 @@ export async function* listApiBackfill(opts: {
               supportsLimit: resourceConfig.supportsLimit !== false,
               backfillLimit,
               totalEmitted,
-              acquireToken,
+              rateLimiter,
             })
           )
 

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -18,7 +18,7 @@ const SKIPPABLE_ERROR_PATTERNS = [
   'Missing required param',
 ]
 
-const NUM_SEGMENTS = 200
+const DEFAULT_BACKFILL_CONCURRENCY = 200
 
 function isSkippableError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err)
@@ -81,14 +81,18 @@ async function getAccountCreatedTimestamp(stripe: Stripe): Promise<number> {
 
 // MARK: - Segment creation
 
-function buildSegments(startTimestamp: number, endTimestamp: number): SegmentState[] {
+function buildSegments(
+  startTimestamp: number,
+  endTimestamp: number,
+  numSegments = DEFAULT_BACKFILL_CONCURRENCY
+): SegmentState[] {
   const range = endTimestamp - startTimestamp
-  const segmentSize = Math.max(1, Math.ceil(range / NUM_SEGMENTS))
+  const segmentSize = Math.max(1, Math.ceil(range / numSegments))
   const segments: SegmentState[] = []
 
-  for (let i = 0; i < NUM_SEGMENTS; i++) {
+  for (let i = 0; i < numSegments; i++) {
     const gte = startTimestamp + i * segmentSize
-    const lt = i === NUM_SEGMENTS - 1 ? endTimestamp + 1 : startTimestamp + (i + 1) * segmentSize
+    const lt = i === numSegments - 1 ? endTimestamp + 1 : startTimestamp + (i + 1) * segmentSize
     if (gte >= endTimestamp + 1) break
     segments.push({ index: i, gte, lt, pageCursor: null, status: 'pending' })
   }
@@ -192,9 +196,10 @@ async function* sequentialBackfillStream(opts: {
   streamName: string
   pageCursor: string | null
   backfillLimit?: number
+  rateLimiter: RateLimiter
   drainQueue?: () => AsyncGenerator<Message>
 }): AsyncGenerator<Message> {
-  const { resourceConfig, streamName, backfillLimit, drainQueue } = opts
+  const { resourceConfig, streamName, backfillLimit, rateLimiter, drainQueue } = opts
   let pageCursor = opts.pageCursor
   let hasMore = true
   let totalEmitted = 0
@@ -210,6 +215,8 @@ async function* sequentialBackfillStream(opts: {
       params.starting_after = pageCursor
     }
 
+    const wait = await rateLimiter()
+    if (wait > 0) await new Promise((r) => setTimeout(r, wait * 1000))
     console.error({
       msg: 'Starting Stripe list page',
       stream: streamName,
@@ -264,9 +271,19 @@ export async function* listApiBackfill(opts: {
   stripe: Stripe
   rateLimiter: RateLimiter
   backfillLimit?: number
+  backfillConcurrency?: number
   drainQueue?: () => AsyncGenerator<Message>
 }): AsyncGenerator<Message> {
-  const { catalog, state, registry, stripe, rateLimiter, backfillLimit, drainQueue } = opts
+  const {
+    catalog,
+    state,
+    registry,
+    stripe,
+    rateLimiter,
+    backfillLimit,
+    backfillConcurrency = DEFAULT_BACKFILL_CONCURRENCY,
+    drainQueue,
+  } = opts
 
   let accountCreated: number | null = null
 
@@ -308,7 +325,7 @@ export async function* listApiBackfill(opts: {
             accountCreated = await getAccountCreatedTimestamp(stripe)
           }
           const now = Math.floor(Date.now() / 1000)
-          segments = buildSegments(accountCreated, now)
+          segments = buildSegments(accountCreated, now, backfillConcurrency)
         }
 
         const incompleteSegments = segments.filter((s) => s.status !== 'complete')
@@ -327,7 +344,7 @@ export async function* listApiBackfill(opts: {
             })
           )
 
-          yield* mergeAsync(generators, NUM_SEGMENTS)
+          yield* mergeAsync(generators, backfillConcurrency)
         }
       } else {
         // Sequential path: no created filter support
@@ -337,6 +354,7 @@ export async function* listApiBackfill(opts: {
           streamName: stream.name,
           pageCursor,
           backfillLimit,
+          rateLimiter,
           drainQueue,
         })
       }

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -6,6 +6,8 @@ import type {
 } from '@stripe/sync-protocol'
 import { toRecordMessage } from '@stripe/sync-protocol'
 import type { ResourceConfig } from './types.js'
+import type { SegmentState } from './index.js'
+import type Stripe from 'stripe'
 
 const SKIPPABLE_ERROR_PATTERNS = [
   'only available in testmode',
@@ -14,6 +16,50 @@ const SKIPPABLE_ERROR_PATTERNS = [
   'Must provide ',
   'Missing required param',
 ]
+
+const NUM_SEGMENTS = 200
+const DEFAULT_REQUESTS_PER_SECOND = 25
+
+function getMaxRequestsPerSecond(): number {
+  const env = process.env.RATE_LIMIT
+  if (env) {
+    const parsed = parseInt(env, 10)
+    if (Number.isFinite(parsed) && parsed > 0) return parsed
+  }
+  return DEFAULT_REQUESTS_PER_SECOND
+}
+
+// MARK: - Token-bucket rate limiter
+
+function createRateLimiter(rps: number) {
+  let tokens = rps
+  let lastRefill = Date.now()
+
+  return async function acquire(): Promise<void> {
+    while (true) {
+      const now = Date.now()
+      const elapsed = now - lastRefill
+      if (elapsed >= 1000) {
+        tokens = rps
+        lastRefill = now
+      } else {
+        const refill = Math.floor((elapsed / 1000) * rps)
+        if (refill > 0) {
+          tokens = Math.min(rps, tokens + refill)
+          lastRefill = now
+        }
+      }
+
+      if (tokens > 0) {
+        tokens--
+        return
+      }
+
+      const waitMs = Math.ceil(((1 - tokens / rps) * 1000) / rps)
+      await new Promise((r) => setTimeout(r, Math.max(waitMs, 10)))
+    }
+  }
+}
 
 function isSkippableError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err)
@@ -27,14 +73,242 @@ function findConfigByTableName(
   return Object.values(registry).find((cfg) => cfg.tableName === tableName)
 }
 
-export async function* listApiBackfill(opts: {
-  catalog: { streams: Array<{ stream: { name: string } }> }
-  state: Record<string, { pageCursor: string | null; status: string }> | undefined
-  registry: Record<string, ResourceConfig>
+// MARK: - mergeAsync
+
+type IndexedResult<T> = { index: number; result: IteratorResult<T, undefined> }
+
+async function* mergeAsync<T>(
+  generators: AsyncGenerator<T>[],
+  concurrency: number
+): AsyncGenerator<T> {
+  const active = new Map<number, Promise<IndexedResult<T>>>()
+  let nextIndex = 0
+
+  function pull(gen: AsyncGenerator<T>, index: number) {
+    active.set(
+      index,
+      gen.next().then((result) => ({ index, result: result as IteratorResult<T, undefined> }))
+    )
+  }
+
+  const limit = Math.min(concurrency, generators.length)
+  for (let i = 0; i < limit; i++) {
+    pull(generators[i], i)
+    nextIndex = i + 1
+  }
+
+  while (active.size > 0) {
+    const { index, result } = await Promise.race(active.values())
+    active.delete(index)
+
+    if (result.done) {
+      if (nextIndex < generators.length) {
+        pull(generators[nextIndex], nextIndex)
+        nextIndex++
+      }
+    } else {
+      yield result.value
+      pull(generators[index], index)
+    }
+  }
+}
+
+// MARK: - Account created timestamp
+
+async function getAccountCreatedTimestamp(stripe: Stripe): Promise<number> {
+  const account = await stripe.accounts.retrieve()
+  return account.created ?? Math.floor(Date.now() / 1000)
+}
+
+// MARK: - Segment creation
+
+function buildSegments(startTimestamp: number, endTimestamp: number): SegmentState[] {
+  const range = endTimestamp - startTimestamp
+  const segmentSize = Math.max(1, Math.ceil(range / NUM_SEGMENTS))
+  const segments: SegmentState[] = []
+
+  for (let i = 0; i < NUM_SEGMENTS; i++) {
+    const gte = startTimestamp + i * segmentSize
+    const lt = i === NUM_SEGMENTS - 1 ? endTimestamp + 1 : startTimestamp + (i + 1) * segmentSize
+    if (gte >= endTimestamp + 1) break
+    segments.push({ index: i, gte, lt, pageCursor: null, status: 'pending' })
+  }
+
+  return segments
+}
+
+// MARK: - Segment pagination
+
+async function* paginateSegment(opts: {
+  listFn: NonNullable<ResourceConfig['listFn']>
+  segment: SegmentState
+  segments: SegmentState[]
+  streamName: string
+  supportsLimit: boolean
+  backfillLimit?: number
+  totalEmitted: { count: number }
+  acquireToken: () => Promise<void>
+}): AsyncGenerator<Message> {
+  const {
+    listFn,
+    segment,
+    segments,
+    streamName,
+    supportsLimit,
+    backfillLimit,
+    totalEmitted,
+    acquireToken,
+  } = opts
+
+  let pageCursor: string | null = segment.pageCursor
+  let hasMore = true
+
+  while (hasMore) {
+    const params: Record<string, unknown> = {
+      created: { gte: segment.gte, lt: segment.lt },
+    }
+    if (supportsLimit !== false) {
+      params.limit = 100
+    }
+    if (pageCursor) {
+      params.starting_after = pageCursor
+    }
+
+    await acquireToken()
+    console.error({
+      msg: 'Starting Stripe list page',
+      stream: streamName,
+      segment: segment.index,
+      pageCursor,
+      created: params.created,
+    })
+    const response = await listFn(params as Parameters<typeof listFn>[0])
+    console.error({
+      msg: 'Completed Stripe list page',
+      stream: streamName,
+      segment: segment.index,
+      pageCursor,
+      recordCount: response.data.length,
+      hasMore: response.has_more,
+    })
+
+    for (const item of response.data) {
+      yield toRecordMessage(streamName, item as Record<string, unknown>)
+      totalEmitted.count++
+    }
+
+    hasMore = response.has_more
+    if (response.pageCursor) {
+      pageCursor = response.pageCursor
+    } else if (response.data.length > 0) {
+      pageCursor = (response.data[response.data.length - 1] as { id: string }).id
+    }
+
+    if (backfillLimit && totalEmitted.count >= backfillLimit) {
+      hasMore = false
+    }
+
+    // Update shared segment state and emit checkpoint
+    segment.pageCursor = hasMore ? pageCursor : null
+    segment.status = hasMore ? 'pending' : 'complete'
+
+    const allComplete = segments.every((s) => s.status === 'complete')
+    yield {
+      type: 'state',
+      stream: streamName,
+      data: {
+        pageCursor: null,
+        status: allComplete ? 'complete' : 'pending',
+        segments: segments.map((s) => ({ ...s })),
+      },
+    } satisfies StateMessage
+  }
+}
+
+// MARK: - Sequential fallback (original logic)
+
+async function* sequentialBackfillStream(opts: {
+  resourceConfig: ResourceConfig
+  streamName: string
+  pageCursor: string | null
   backfillLimit?: number
   drainQueue?: () => AsyncGenerator<Message>
 }): AsyncGenerator<Message> {
-  const { catalog, state, registry, backfillLimit, drainQueue } = opts
+  const { resourceConfig, streamName, backfillLimit, drainQueue } = opts
+  let pageCursor = opts.pageCursor
+  let hasMore = true
+  let totalEmitted = 0
+
+  while (hasMore) {
+    if (drainQueue) yield* drainQueue()
+
+    const params: Record<string, unknown> = {}
+    if (resourceConfig.supportsLimit !== false) {
+      params.limit = 100
+    }
+    if (pageCursor) {
+      params.starting_after = pageCursor
+    }
+
+    console.error({
+      msg: 'Starting Stripe list page',
+      stream: streamName,
+      pageCursor,
+    })
+    const response = await resourceConfig.listFn!(
+      params as Parameters<NonNullable<typeof resourceConfig.listFn>>[0]
+    )
+    console.error({
+      msg: 'Completed Stripe list page',
+      stream: streamName,
+      pageCursor,
+      recordCount: response.data.length,
+      hasMore: response.has_more,
+    })
+
+    for (const item of response.data) {
+      yield toRecordMessage(streamName, item as Record<string, unknown>)
+      totalEmitted++
+    }
+
+    hasMore = response.has_more
+    if (response.pageCursor) {
+      pageCursor = response.pageCursor
+    } else if (response.data.length > 0) {
+      pageCursor = (response.data[response.data.length - 1] as { id: string }).id
+    }
+
+    if (backfillLimit && totalEmitted >= backfillLimit) {
+      hasMore = false
+    }
+
+    yield {
+      type: 'state',
+      stream: streamName,
+      data: {
+        pageCursor: hasMore ? pageCursor : null,
+        status: hasMore ? 'pending' : 'complete',
+      },
+    } satisfies StateMessage
+  }
+}
+
+// MARK: - Main entry point
+
+export async function* listApiBackfill(opts: {
+  catalog: { streams: Array<{ stream: { name: string } }> }
+  state:
+    | Record<string, { pageCursor: string | null; status: string; segments?: SegmentState[] }>
+    | undefined
+  registry: Record<string, ResourceConfig>
+  stripe: Stripe
+  backfillLimit?: number
+  drainQueue?: () => AsyncGenerator<Message>
+}): AsyncGenerator<Message> {
+  const { catalog, state, registry, stripe, backfillLimit, drainQueue } = opts
+
+  let accountCreated: number | null = null
+  const acquireToken = createRateLimiter(getMaxRequestsPerSecond())
 
   for (const configuredStream of catalog.streams) {
     const stream = configuredStream.stream
@@ -51,7 +325,6 @@ export async function* listApiBackfill(opts: {
 
     if (!resourceConfig.listFn) continue
 
-    // Skip already-complete streams (e.g. resuming after full backfill for events polling)
     const streamState = state?.[stream.name]
     if (streamState?.status === 'complete') continue
 
@@ -61,69 +334,51 @@ export async function* listApiBackfill(opts: {
       status: 'started',
     } satisfies StreamStatusMessage
 
-    // Restore cursor from combined state if available
-    let pageCursor: string | null = streamState?.pageCursor ?? null
-
     try {
-      let hasMore = true
-      let totalEmitted = 0
-      while (hasMore) {
-        // Drain any queued events before each page
-        if (drainQueue) yield* drainQueue()
+      // Parallel path: streams that support created filter
+      if (resourceConfig.supportsCreatedFilter) {
+        let segments: SegmentState[]
 
-        const params: Record<string, unknown> = {}
-        if (resourceConfig.supportsLimit !== false) {
-          params.limit = 100
-        }
-        if (pageCursor) {
-          params.starting_after = pageCursor
+        if (streamState?.segments) {
+          // Resume from prior segment state — only run incomplete segments
+          segments = streamState.segments.map((s) => ({ ...s }))
+        } else {
+          // First run: fetch account creation date and build segments
+          if (accountCreated === null) {
+            accountCreated = await getAccountCreatedTimestamp(stripe)
+          }
+          const now = Math.floor(Date.now() / 1000)
+          segments = buildSegments(accountCreated, now)
         }
 
-        // TODO: replace with structured logger once one is wired into the source connector;
-        // console.error (stderr) is used here intentionally — console.log/info would write
-        // to stdout and corrupt the NDJSON output stream.
-        console.error({
-          msg: 'Starting Stripe list page',
-          stream: stream.name,
+        const incompleteSegments = segments.filter((s) => s.status !== 'complete')
+        if (incompleteSegments.length > 0) {
+          const totalEmitted = { count: 0 }
+          const generators = incompleteSegments.map((segment) =>
+            paginateSegment({
+              listFn: resourceConfig.listFn!,
+              segment,
+              segments,
+              streamName: stream.name,
+              supportsLimit: resourceConfig.supportsLimit !== false,
+              backfillLimit,
+              totalEmitted,
+              acquireToken,
+            })
+          )
+
+          yield* mergeAsync(generators, NUM_SEGMENTS)
+        }
+      } else {
+        // Sequential path: no created filter support
+        const pageCursor: string | null = streamState?.pageCursor ?? null
+        yield* sequentialBackfillStream({
+          resourceConfig,
+          streamName: stream.name,
           pageCursor,
+          backfillLimit,
+          drainQueue,
         })
-        const response = await resourceConfig.listFn(
-          params as Parameters<typeof resourceConfig.listFn>[0]
-        )
-        console.error({
-          msg: 'Completed Stripe list page',
-          stream: stream.name,
-          pageCursor,
-          recordCount: response.data.length,
-          hasMore: response.has_more,
-        })
-
-        for (const item of response.data) {
-          yield toRecordMessage(stream.name, item as Record<string, unknown>)
-          totalEmitted++
-        }
-
-        hasMore = response.has_more
-        if (response.pageCursor) {
-          pageCursor = response.pageCursor
-        } else if (response.data.length > 0) {
-          pageCursor = (response.data[response.data.length - 1] as { id: string }).id
-        }
-
-        // Stop early if backfill limit reached
-        if (backfillLimit && totalEmitted >= backfillLimit) {
-          hasMore = false
-        }
-
-        // Emit state checkpoint after each page
-        yield {
-          type: 'state',
-          stream: stream.name,
-          data: {
-            pageCursor: hasMore ? pageCursor : null,
-            status: hasMore ? 'pending' : 'complete',
-          },
-        } satisfies StateMessage
       }
 
       yield {
@@ -143,7 +398,6 @@ export async function* listApiBackfill(opts: {
       console.error({
         msg: 'Stripe list page failed',
         stream: stream.name,
-        pageCursor,
         error: err instanceof Error ? err.message : String(err),
       })
       const isRateLimit = err instanceof Error && err.message.includes('Rate limit')

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -76,7 +76,7 @@ async function* mergeAsync<T>(
 
 async function getAccountCreatedTimestamp(stripe: Stripe): Promise<number> {
   const account = await stripe.accounts.retrieve()
-  return account.created ?? Math.floor(Date.now() / 1000)
+  return account.created ?? 1293840000
 }
 
 // MARK: - Segment creation

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       '@stripe/sync-ts-cli':
         specifier: workspace:*
         version: link:../../packages/ts-cli
+      '@stripe/sync-util-postgres':
+        specifier: workspace:*
+        version: link:../../packages/util-postgres
       citty:
         specifier: ^0.1.6
         version: 0.1.6


### PR DESCRIPTION
## Summary

v2 dropped parallel backfill support, causing all Stripe list API calls to run sequentially. This restores parallel sync by splitting backfills into time-based segments using the account's created timestamp.

Streams that support created filter are split into 200 time segments and fetched concurrently via mergeAsync
Token-bucket rate limiter (default 25 req/s, configurable via RATE_LIMIT env) prevents hitting Stripe rate limits
Segment state is persisted in stream state for resumability across restarts
Streams without created filter support fall back to sequential pagination (existing behavior)

## Test plan

- [x] Run backfill against a Stripe account with substantial data and verify parallel segments are fetched concurrently
- [x] Interrupt and resume a sync to verify segment checkpoint/resume works
- [x] Verify streams without supportsCreatedFilter still sync sequentially
- [x] Test with RATE_LIMIT env var to confirm rate limiting is respected
