### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through a stack trace

### DIFF
--- a/packages/sync-engine/src/supabase/edge-functions/sigma-data-worker.ts
+++ b/packages/sync-engine/src/supabase/edge-functions/sigma-data-worker.ts
@@ -39,11 +39,10 @@ Deno.serve(async (req) => {
     sql = postgres(dbUrl, { max: 1, prepare: false })
   } catch (error: unknown) {
     const err = error as Error
+    console.error('Failed to create postgres connection', err)
     return jsonResponse(
       {
         error: 'Failed to create postgres connection',
-        details: err.message,
-        stack: err.stack,
       },
       500
     )
@@ -83,12 +82,11 @@ Deno.serve(async (req) => {
     })
   } catch (error: unknown) {
     const err = error as Error
+    console.error('Failed to create StripeSync', err)
     await sql.end()
     return jsonResponse(
       {
         error: 'Failed to create StripeSync',
-        details: err.message,
-        stack: err.stack,
       },
       500
     )
@@ -308,8 +306,8 @@ Deno.serve(async (req) => {
     })
   } catch (error: unknown) {
     const err = error as Error
-    console.error('Sigma worker error:', error)
-    return jsonResponse({ error: err.message, stack: err.stack }, 500)
+    console.error('Sigma worker error:', err)
+    return jsonResponse({ error: 'Sigma worker encountered an unexpected error' }, 500)
   } finally {
     if (sql) await sql.end()
     if (stripeSync) await stripeSync.postgresClient.pool.end()


### PR DESCRIPTION
Potential fix for [https://github.com/stripe/sync-engine/security/code-scanning/5](https://github.com/stripe/sync-engine/security/code-scanning/5)

To fix the problem, the stack trace and other low-level error details should no longer be returned to the client. Instead, the server should log the full error (including `err.stack`) and send back a generic, high-level error message. This preserves debuggability while preventing remote callers from learning about internal structure.

Concretely, in `packages/sync-engine/src/supabase/edge-functions/sigma-data-worker.ts`:

1. In the `catch` block around `postgres(dbUrl, ...)` (lines 38–50), replace the `jsonResponse` body so that it does not contain `details` or `stack`. Optionally log the error server-side with `console.error`.
2. In the `catch` block around `StripeSync.create(...)` (lines 84–95), likewise stop including `details` and `stack` in the JSON response, and optionally log the error.
3. In the outermost `try/catch` (lines 309–313), stop returning `{ error: err.message, stack: err.stack }` and instead return a generic message, while logging the full error including stack.

No changes are needed in `packages/sync-engine/src/database/postgres.ts`; the stack there is simply thrown and only becomes problematic when it is formatted into HTTP responses. We can use existing `console.error` for logging, so no new imports are required. Functionality from the client’s perspective remains the same in terms of status codes and high-level messages (still 500s, still indicate failure), but without leaking stack traces.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
