### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: github.repository == 'supabase/stripe-sync-engine'
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/stripe/sync-engine/security/code-scanning/2](https://github.com/stripe/sync-engine/security/code-scanning/2)

In general, to fix this issue, add an explicit `permissions` block at either the workflow root or the job level so that the `GITHUB_TOKEN` has only the minimal privileges required. For a docs deployment that pushes to GitHub Pages (typically to `gh-pages`), it needs permission to read contents and to write contents (to push the generated site). It does not appear to need any other scopes (issues, pull requests, etc.).

The best minimal fix here is to add a `permissions` block under the `deploy` job (or at the root) specifying `contents: write`. `mkdocs gh-deploy` uses `GITHUB_TOKEN` to push to the `gh-pages` branch, so write access to repository contents is required; setting `contents: read` only would break the deployment. No other steps in the job need additional scopes. Concretely, in `.github/workflows/docs.yml`, insert:

```yaml
    permissions:
      contents: write
```

directly under the job configuration (e.g., below `runs-on` or below the `if:` line) for the `deploy` job. No imports or external libraries are involved, and no functional behavior aside from token scoping is changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
