### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,8 @@
 name: Stripe Build Image
 
+permissions:
+  contents: read
+
 on:
   # Manual trigger
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/stripe/sync-engine/security/code-scanning/16](https://github.com/stripe/sync-engine/security/code-scanning/16)

In general, the problem is fixed by explicitly declaring a `permissions` block at the workflow or job level to constrain the automatically provided `GITHUB_TOKEN`. For a workflow that only needs to check out code and does not modify the repository on GitHub (no pushes, releases, PR writes, etc.), the minimal appropriate permissions are usually `contents: read`. This documents the intent and ensures the workflow remains least-privileged even if repository/organization defaults change.

The single best fix here is to add a `permissions` block at the top (root) level of `.github/workflows/docker-image.yml`, so that it applies to all jobs. We’ll set `contents: read`, which is sufficient for `actions/checkout` to read the repository. The Docker-related steps authenticate to Docker Hub via secrets and do not need broader GitHub API access. Concretely, in `.github/workflows/docker-image.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name: Stripe Build Image` line and the `on:` block. No other changes, imports, or additions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
