### PR TITLE
feat(registry): add payout sync support with webhook events

### DIFF
--- a/packages/sync-engine/src/resourceRegistry.ts
+++ b/packages/sync-engine/src/resourceRegistry.ts
@@ -225,6 +225,16 @@ const RESOURCE_MAP: Record<string, ResourceDef> = {
     supportsCreatedFilter: true,
     sync: false,
   },
+  payout: {
+    order: 20,
+    tableName: 'payouts',
+    list: (s) => (p) => s.payouts.list(p),
+    retrieve: (s) => (id) => s.payouts.retrieve(id),
+    supportsCreatedFilter: true,
+    sync: true,
+    isFinalState: (p: Stripe.Payout) =>
+      p.status === 'paid' || p.status === 'failed' || p.status === 'canceled',
+  },
 } satisfies Record<string, ResourceDef>
 
 // Union of all object keys defined in RESOURCE_MAP. Used as the canonical object-name type across sync and registry helpers.
@@ -349,6 +359,7 @@ export const PREFIX_RESOURCE_MAP: Record<string, StripeObject> = {
   re_: 'refund',
   feat_: 'active_entitlements',
   cs_: 'checkout_sessions',
+  po_: 'payout',
 }
 
 // Prefixes sorted longest-first to avoid partial-prefix collisions.

--- a/packages/sync-engine/src/types.ts
+++ b/packages/sync-engine/src/types.ts
@@ -192,6 +192,12 @@ export const SUPPORTED_WEBHOOK_EVENTS: Stripe.WebhookEndpointCreateParams.Enable
   'review.closed',
   'review.opened',
   'entitlements.active_entitlement_summary.updated',
+  'payout.canceled',
+  'payout.created',
+  'payout.failed',
+  'payout.paid',
+  'payout.reconciliation_completed',
+  'payout.updated',
 ]
 
 export interface Sync {


### PR DESCRIPTION
## Summary

The `payouts` table is created by migrations but never populated — `payout` was missing from `RESOURCE_MAP`, `PREFIX_RESOURCE_MAP`, and `SUPPORTED_WEBHOOK_EVENTS`.

**Changes:**

- Added `payout` entry to `RESOURCE_MAP` (order 20, `sync: true`, `isFinalState` for `paid`/`failed`/`canceled`)
- Added `po_:` prefix to `PREFIX_RESOURCE_MAP` for ID-based routing
- Added payout webhook events to `SUPPORTED_WEBHOOK_EVENTS`:
  - `payout.canceled`
  - `payout.created`
  - `payout.failed`
  - `payout.paid`
  - `payout.reconciliation_completed`
  - `payout.updated`

This enables payment reconciliation use-cases: `payment_intents → charges → payouts` all sync correctly now.

## Test plan

- [ ] Run backfill sync and verify `payouts` table is populated
- [ ] Trigger `payout.paid` webhook and verify the payout row is upserted
- [ ] Verify `getResourceFromPrefix("po_abc")` resolves to `payout`
- [ ] `getSupportedEventTypes()` includes the new payout events

Closes #151