### PR TITLE
feat(postgres): support CA bundle for SSL verify-ca / verify-full

### DIFF
--- a/packages/destination-postgres/src/buildPoolConfig.test.ts
+++ b/packages/destination-postgres/src/buildPoolConfig.test.ts
@@ -47,7 +47,7 @@ describe('buildPoolConfig', () => {
     expect(result.ssl).toBe(false)
   })
 
-  it('sslmode=verify-full → ssl: true', async () => {
+  it('sslmode=verify-full → ssl: { rejectUnauthorized: true }', async () => {
     const config: Config = {
       connection_string: 'postgres://user:pass@host:5432/mydb?sslmode=verify-full',
       port: 5432,
@@ -55,7 +55,9 @@ describe('buildPoolConfig', () => {
       batch_size: 100,
     }
     const result = await buildPoolConfig(config)
-    expect(result.ssl).toBe(true)
+    expect(result.ssl).toEqual({ rejectUnauthorized: true })
+    // stripSslParams removes sslmode from the connection string
+    expect(result.connectionString).toBe('postgres://user:pass@host:5432/mydb')
   })
 
   it('sslmode=require → ssl: { rejectUnauthorized: false }', async () => {

--- a/packages/destination-postgres/src/index.ts
+++ b/packages/destination-postgres/src/index.ts
@@ -5,6 +5,7 @@ import type { Destination, DestinationInput, ErrorMessage, LogMessage } from '@s
 import {
   sql,
   sslConfigFromConnectionString,
+  stripSslParams,
   upsert,
   withPgConnectProxy,
 } from '@stripe/sync-util-postgres'
@@ -29,6 +30,12 @@ export const spec = z.object({
     })
     .optional()
     .describe('AWS RDS IAM authentication config'),
+  ssl_ca_pem: z
+    .string()
+    .optional()
+    .describe(
+      'PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA)'
+    ),
 })
 
 export type Config = z.infer<typeof spec>
@@ -60,8 +67,8 @@ export async function buildPoolConfig(config: Config): Promise<PoolConfig> {
   const connStr = config.connection_string ?? config.url
   if (connStr) {
     return withPgConnectProxy({
-      connectionString: connStr,
-      ssl: sslConfigFromConnectionString(connStr),
+      connectionString: stripSslParams(connStr),
+      ssl: sslConfigFromConnectionString(connStr, { sslCaPem: config.ssl_ca_pem }),
     })
   }
 

--- a/packages/state-postgres/src/state-store.ts
+++ b/packages/state-postgres/src/state-store.ts
@@ -1,5 +1,10 @@
 import pg from 'pg'
-import { sql, sslConfigFromConnectionString, withPgConnectProxy } from '@stripe/sync-util-postgres'
+import {
+  sql,
+  sslConfigFromConnectionString,
+  stripSslParams,
+  withPgConnectProxy,
+} from '@stripe/sync-util-postgres'
 
 export interface StateStore {
   get(syncId: string): Promise<Record<string, unknown> | undefined>
@@ -79,11 +84,12 @@ export function createScopedPgStateStore(
 export async function setupStateStore(config: {
   connection_string: string
   schema?: string
+  ssl_ca_pem?: string
 }): Promise<void> {
   const pool = new pg.Pool(
     withPgConnectProxy({
-      connectionString: config.connection_string,
-      ssl: sslConfigFromConnectionString(config.connection_string),
+      connectionString: stripSslParams(config.connection_string),
+      ssl: sslConfigFromConnectionString(config.connection_string, { sslCaPem: config.ssl_ca_pem }),
     })
   )
   const schema = config.schema ?? 'public'
@@ -108,13 +114,13 @@ export async function setupStateStore(config: {
  * per destination; the service layer passes a real UUID for multi-tenancy.
  */
 export function createStateStore(
-  config: { connection_string: string; schema?: string },
+  config: { connection_string: string; schema?: string; ssl_ca_pem?: string },
   syncId = 'default'
 ): ScopedStateStore & { close(): Promise<void> } {
   const pool = new pg.Pool(
     withPgConnectProxy({
-      connectionString: config.connection_string,
-      ssl: sslConfigFromConnectionString(config.connection_string),
+      connectionString: stripSslParams(config.connection_string),
+      ssl: sslConfigFromConnectionString(config.connection_string, { sslCaPem: config.ssl_ca_pem }),
     })
   )
   const scoped = createScopedPgStateStore(pool, config.schema ?? 'public', syncId)

--- a/packages/util-postgres/src/index.ts
+++ b/packages/util-postgres/src/index.ts
@@ -4,4 +4,8 @@ export type { UpsertOptions } from './upsert.js'
 export { acquire, createRateLimiterTable } from './rateLimiter.js'
 export type { RateLimiterOptions } from './rateLimiter.js'
 export { createPgHttpConnectStreamFactory, withPgConnectProxy } from './httpConnectStream.js'
-export { sslConfigFromConnectionString, type PgSslConfig } from './sslConfigFromConnectionString.js'
+export {
+  sslConfigFromConnectionString,
+  stripSslParams,
+  type PgSslConfig,
+} from './sslConfigFromConnectionString.js'

--- a/packages/util-postgres/src/sslConfigFromConnectionString.test.ts
+++ b/packages/util-postgres/src/sslConfigFromConnectionString.test.ts
@@ -1,36 +1,69 @@
 import { describe, it, expect } from 'vitest'
-import { sslConfigFromConnectionString } from './sslConfigFromConnectionString.js'
+import { sslConfigFromConnectionString, stripSslParams } from './sslConfigFromConnectionString.js'
+
+const base = 'postgres://user:pass@localhost:5432/mydb'
+const ca = '-----BEGIN CERTIFICATE-----\nMIIBIjANBg==\n-----END CERTIFICATE-----'
 
 describe('sslConfigFromConnectionString', () => {
   it('no sslmode → false', () => {
-    expect(sslConfigFromConnectionString('postgres://user:pass@localhost:5432/mydb')).toBe(false)
+    expect(sslConfigFromConnectionString(base)).toBe(false)
   })
 
   it('sslmode=disable → false', () => {
-    expect(
-      sslConfigFromConnectionString('postgres://user:pass@localhost:5432/mydb?sslmode=disable')
-    ).toBe(false)
-  })
-
-  it('sslmode=verify-full → true', () => {
-    expect(
-      sslConfigFromConnectionString('postgres://user:pass@host:5432/mydb?sslmode=verify-full')
-    ).toBe(true)
-  })
-
-  it('sslmode=verify-ca → true', () => {
-    expect(
-      sslConfigFromConnectionString('postgres://user:pass@host:5432/mydb?sslmode=verify-ca')
-    ).toBe(true)
+    expect(sslConfigFromConnectionString(`${base}?sslmode=disable`)).toBe(false)
   })
 
   it('sslmode=require → rejectUnauthorized: false', () => {
-    expect(
-      sslConfigFromConnectionString('postgres://user:pass@host:5432/mydb?sslmode=require')
-    ).toEqual({ rejectUnauthorized: false })
+    expect(sslConfigFromConnectionString(`${base}?sslmode=require`)).toEqual({
+      rejectUnauthorized: false,
+    })
+  })
+
+  it('sslmode=verify-full without CA → rejectUnauthorized: true, no ca', () => {
+    expect(sslConfigFromConnectionString(`${base}?sslmode=verify-full`)).toEqual({
+      rejectUnauthorized: true,
+    })
+  })
+
+  it('sslmode=verify-full with CA → includes ca', () => {
+    const result = sslConfigFromConnectionString(`${base}?sslmode=verify-full`, { sslCaPem: ca })
+    expect(result).toEqual({ rejectUnauthorized: true, ca })
+  })
+
+  it('sslmode=verify-ca without CA → rejectUnauthorized: true, skips hostname check', () => {
+    const result = sslConfigFromConnectionString(`${base}?sslmode=verify-ca`)
+    expect(result).toMatchObject({ rejectUnauthorized: true })
+    expect(typeof (result as { checkServerIdentity?: unknown }).checkServerIdentity).toBe(
+      'function'
+    )
+  })
+
+  it('sslmode=verify-ca with CA → includes ca, skips hostname check', () => {
+    const result = sslConfigFromConnectionString(`${base}?sslmode=verify-ca`, { sslCaPem: ca })
+    expect(result).toMatchObject({ rejectUnauthorized: true, ca })
+    expect(typeof (result as { checkServerIdentity?: unknown }).checkServerIdentity).toBe(
+      'function'
+    )
   })
 
   it('invalid URL → false', () => {
     expect(sslConfigFromConnectionString('not-a-url')).toBe(false)
+  })
+})
+
+describe('stripSslParams', () => {
+  it('removes sslmode, sslrootcert, sslcert, sslkey', () => {
+    const url = `${base}?sslmode=verify-full&sslrootcert=/tmp/ca.pem&sslcert=/tmp/client.pem&sslkey=/tmp/key.pem`
+    expect(stripSslParams(url)).toBe(base)
+  })
+
+  it('preserves other params', () => {
+    expect(stripSslParams(`${base}?sslmode=require&connect_timeout=10`)).toBe(
+      `${base}?connect_timeout=10`
+    )
+  })
+
+  it('invalid URL → returns as-is', () => {
+    expect(stripSslParams('not-a-url')).toBe('not-a-url')
   })
 })

--- a/packages/util-postgres/src/sslConfigFromConnectionString.ts
+++ b/packages/util-postgres/src/sslConfigFromConnectionString.ts
@@ -4,16 +4,50 @@ import type { ConnectionOptions } from 'node:tls'
 export type PgSslConfig = boolean | ConnectionOptions
 
 /**
- * Map the `sslmode` query parameter from a Postgres connection string to a pg
- * `ssl` option. Defaults to `false` (no SSL) when no sslmode is present — SSL
- * must be opted into explicitly via `sslmode=require` (or `verify-ca`/`verify-full`).
+ * Strips SSL-related query params from a Postgres connection string before
+ * passing it to pg. If left in the URL, pg's URL parser overrides any `ssl`
+ * object you supply — including the `ca` field.
  */
-export function sslConfigFromConnectionString(connStr: string): PgSslConfig {
+export function stripSslParams(connStr: string): string {
+  try {
+    const url = new URL(connStr)
+    for (const key of ['sslmode', 'sslrootcert', 'sslcert', 'sslkey']) {
+      url.searchParams.delete(key)
+    }
+    return url.toString()
+  } catch {
+    return connStr
+  }
+}
+
+/**
+ * Maps the `sslmode` query parameter from a Postgres connection string to a pg
+ * `ssl` option. Defaults to `false` (no SSL) when no sslmode is present.
+ *
+ * @param sslCaPem - PEM-encoded CA certificate. Required for `verify-ca` /
+ *   `verify-full` to trust a private CA (e.g. RDS, internal DBs). If omitted
+ *   those modes fall back to the Node.js system trust store.
+ */
+export function sslConfigFromConnectionString(
+  connStr: string,
+  { sslCaPem }: { sslCaPem?: string } = {}
+): PgSslConfig {
   try {
     const sslmode = new URL(connStr).searchParams.get('sslmode')
     if (sslmode === 'disable') return false
-    if (sslmode === 'verify-ca' || sslmode === 'verify-full') return true
     if (sslmode === 'require') return { rejectUnauthorized: false }
+    if (sslmode === 'verify-full') {
+      return { rejectUnauthorized: true, ...(sslCaPem ? { ca: sslCaPem } : {}) }
+    }
+    if (sslmode === 'verify-ca') {
+      // verify-ca checks CA trust but skips hostname verification — useful when
+      // connecting through a proxy or pgbouncer where the hostname doesn't match.
+      return {
+        rejectUnauthorized: true,
+        ...(sslCaPem ? { ca: sslCaPem } : {}),
+        checkServerIdentity: () => undefined,
+      }
+    }
     return false
   } catch {
     return false


### PR DESCRIPTION
## Summary
- Add `stripSslParams` helper to remove SSL query params from connection strings before passing to `pg`, preventing pg's URL parser from overriding the `ssl` config object.
- Extend `sslConfigFromConnectionString` with an optional `sslCaPem` parameter to inject a PEM-encoded CA certificate for `verify-ca` and `verify-full` modes.
- Wire `ssl_ca_pem` config through `destination-postgres` and `state-postgres` so users can trust private CAs (e.g. RDS, internal DBs).

## Test plan
- [x] Unit tests updated for `sslConfigFromConnectionString` covering all sslmode values with and without CA
- [x] Unit tests added for `stripSslParams`
- [x] All assertions verified manually (vitest esbuild binary incompatible with local env; CI will run full suite)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)