### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/stripe/sync-engine/security/code-scanning/3](https://github.com/stripe/sync-engine/security/code-scanning/3)

In general, the problem is fixed by adding an explicit `permissions` block that scopes the `GITHUB_TOKEN` to the least privileges required. For a typical CI workflow that only checks out source code and runs tests, `contents: read` at the workflow or job level is sufficient. This documents the intended permissions and prevents the workflow from inheriting broader defaults if repository or organization settings change.

The best way to fix this specific workflow without changing existing behavior is to add a minimal `permissions` block at the top (root) of the workflow, just under `name: CI` (or above `on:`). This will apply to all jobs (`test` and `e2e-test`), and both appear to only need read access to repository contents. No step in the snippet pushes commits, creates releases, modifies issues, or otherwise requires write permissions. Thus, we can safely specify:

```yaml
permissions:
  contents: read
```

Only `.github/workflows/ci.yml` needs to be edited, and no additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
