### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/stripe/sync-engine/security/code-scanning/1](https://github.com/stripe/sync-engine/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block defining the least privileges the workflow needs. Since this workflow only checks out code and runs local commands, it can safely use `contents: read` (the minimal permission needed for `actions/checkout@v5`). No other GitHub API scopes (like `pull-requests: write` or `issues: write`) are needed.

The best minimal, non-functional-change fix here is:

- Add a workflow-level `permissions` block near the top of `.github/workflows/ci.yml` (after `name:` or after `on:`).  
- Set `contents: read` so that both `test` and `e2e-test` jobs inherit read-only repository contents access, while keeping everything else at default “none”.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `name: CI` line (line 1). No imports or additional definitions are required since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
