### PR TITLE
fix(webhook): decode request body to string to avoid Buffer in Deno

### DIFF
--- a/packages/sync-engine/src/supabase/edge-functions/stripe-webhook.ts
+++ b/packages/sync-engine/src/supabase/edge-functions/stripe-webhook.ts
@@ -26,8 +26,9 @@ Deno.serve(async (req) => {
   })
 
   try {
-    const rawBody = new Uint8Array(await req.arrayBuffer())
-    await stripeSync.webhook.processWebhook(rawBody, sig)
+    const rawBody = await req.arrayBuffer()
+    const bodyString = new TextDecoder().decode(rawBody)
+    await stripeSync.webhook.processWebhook(bodyString, sig)
     return new Response(JSON.stringify({ received: true }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

The Stripe SDK calls `Buffer.isBuffer()` internally when processing the webhook payload. `Buffer` is a Node.js global that doesn't exist in the Deno edge function runtime, causing:

```
ReferenceError: Buffer is not defined
  at _StripeSyncWebhook.processWebhook (index.ts:47309:65)
```

**Root cause:** `stripe-webhook.ts` passed a `Uint8Array` to `processWebhook`, which forwarded it to the Stripe SDK's `constructEventAsync`. The SDK's internal signature computation checks `Buffer.isBuffer(payload)` — in Deno that throws instead of returning `false`.

**Fix:** Decode the `ArrayBuffer` to a UTF-8 string before calling `processWebhook`. The Stripe signature verification works correctly on strings, and the `string` code path in the SDK never references `Buffer`.

## Test plan

- [ ] Deploy the edge function to a Supabase project and fire a test webhook — verify `{ received: true }` response with no `Buffer is not defined` error
- [ ] Verify signature rejection still works by sending a webhook with a wrong secret

Closes #170