### PR TITLE
feat(openapi): bundle latest spec (2026-03-25.dahlia) as filesystem fallback

### DIFF
--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -11,7 +11,7 @@
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp bundled-spec.json dist/bundled-spec.json",
     "test": "vitest --passWithNoTests"
   },
   "files": [

--- a/packages/openapi/specFetchHelper.ts
+++ b/packages/openapi/specFetchHelper.ts
@@ -1,10 +1,15 @@
 import os from 'node:os'
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import type { OpenApiSpec, ResolveSpecConfig, ResolvedOpenApiSpec } from './types.js'
 import { fetchWithProxy } from './transport.js'
 
 const DEFAULT_CACHE_DIR = path.join(os.tmpdir(), 'stripe-sync-openapi-cache')
+
+// The spec bundled into this package at build time.
+// Update this constant and bundled-spec.json together when bumping.
+export const BUNDLED_API_VERSION = '2026-03-25.dahlia'
 
 export async function resolveOpenApiSpec(config: ResolveSpecConfig): Promise<ResolvedOpenApiSpec> {
   const apiVersion = config.apiVersion
@@ -21,6 +26,19 @@ export async function resolveOpenApiSpec(config: ResolveSpecConfig): Promise<Res
       spec: explicitSpec,
       source: 'explicit_path',
       cachePath: config.openApiSpecPath,
+    }
+  }
+
+  // If the requested version matches what's bundled, serve from the filesystem
+  // without any network calls or caching overhead.
+  if (extractDatePart(apiVersion) === extractDatePart(BUNDLED_API_VERSION)) {
+    const bundledPath = fileURLToPath(new URL('./bundled-spec.json', import.meta.url))
+    const spec = await readSpecFromPath(bundledPath)
+    return {
+      apiVersion,
+      spec,
+      source: 'bundled',
+      cachePath: bundledPath,
     }
   }
 

--- a/packages/openapi/types.ts
+++ b/packages/openapi/types.ts
@@ -114,7 +114,7 @@ export type ResolveSpecConfig = {
 export type ResolvedOpenApiSpec = {
   apiVersion: string
   spec: OpenApiSpec
-  source: 'explicit_path' | 'cache' | 'github'
+  source: 'explicit_path' | 'cache' | 'github' | 'bundled'
   cachePath?: string
   commitSha?: string
 }


### PR DESCRIPTION
## Summary

- Bundles `openapi.spec3.sdk.json` (version `2026-03-25.dahlia`) directly into `packages/openapi/` as `bundled-spec.json`
- When the requested API version matches the bundled one, `resolveOpenApiSpec` serves from the local file — zero network calls
- All other versions fall through to the existing cache → GitHub fetch flow unchanged
- Build script updated to copy `bundled-spec.json` into `dist/` so it's available at runtime
- Added `'bundled'` to the `source` union type in `ResolvedOpenApiSpec`

## Why

The CDN (`b.stripecdn.com/api-artifacts/assets/openapi/...`) only retains the last ~4 monthly releases (`max_versions: 5` in the `api-artifacts` namespace config). Older versions 403. The GitHub API is also rate-limited without a token. The bundled spec gives a zero-dependency fallback for the common case of using the latest version.

## Updating the bundled spec

When a new Stripe API version ships, run:
```sh
curl -sL https://raw.githubusercontent.com/stripe/openapi/master/latest/openapi.spec3.sdk.json \
  -o packages/openapi/bundled-spec.json
# bump BUNDLED_API_VERSION in packages/openapi/specFetchHelper.ts to match info.version
```

## Test plan

- [ ] `pnpm build` passes in `packages/openapi`
- [ ] Requesting version `2026-03-25.dahlia` returns `source: 'bundled'` with no network calls
- [ ] Requesting any other version still hits cache / GitHub as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)