### PR TITLE
Supabase edge function fixes and refactor

### DIFF
--- a/apps/engine/package.json
+++ b/apps/engine/package.json
@@ -38,6 +38,7 @@
     "@scalar/hono-api-reference": "^0.6",
     "@stripe/sync-destination-google-sheets": "workspace:*",
     "@stripe/sync-destination-postgres": "workspace:*",
+    "@stripe/sync-integration-supabase": "workspace:*",
     "@stripe/sync-protocol": "workspace:*",
     "@stripe/sync-source-stripe": "workspace:*",
     "@stripe/sync-state-postgres": "workspace:*",

--- a/apps/engine/src/cli/command.ts
+++ b/apps/engine/src/cli/command.ts
@@ -6,6 +6,7 @@ import { parseJsonOrFile } from '@stripe/sync-ts-cli'
 import { createConnectorResolver } from '../lib/index.js'
 import { createApp } from '../api/app.js'
 import { serveAction } from '../serve-command.js'
+import { supabaseCmd } from './supabase.js'
 import sourceStripe from '@stripe/sync-source-stripe'
 import destinationPostgres from '@stripe/sync-destination-postgres'
 import destinationGoogleSheets from '@stripe/sync-destination-google-sheets'
@@ -104,6 +105,6 @@ export async function createProgram() {
 
   return defineCommand({
     ...specCli,
-    subCommands: { serve: serveCmd, ...specCli.subCommands },
+    subCommands: { serve: serveCmd, supabase: supabaseCmd, ...specCli.subCommands },
   })
 }

--- a/apps/engine/src/cli/supabase.ts
+++ b/apps/engine/src/cli/supabase.ts
@@ -1,0 +1,142 @@
+import { defineCommand } from 'citty'
+import { install, uninstall, getCurrentVersion } from '@stripe/sync-integration-supabase'
+
+const installCmd = defineCommand({
+  meta: {
+    name: 'install',
+    description: 'Install Stripe sync to Supabase Edge Functions',
+  },
+  args: {
+    token: {
+      type: 'string',
+      description: 'Supabase access token (or SUPABASE_ACCESS_TOKEN env)',
+    },
+    project: {
+      type: 'string',
+      description: 'Supabase project ref (or SUPABASE_PROJECT_REF env)',
+    },
+    stripeKey: {
+      type: 'string',
+      description: 'Stripe API key (or STRIPE_API_KEY env)',
+    },
+    packageVersion: {
+      type: 'string',
+      description: 'Package version to install (e.g., 1.0.8-beta.1, defaults to latest)',
+    },
+    workerInterval: {
+      type: 'string',
+      default: '60',
+      description: 'Worker interval in seconds (default: 60)',
+    },
+    managementUrl: {
+      type: 'string',
+      description:
+        'Supabase management API URL with protocol (e.g., http://localhost:54323, defaults to https://api.supabase.com or SUPABASE_MANAGEMENT_URL env)',
+    },
+    rateLimit: {
+      type: 'string',
+      default: '60',
+      description: 'Max Stripe API requests per second (default: 60)',
+    },
+    syncInterval: {
+      type: 'string',
+      default: '604800',
+      description: 'How often to run a full resync in seconds (default: 604800 = 1 week)',
+    },
+    skipInitialSync: {
+      type: 'boolean',
+      default: false,
+      description: 'Skip triggering the first sync immediately after install',
+    },
+  },
+  async run({ args }) {
+    const token = args.token || process.env.SUPABASE_ACCESS_TOKEN
+    const project = args.project || process.env.SUPABASE_PROJECT_REF
+    const stripeKey = args.stripeKey || process.env.STRIPE_API_KEY
+    const managementUrl = args.managementUrl || process.env.SUPABASE_MANAGEMENT_URL
+
+    if (!token) {
+      throw new Error('Missing --token or SUPABASE_ACCESS_TOKEN env')
+    }
+    if (!project) {
+      throw new Error('Missing --project or SUPABASE_PROJECT_REF env')
+    }
+    if (!stripeKey) {
+      throw new Error('Missing --stripe-key or STRIPE_API_KEY env')
+    }
+
+    const version = args.packageVersion || getCurrentVersion()
+
+    console.log(`Installing Stripe sync to Supabase project ${project}...`)
+    console.log(`  Edge function version: ${version}`)
+
+    await install({
+      supabaseAccessToken: token,
+      supabaseProjectRef: project,
+      stripeKey,
+      packageVersion: version,
+      workerIntervalSeconds: parseInt(args.workerInterval),
+      rateLimit: parseInt(args.rateLimit),
+      syncIntervalSeconds: parseInt(args.syncInterval),
+      skipInitialSync: args.skipInitialSync,
+      supabaseManagementUrl: managementUrl,
+    })
+
+    console.log('Installation complete.')
+  },
+})
+
+const uninstallCmd = defineCommand({
+  meta: {
+    name: 'uninstall',
+    description: 'Uninstall Stripe sync from Supabase Edge Functions',
+  },
+  args: {
+    token: {
+      type: 'string',
+      description: 'Supabase access token (or SUPABASE_ACCESS_TOKEN env)',
+    },
+    project: {
+      type: 'string',
+      description: 'Supabase project ref (or SUPABASE_PROJECT_REF env)',
+    },
+    managementUrl: {
+      type: 'string',
+      description:
+        'Supabase management API URL with protocol (e.g., http://localhost:54323, defaults to https://api.supabase.com or SUPABASE_MANAGEMENT_URL env)',
+    },
+  },
+  async run({ args }) {
+    const token = args.token || process.env.SUPABASE_ACCESS_TOKEN
+    const project = args.project || process.env.SUPABASE_PROJECT_REF
+    const managementUrl = args.managementUrl || process.env.SUPABASE_MANAGEMENT_URL
+
+    if (!token) {
+      throw new Error('Missing --token or SUPABASE_ACCESS_TOKEN env')
+    }
+    if (!project) {
+      throw new Error('Missing --project or SUPABASE_PROJECT_REF env')
+    }
+
+    console.log(`Uninstalling Stripe sync from Supabase project ${project}...`)
+
+    await uninstall({
+      supabaseAccessToken: token,
+      supabaseProjectRef: project,
+      supabaseManagementUrl: managementUrl,
+    })
+
+    console.log('Uninstall complete.')
+  },
+})
+
+export const supabaseCmd = defineCommand({
+  meta: {
+    name: 'supabase',
+    description: 'Manage Stripe sync on Supabase',
+  },
+  subCommands: {
+    install: installCmd,
+    uninstall: uninstallCmd,
+  },
+})

--- a/apps/engine/src/cli/supabase.ts
+++ b/apps/engine/src/cli/supabase.ts
@@ -25,8 +25,8 @@ const installCmd = defineCommand({
     },
     workerInterval: {
       type: 'string',
-      default: '60',
-      description: 'Worker interval in seconds (default: 60)',
+      default: '30',
+      description: 'Worker interval in seconds (default: 30)',
     },
     managementUrl: {
       type: 'string',

--- a/apps/supabase/build.mjs
+++ b/apps/supabase/build.mjs
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { builtinModules } from 'node:module'
 import * as esbuild from 'esbuild'
 
-function nodePrefixBuiltinsPlugin() {
+function denoImportsPlugin() {
   const builtins = new Set(builtinModules.map((m) => (m.startsWith('node:') ? m.slice(5) : m)))
 
   const isBare = (spec) =>
@@ -21,28 +21,18 @@ function nodePrefixBuiltinsPlugin() {
         const spec = args.path
         if (!isBare(spec)) return
 
-        let newImport
         if (isBuiltin(spec)) {
-          newImport = spec.startsWith('node:') ? spec : `node:${spec}`
-        } else {
-          newImport = spec.startsWith('npm:') ? spec : `npm:${spec}`
+          return {
+            path: spec.startsWith('node:') ? spec : `node:${spec}`,
+            external: true,
+          }
         }
 
-        return {
-          path: newImport,
-          namespace: 'deno-import',
-        }
-      })
+        // @stripe/* workspace packages are bundled inline from the monorepo.
+        // Everything else is externalized as npm: for Deno resolution.
+        if (spec.startsWith('@stripe/')) return
 
-      build.onLoad({ filter: /.*/, namespace: 'deno-import' }, (args) => {
-        const spec = args.path
-        return {
-          loader: 'js',
-          contents: `
-            export * from ${JSON.stringify(spec)};
-            export { default } from ${JSON.stringify(spec)};
-          `,
-        }
+        return { path: `npm:${spec}`, external: true }
       })
     },
   }
@@ -72,7 +62,7 @@ const rawTsBundledPlugin = {
         sourcemap: false,
         minify: false,
         logLevel: 'silent',
-        plugins: [nodePrefixBuiltinsPlugin()],
+        plugins: [denoImportsPlugin()],
       })
 
       const bundled = result.outputFiles?.[0]?.text ?? ''

--- a/apps/supabase/src/__tests__/bundle.test.ts
+++ b/apps/supabase/src/__tests__/bundle.test.ts
@@ -6,19 +6,39 @@ import { beforeAll, describe, expect, it } from 'vitest'
 // ---------------------------------------------------------------------------
 
 describe.concurrent('Bundled edge function code', () => {
+  let setupCode: string
+  let webhookCode: string
   let syncCode: string
 
   beforeAll(async () => {
     const distPath = resolve(import.meta.dirname, '../../dist/index.js')
     const mod = await import(distPath)
+    setupCode = mod.setupFunctionCode
+    webhookCode = mod.webhookFunctionCode
     syncCode = mod.syncFunctionCode
   })
 
-  it('consolidated edge function is bundled', () => {
+  it('setup edge function is bundled', () => {
+    expect(setupCode).toBeTruthy()
+  })
+
+  it('webhook edge function is bundled', () => {
+    expect(webhookCode).toBeTruthy()
+  })
+
+  it('sync edge function is bundled', () => {
     expect(syncCode).toBeTruthy()
   })
 
-  it('bundled code contains Deno.serve entry point', () => {
+  it('setup code contains Deno.serve entry point', () => {
+    expect(setupCode).toContain('Deno.serve')
+  })
+
+  it('webhook code contains Deno.serve entry point', () => {
+    expect(webhookCode).toContain('Deno.serve')
+  })
+
+  it('sync code contains Deno.serve entry point', () => {
     expect(syncCode).toContain('Deno.serve')
   })
 

--- a/apps/supabase/src/edge-function-code.ts
+++ b/apps/supabase/src/edge-function-code.ts
@@ -1,4 +1,10 @@
 // @ts-ignore
-import syncFunctionCodeRaw from './edge-functions/stripe-sync.ts?raw'
+import setupCodeRaw from './edge-functions/stripe-setup.ts?raw'
+// @ts-ignore
+import webhookCodeRaw from './edge-functions/stripe-webhook.ts?raw'
+// @ts-ignore
+import syncCodeRaw from './edge-functions/stripe-sync.ts?raw'
 
-export const syncFunctionCode = syncFunctionCodeRaw as string
+export const setupFunctionCode = setupCodeRaw as string
+export const webhookFunctionCode = webhookCodeRaw as string
+export const syncFunctionCode = syncCodeRaw as string

--- a/apps/supabase/src/edge-functions/stripe-setup.ts
+++ b/apps/supabase/src/edge-functions/stripe-setup.ts
@@ -1,0 +1,523 @@
+/**
+ * Stripe Setup Edge Function
+ *
+ *   POST   → install (run migrations, create webhook, store secrets)
+ *   GET    → status (installation status + sync runs)
+ *   DELETE → uninstall (drop schema, delete webhooks/secrets/functions)
+ */
+
+import { runMigrationsFromContent, migrations } from '@stripe/sync-state-postgres'
+import Stripe from 'npm:stripe'
+import pg from 'npm:pg@8'
+
+// ---------------------------------------------------------------------------
+// Helpers (inlined — edge functions must be self-contained)
+// ---------------------------------------------------------------------------
+
+type SchemaInstallationStatus =
+  | 'installing'
+  | 'installed'
+  | 'install error'
+  | 'uninstalling'
+  | 'uninstalled'
+  | 'uninstall error'
+
+interface StripeSchemaComment {
+  status: SchemaInstallationStatus
+  oldVersion?: string
+  newVersion?: string
+  errorMessage?: string
+  startTime?: number
+}
+
+function parseSchemaComment(comment: string | null | undefined): StripeSchemaComment {
+  if (!comment) return { status: 'uninstalled' }
+  try {
+    const parsed = JSON.parse(comment) as StripeSchemaComment
+    if (parsed.status) return parsed
+  } catch {
+    // fall through to legacy parsing
+  }
+  if (!comment.includes('stripe-sync')) return { status: 'uninstalled' }
+  const versionMatch = comment.match(/stripe-sync\s+v?([0-9]+\.[0-9]+\.[0-9]+)/)
+  const version = versionMatch?.[1]
+  let status: SchemaInstallationStatus
+  let errorMessage: string | undefined
+  if (comment.includes('uninstallation:error')) {
+    status = 'uninstall error'
+    errorMessage = comment.match(/uninstallation:error\s*-\s*(.+)$/)?.[1]
+  } else if (comment.includes('uninstallation:started')) {
+    status = 'uninstalling'
+  } else if (comment.includes('installation:error')) {
+    status = 'install error'
+    errorMessage = comment.match(/installation:error\s*-\s*(.+)$/)?.[1]
+  } else if (comment.includes('installation:started')) {
+    status = 'installing'
+  } else if (comment.includes('installed')) {
+    status = 'installed'
+  } else {
+    return { status: 'uninstalled' }
+  }
+  return { status, oldVersion: undefined, newVersion: version, errorMessage }
+}
+
+const VERSION = '0.1.0'
+
+const MGMT_API_BASE_RAW = Deno.env.get('MANAGEMENT_API_URL') || 'https://api.supabase.com'
+const MGMT_API_BASE = MGMT_API_BASE_RAW.match(/^https?:\/\//)
+  ? MGMT_API_BASE_RAW
+  : `https://${MGMT_API_BASE_RAW}`
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+interface AuthContext {
+  supabaseUrl: string
+  projectRef: string
+  accessToken: string
+}
+
+function extractAuthContext(req: Request): AuthContext | Response {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')
+  if (!supabaseUrl) {
+    return jsonResponse({ error: 'SUPABASE_URL not set' }, 500)
+  }
+  const authHeader = req.headers.get('Authorization')
+  if (!authHeader?.startsWith('Bearer ')) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+  return {
+    supabaseUrl,
+    projectRef: new URL(supabaseUrl).hostname.split('.')[0],
+    accessToken: authHeader.substring(7),
+  }
+}
+
+function mgmtHeaders(accessToken: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    'Content-Type': 'application/json',
+  }
+}
+
+async function deleteEdgeFunction(
+  projectRef: string,
+  functionSlug: string,
+  accessToken: string
+): Promise<void> {
+  const url = `${MGMT_API_BASE}/v1/projects/${projectRef}/functions/${functionSlug}`
+  const response = await fetch(url, { method: 'DELETE', headers: mgmtHeaders(accessToken) })
+
+  if (!response.ok && response.status !== 404) {
+    const text = await response.text()
+    throw new Error(`Failed to delete function ${functionSlug}: ${response.status} ${text}`)
+  }
+}
+
+async function deleteSecret(
+  projectRef: string,
+  secretName: string,
+  accessToken: string
+): Promise<void> {
+  const url = `${MGMT_API_BASE}/v1/projects/${projectRef}/secrets`
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: mgmtHeaders(accessToken),
+    body: JSON.stringify([secretName]),
+  })
+
+  if (!response.ok && response.status !== 404) {
+    const text = await response.text()
+    console.warn(`Failed to delete secret ${secretName}: ${response.status} ${text}`)
+  }
+}
+
+async function setSecrets(
+  projectRef: string,
+  secrets: Array<{ name: string; value: string }>,
+  accessToken: string
+): Promise<void> {
+  const url = `${MGMT_API_BASE}/v1/projects/${projectRef}/secrets`
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: mgmtHeaders(accessToken),
+    body: JSON.stringify(secrets),
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`Failed to set secrets: ${response.status} ${text}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST /setup — install (migrations + webhook)
+// ---------------------------------------------------------------------------
+
+async function handleSetupPost(req: Request): Promise<Response> {
+  const ctx = extractAuthContext(req)
+  if (ctx instanceof Response) return ctx
+  const { supabaseUrl, projectRef, accessToken } = ctx
+
+  let pool: pg.Pool | null = null
+  try {
+    const dbUrl = Deno.env.get('SUPABASE_DB_URL')
+    if (!dbUrl) {
+      throw new Error('SUPABASE_DB_URL environment variable is not set')
+    }
+
+    const schemaName = Deno.env.get('SYNC_SCHEMA_NAME') ?? 'stripe'
+    const syncTablesSchemaName = Deno.env.get('SYNC_TABLES_SCHEMA_NAME') ?? schemaName
+
+    // Step 1: Run migrations
+    await runMigrationsFromContent(
+      {
+        databaseUrl: dbUrl,
+        schemaName,
+        syncTablesSchemaName,
+      },
+      migrations
+    )
+
+    pool = new pg.Pool({ connectionString: dbUrl, max: 2 })
+
+    // Release any stale advisory locks from previous timeouts
+    await pool.query('SELECT pg_advisory_unlock_all()')
+
+    // Clear skip_until so cron resumes immediately after reinstall
+    try {
+      await pool.query(`DELETE FROM vault.secrets WHERE name = 'stripe_sync_skip_until'`)
+    } catch (err) {
+      console.warn('Could not delete skip_until vault secret:', err)
+    }
+
+    // Clear stale sync state so the new install starts fresh
+    const safeSchema = schemaName.replace(/"/g, '""')
+    try {
+      await pool.query(`DELETE FROM "${safeSchema}"."_sync_state" WHERE sync_id = 'default'`)
+    } catch {
+      // Table may not exist yet on first install — safe to ignore
+    }
+
+    const stripeKey = Deno.env.get('STRIPE_SECRET_KEY')!
+    const stripe = new Stripe(stripeKey)
+
+    // Step 2: Create managed webhook endpoint via Stripe SDK
+    const webhookUrl = `${supabaseUrl}/functions/v1/stripe-webhook`
+
+    const existing = await stripe.webhookEndpoints.list({ limit: 100 })
+    const managedWebhooks = existing.data.filter((wh) => wh.metadata?.managed_by === 'stripe-sync')
+
+    // Clean up webhooks pointing to old URLs (e.g. /stripe-worker/webhook)
+    for (const old of managedWebhooks.filter((wh) => wh.url !== webhookUrl)) {
+      try {
+        await stripe.webhookEndpoints.del(old.id)
+        console.log(`Deleted legacy webhook ${old.id} (${old.url})`)
+      } catch (err) {
+        console.warn(`Could not delete legacy webhook ${old.id}:`, err)
+      }
+    }
+
+    const current = managedWebhooks.find((wh) => wh.url === webhookUrl)
+    let webhookSecret = ''
+    let webhookId = current?.id
+    if (!current || current.status !== 'enabled') {
+      if (current) {
+        await stripe.webhookEndpoints.del(current.id)
+      }
+      const endpoint = await stripe.webhookEndpoints.create({
+        url: webhookUrl,
+        enabled_events: ['*'],
+        metadata: { managed_by: 'stripe-sync' },
+      })
+      webhookSecret = endpoint.secret!
+      webhookId = endpoint.id
+    }
+
+    // Step 3: Resolve account ID and store secrets
+    const account = await stripe.accounts.retrieve()
+    const secrets: Array<{ name: string; value: string }> = [
+      { name: 'STRIPE_ACCOUNT_ID', value: account.id },
+    ]
+    if (webhookSecret) {
+      secrets.push({ name: 'STRIPE_WEBHOOK_SECRET', value: webhookSecret })
+    }
+    await setSecrets(projectRef, secrets, accessToken)
+
+    await pool.end()
+    pool = null
+
+    return jsonResponse({
+      success: true,
+      message: 'Setup complete',
+      webhookId,
+    })
+  } catch (error: unknown) {
+    const err = error as Error
+    console.error('Setup error:', error)
+    if (pool) {
+      try {
+        await pool.query('SELECT pg_advisory_unlock_all()')
+        await pool.end()
+      } catch (cleanupErr) {
+        console.warn('Cleanup failed:', cleanupErr)
+      }
+    }
+    return jsonResponse({ success: false, error: err.message }, 500)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GET /setup — status
+// ---------------------------------------------------------------------------
+
+async function handleSetupGet(_req: Request): Promise<Response> {
+  const dbUrl = Deno.env.get('SUPABASE_DB_URL')
+  if (!dbUrl) {
+    return jsonResponse({ error: 'SUPABASE_DB_URL not set' }, 500)
+  }
+
+  const pool = new pg.Pool({ connectionString: dbUrl, max: 1 })
+
+  try {
+    const schemaName = Deno.env.get('SYNC_SCHEMA_NAME') ?? 'stripe'
+    const commentResult = await pool.query(
+      `SELECT obj_description(oid, 'pg_namespace') as comment
+       FROM pg_namespace
+       WHERE nspname = $1`,
+      [schemaName]
+    )
+
+    const comment = commentResult.rows[0]?.comment || null
+
+    let syncStatus: Array<Record<string, unknown>> = []
+    if (comment) {
+      try {
+        const syncSchema = Deno.env.get('SYNC_TABLES_SCHEMA_NAME') ?? schemaName
+        const safeSchema = syncSchema.replace(/"/g, '""')
+        const syncResult = await pool.query(`
+          SELECT DISTINCT ON (account_id)
+            account_id, started_at, closed_at, status, error_message,
+            total_processed, total_objects, complete_count, error_count,
+            running_count, pending_count, triggered_by, max_concurrent
+          FROM "${safeSchema}"."sync_runs"
+          ORDER BY account_id, started_at DESC
+        `)
+        syncStatus = syncResult.rows
+      } catch (err) {
+        console.warn('sync_runs query failed (may not exist yet):', err)
+      }
+    }
+
+    const parsedComment = parseSchemaComment(comment)
+
+    return new Response(
+      JSON.stringify({
+        package_version: VERSION,
+        installation_status: parsedComment.status,
+        sync_status: syncStatus,
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+        },
+      }
+    )
+  } catch (error: unknown) {
+    const err = error as Error
+    console.error('Status query error:', error)
+    return jsonResponse(
+      {
+        error: err.message,
+        package_version: VERSION,
+        installation_status: 'not_installed',
+      },
+      500
+    )
+  } finally {
+    await pool.end()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /setup — uninstall
+// ---------------------------------------------------------------------------
+
+async function handleSetupDelete(req: Request): Promise<Response> {
+  const ctx = extractAuthContext(req)
+  if (ctx instanceof Response) return ctx
+  const { projectRef, accessToken } = ctx
+
+  let pool: pg.Pool | null = null
+  try {
+    const dbUrl = Deno.env.get('SUPABASE_DB_URL')
+    if (!dbUrl) {
+      throw new Error('SUPABASE_DB_URL environment variable is not set')
+    }
+
+    const stripeKey = Deno.env.get('STRIPE_SECRET_KEY')
+    if (!stripeKey) {
+      throw new Error('STRIPE_SECRET_KEY environment variable is required for uninstall')
+    }
+
+    const schemaName = Deno.env.get('SYNC_SCHEMA_NAME') ?? 'stripe'
+    const syncTablesSchemaName = Deno.env.get('SYNC_TABLES_SCHEMA_NAME') ?? schemaName
+
+    pool = new pg.Pool({ connectionString: dbUrl, max: 2 })
+    const stripe = new Stripe(stripeKey)
+
+    // Step 1: Delete all managed webhooks via Stripe SDK
+    try {
+      const endpoints = await stripe.webhookEndpoints.list({ limit: 100 })
+      for (const wh of endpoints.data) {
+        if (wh.metadata?.managed_by === 'stripe-sync') {
+          try {
+            await stripe.webhookEndpoints.del(wh.id)
+            console.log(`Deleted webhook: ${wh.id}`)
+          } catch (err) {
+            console.warn(`Could not delete webhook ${wh.id}:`, err)
+          }
+        }
+      }
+    } catch (err) {
+      console.warn(`Could not get webhooks:`, err)
+    }
+
+    // Unschedule pg_cron jobs
+    try {
+      await pool.query(`
+        DO $$
+        BEGIN
+          IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'stripe-sync-worker') THEN
+            PERFORM cron.unschedule('stripe-sync-worker');
+          END IF;
+          IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'stripe-sigma-worker') THEN
+            PERFORM cron.unschedule('stripe-sigma-worker');
+          END IF;
+        END $$;
+      `)
+    } catch (err) {
+      console.warn('Could not unschedule pg_cron job:', err)
+    }
+
+    // Delete vault secrets
+    try {
+      await pool.query(`
+        DELETE FROM vault.secrets
+        WHERE name IN ('stripe_sync_worker_secret', 'stripe_sigma_worker_secret')
+      `)
+    } catch (err) {
+      console.warn('Could not delete vault secret:', err)
+    }
+
+    // Drop Sigma self-trigger function if present
+    try {
+      const dropSchema = syncTablesSchemaName.replace(/"/g, '""')
+      await pool.query(`DROP FUNCTION IF EXISTS "${dropSchema}".trigger_sigma_worker()`)
+    } catch (err) {
+      console.warn('Could not drop sigma trigger function:', err)
+    }
+
+    // Terminate connections holding locks on schema
+    try {
+      await pool.query(
+        `SELECT pg_terminate_backend(pid)
+         FROM pg_locks l
+         JOIN pg_class c ON l.relation = c.oid
+         JOIN pg_namespace n ON c.relnamespace = n.oid
+         WHERE n.nspname = $1 AND l.pid != pg_backend_pid()`,
+        [syncTablesSchemaName]
+      )
+    } catch (err) {
+      console.warn('Could not terminate connections:', err)
+    }
+
+    // Drop schema(s) with retry
+    const schemasToDrop = [...new Set([schemaName, syncTablesSchemaName])]
+    let dropAttempts = 0
+    const maxAttempts = 3
+    while (dropAttempts < maxAttempts) {
+      try {
+        for (const s of schemasToDrop) {
+          const safe = s.replace(/"/g, '""')
+          await pool.query(`DROP SCHEMA IF EXISTS "${safe}" CASCADE`)
+        }
+        break
+      } catch (err: unknown) {
+        const error = err as Error
+        dropAttempts++
+        if (dropAttempts >= maxAttempts) {
+          throw new Error(
+            `Failed to drop schema after ${maxAttempts} attempts. ` +
+              `There may be active connections or locks on the stripe schema. ` +
+              `Error: ${error.message}`
+          )
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+      }
+    }
+
+    await pool.end()
+    pool = null
+
+    // Step 2: Delete Supabase secrets
+    for (const secretName of [
+      'STRIPE_SECRET_KEY',
+      'MANAGEMENT_API_URL',
+      'ENABLE_SIGMA',
+      'STRIPE_ACCOUNT_ID',
+      'STRIPE_WEBHOOK_SECRET',
+    ]) {
+      try {
+        await deleteSecret(projectRef, secretName, accessToken)
+      } catch (err) {
+        console.warn(`Could not delete ${secretName} secret:`, err)
+      }
+    }
+
+    // Step 3: Delete edge functions (current + legacy)
+    for (const slug of [
+      'stripe-setup',
+      'stripe-webhook',
+      'stripe-sync',
+      'stripe-worker',
+      'stripe-backfill-worker',
+      'sigma-data-worker',
+    ]) {
+      try {
+        await deleteEdgeFunction(projectRef, slug, accessToken)
+      } catch (err) {
+        console.warn(`Could not delete ${slug} function:`, err)
+      }
+    }
+
+    return jsonResponse({ success: true, message: 'Uninstall complete' })
+  } catch (error: unknown) {
+    const err = error as Error
+    console.error('Uninstall error:', error)
+    if (pool) {
+      try {
+        await pool.end()
+      } catch (cleanupErr) {
+        console.warn('Cleanup failed:', cleanupErr)
+      }
+    }
+    return jsonResponse({ success: false, error: err.message }, 500)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+Deno.serve(async (req) => {
+  if (req.method === 'GET') return handleSetupGet(req)
+  if (req.method === 'POST') return handleSetupPost(req)
+  if (req.method === 'DELETE') return handleSetupDelete(req)
+  return new Response('Method not allowed', { status: 405 })
+})

--- a/apps/supabase/src/edge-functions/stripe-sync.ts
+++ b/apps/supabase/src/edge-functions/stripe-sync.ts
@@ -603,7 +603,7 @@ async function handleWebhook(req: Request): Promise<Response> {
 // ---------------------------------------------------------------------------
 
 const SYNC_INTERVAL = Number(Deno.env.get('SYNC_INTERVAL')) || 60 * 60 * 24 * 7
-const PAGES_PER_INVOCATION = Number(Deno.env.get('PAGES_PER_INVOCATION')) || 1000
+const PAGES_PER_INVOCATION = Number(Deno.env.get('PAGES_PER_INVOCATION')) || 200
 
 async function handleSync(req: Request): Promise<Response> {
   if (req.method !== 'POST') {

--- a/apps/supabase/src/edge-functions/stripe-sync.ts
+++ b/apps/supabase/src/edge-functions/stripe-sync.ts
@@ -7,20 +7,19 @@
  *   GET    /setup     → status (installation status + sync runs)
  *   DELETE /setup     → uninstall (drop schema, delete webhooks/secrets/functions)
  *   POST   /webhook   → process Stripe webhook event
- *   POST   /sync      → cron coordinator (discovers streams, fans out to /backfill)
- *   POST   /backfill  → per-stream backfill worker
+ *   POST   /sync      → cron-driven pipeline (source → destination with bounded checkpoints)
  */
 
-import { runMigrationsFromContent, migrations } from '@stripe/sync-state-postgres'
+import {
+  runMigrationsFromContent,
+  migrations,
+  createScopedPgStateStore,
+} from '@stripe/sync-state-postgres'
 import sourceStripe, {
   type Config as SourceConfig,
-  buildResourceRegistry,
-  catalogFromRegistry,
+  DEFAULT_SYNC_OBJECTS,
 } from '@stripe/sync-source-stripe'
-import destinationPostgres, {
-  type Config as DestConfig,
-  upsertMany,
-} from '@stripe/sync-destination-postgres'
+import destinationPostgres, { type Config as DestConfig } from '@stripe/sync-destination-postgres'
 import Stripe from 'npm:stripe'
 import pg from 'npm:pg@8'
 
@@ -227,7 +226,7 @@ async function handleSetupPost(req: Request): Promise<Response> {
     const stripe = new Stripe(stripeKey)
 
     // Step 2: Create managed webhook endpoint via Stripe SDK
-    const webhookUrl = `${supabaseUrl}/functions/v1/stripe-sync/webhook`
+    const webhookUrl = `${supabaseUrl}/functions/v1/stripe-worker/webhook`
 
     const existing = await stripe.webhookEndpoints.list({ limit: 100 })
     const managed = existing.data.find(
@@ -502,7 +501,7 @@ async function handleSetupDelete(req: Request): Promise<Response> {
 
     // Step 3: Delete edge functions (current + legacy from before consolidation)
     for (const slug of [
-      'stripe-sync',
+      'stripe-worker',
       'stripe-setup',
       'stripe-webhook',
       'stripe-worker',
@@ -565,9 +564,13 @@ async function handleWebhook(req: Request): Promise<Response> {
     batch_size: 100,
   }
 
-  const stripe = new Stripe(stripeKey)
-  const registry = buildResourceRegistry(stripe)
-  const catalog = catalogFromRegistry(registry)
+  const catalog = {
+    streams: DEFAULT_SYNC_OBJECTS.map((name) => ({
+      stream: { name, primary_key: [['id']] },
+      sync_mode: 'full_refresh' as const,
+      destination_sync_mode: 'append_dedup' as const,
+    })),
+  }
 
   try {
     const rawBody = new Uint8Array(await req.arrayBuffer())
@@ -596,10 +599,11 @@ async function handleWebhook(req: Request): Promise<Response> {
 }
 
 // ---------------------------------------------------------------------------
-// Route: POST /sync — cron coordinator (discovers streams, fans out to /backfill)
+// Route: POST /sync — cron-driven pipeline (source → destination with bounded checkpoints)
 // ---------------------------------------------------------------------------
 
 const SYNC_INTERVAL = Number(Deno.env.get('SYNC_INTERVAL')) || 60 * 60 * 24 * 7
+const PAGES_PER_INVOCATION = Number(Deno.env.get('PAGES_PER_INVOCATION')) || 10
 
 async function handleSync(req: Request): Promise<Response> {
   if (req.method !== 'POST') {
@@ -613,298 +617,93 @@ async function handleSync(req: Request): Promise<Response> {
 
   const schemaName = Deno.env.get('SYNC_SCHEMA_NAME') ?? 'stripe'
   const safeSchema = schemaName.replace(/"/g, '""')
-
   const stripeKey = Deno.env.get('STRIPE_SECRET_KEY')!
-  const stripe = new Stripe(stripeKey)
   const pool = new pg.Pool({ connectionString: dbUrl, max: 2 })
-  const registry = buildResourceRegistry(stripe)
 
   try {
-    // Auth: validate Bearer token against vault worker secret
     const authErr = await validateWorkerAuth(req, pool)
     if (authErr) {
       await pool.end()
       return authErr
     }
 
-    // Create state tables (idempotent)
-    await pool.query(`
-      CREATE TABLE IF NOT EXISTS "${safeSchema}"._sync_runs (
-        sync_id      text PRIMARY KEY,
-        status       text NOT NULL DEFAULT 'syncing',
-        total_streams int NOT NULL,
-        started_at   timestamptz NOT NULL DEFAULT now(),
-        completed_at timestamptz
-      );
-      CREATE TABLE IF NOT EXISTS "${safeSchema}"._sync_state (
-        sync_id    text NOT NULL,
-        stream     text NOT NULL,
-        cursor     text,
-        status     text NOT NULL DEFAULT 'pending',
-        records    int  NOT NULL DEFAULT 0,
-        error      text,
-        updated_at timestamptz NOT NULL DEFAULT now(),
-        PRIMARY KEY (sync_id, stream)
-      );
-    `)
+    const stateStore = createScopedPgStateStore(pool, schemaName, 'default')
+    let state = (await stateStore.get()) as
+      | Record<string, { pageCursor: string | null; status: string }>
+      | undefined
 
-    // Check for recent completed run within SYNC_INTERVAL → skip if too soon
-    const recentRun = await pool.query(
-      `SELECT sync_id, completed_at FROM "${safeSchema}"._sync_runs
-       WHERE status = 'complete'
-         AND completed_at > now() - make_interval(secs => $1)
-       ORDER BY completed_at DESC LIMIT 1`,
-      [SYNC_INTERVAL]
-    )
-    if (recentRun.rows.length > 0) {
-      const msg = `Skipping — completed run ${recentRun.rows[0].sync_id} at ${recentRun.rows[0].completed_at} (within ${SYNC_INTERVAL}s window)`
-      console.log(msg)
-      await pool.end()
-      return jsonResponse({ skipped: true, message: msg })
+    // Debounce: skip if all streams completed within SYNC_INTERVAL
+    if (state && Object.values(state).every((s) => s?.status === 'complete')) {
+      const { rows } = await pool.query(
+        `SELECT MAX(updated_at) as last_update FROM "${safeSchema}"."_sync_state" WHERE sync_id = 'default'`
+      )
+      const lastUpdate = rows[0]?.last_update
+      if (lastUpdate) {
+        const elapsed = (Date.now() - new Date(lastUpdate).getTime()) / 1000
+        if (elapsed < SYNC_INTERVAL) {
+          console.log(
+            `Skipping — all streams complete ${Math.round(elapsed)}s ago (within ${SYNC_INTERVAL}s window)`
+          )
+          await pool.end()
+          return jsonResponse({
+            skipped: true,
+            message: `All streams complete (${Math.round(elapsed)}s ago)`,
+          })
+        }
+      }
+      // Interval elapsed — clear state to start a fresh re-sync
+      await pool.query(`DELETE FROM "${safeSchema}"."_sync_state" WHERE sync_id = 'default'`)
+      state = undefined
     }
 
-    // Build catalog to discover streams
-    const catalog = catalogFromRegistry(registry)
-    const streams = catalog.streams.map((s) => s.name)
+    const sourceConfig: SourceConfig = { api_key: stripeKey }
+    const destConfig: DestConfig = {
+      connection_string: dbUrl,
+      schema: schemaName,
+      port: 5432,
+      batch_size: 100,
+    }
 
-    // Generate sync ID
-    const syncId = `sync_${Date.now()}`
+    const defaultSet = new Set(DEFAULT_SYNC_OBJECTS)
+    const discovered = await sourceStripe.discover({ config: sourceConfig })
+    const catalog = {
+      streams: discovered.streams
+        .filter((s) => defaultSet.has(s.name))
+        .map((s) => ({
+          stream: s,
+          sync_mode: 'full_refresh' as const,
+          destination_sync_mode: 'append_dedup' as const,
+        })),
+    }
 
-    // Insert run + per-stream state rows
-    await pool.query(
-      `INSERT INTO "${safeSchema}"._sync_runs (sync_id, total_streams) VALUES ($1, $2)`,
-      [syncId, streams.length]
-    )
-    for (const stream of streams) {
-      await pool.query(
-        `INSERT INTO "${safeSchema}"._sync_state (sync_id, stream) VALUES ($1, $2)
-         ON CONFLICT DO NOTHING`,
-        [syncId, stream]
-      )
+    await destinationPostgres.setup({ config: destConfig, catalog })
+
+    const sourceMessages = sourceStripe.read({ config: sourceConfig, catalog, state })
+    const destOutput = destinationPostgres.write({ config: destConfig, catalog }, sourceMessages)
+
+    let checkpoints = 0
+    for await (const msg of destOutput) {
+      if (msg.type === 'state' && msg.stream) {
+        await stateStore.set(msg.stream, msg.data)
+        checkpoints++
+        if (checkpoints >= PAGES_PER_INVOCATION) {
+          console.log(`Reached ${PAGES_PER_INVOCATION} checkpoints, yielding to next cron tick`)
+          break
+        }
+      }
     }
 
     await pool.end()
+    console.log(`Sync pass done — ${checkpoints} checkpoints persisted`)
 
-    // Fan out: one worker per stream via /backfill route
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')
-    const backfillUrl = `${supabaseUrl}/functions/v1/stripe-sync/backfill`
-    const authHeader = req.headers.get('Authorization')!
-
-    await Promise.all(
-      streams.map((stream) =>
-        fetch(backfillUrl, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: authHeader,
-          },
-          body: JSON.stringify({ sync_id: syncId, stream }),
-        })
-      )
-    )
-
-    console.log(`Started sync ${syncId} with ${streams.length} streams`)
-
-    return jsonResponse({ sync_id: syncId, streams: streams.length, status: 'started' })
+    return jsonResponse({ status: checkpoints > 0 ? 'syncing' : 'complete', checkpoints })
   } catch (error: unknown) {
     const err = error as Error
-    console.error('Sync coordinator error:', error)
+    console.error('Sync error:', error)
     try {
       await pool.end()
     } catch {}
     return jsonResponse({ error: err.message }, 500)
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Route: POST /backfill — per-stream backfill worker
-//
-// Future optimizations:
-// - Make the initial /sync invocation in install() fire-and-forget so install
-//   returns faster (currently blocks for up to 30s waiting for coordinator).
-// - Tune PAGES_PER_INVOCATION based on observed cold-start times.
-// - Consider returning a streaming response so the caller can observe progress.
-// - Add exponential backoff on rate-limit errors instead of failing the stream.
-// - Pool pg connections across invocations (module-level singleton).
-// ---------------------------------------------------------------------------
-
-const PAGES_PER_INVOCATION = Number(Deno.env.get('PAGES_PER_INVOCATION')) || 10
-
-async function handleBackfill(req: Request): Promise<Response> {
-  if (req.method !== 'POST') {
-    return new Response('Method not allowed', { status: 405 })
-  }
-
-  const dbUrl = Deno.env.get('SUPABASE_DB_URL')
-  if (!dbUrl) {
-    return jsonResponse({ error: 'SUPABASE_DB_URL not set' }, 500)
-  }
-
-  const schemaName = Deno.env.get('SYNC_SCHEMA_NAME') ?? 'stripe'
-  const safeSchema = schemaName.replace(/"/g, '""')
-
-  const stripeKey = Deno.env.get('STRIPE_SECRET_KEY')!
-  const stripe = new Stripe(stripeKey)
-  const pool = new pg.Pool({ connectionString: dbUrl, max: 2 })
-  const registry = buildResourceRegistry(stripe)
-
-  // Auth: validate Bearer token against vault worker secret
-  const authErr = await validateWorkerAuth(req, pool)
-  if (authErr) {
-    await pool.end()
-    return authErr
-  }
-
-  // Parse request body
-  const { sync_id: syncId, stream } = (await req.json()) as {
-    sync_id: string
-    stream: string
-  }
-  if (!syncId || !stream) {
-    await pool.end()
-    return new Response('Missing sync_id or stream', { status: 400 })
-  }
-
-  /** Find the resource config whose tableName matches the given stream name. */
-  function findConfigByTableName(name: string) {
-    const entry = Object.values(registry).find((cfg) => cfg.tableName === name)
-    if (!entry) throw new Error(`Unknown stream: ${name}`)
-    return entry
-  }
-
-  /**
-   * Barrier-based completion check.
-   * Atomically marks the sync run as complete if all streams have settled.
-   */
-  async function checkCompletion(): Promise<void> {
-    const result = await pool.query(
-      `UPDATE "${safeSchema}"._sync_runs
-       SET status = 'complete', completed_at = now()
-       WHERE sync_id = $1
-         AND status = 'syncing'
-         AND NOT EXISTS (
-           SELECT 1 FROM "${safeSchema}"._sync_state
-           WHERE sync_id = $1 AND status NOT IN ('complete', 'error')
-         )
-       RETURNING *`,
-      [syncId]
-    )
-
-    if (result.rowCount && result.rowCount > 0) {
-      console.log(`Sync ${syncId} complete — all streams settled`)
-    }
-  }
-
-  try {
-    // Load cursor from state table
-    const stateResult = await pool.query(
-      `SELECT cursor, records FROM "${safeSchema}"._sync_state
-       WHERE sync_id = $1 AND stream = $2`,
-      [syncId, stream]
-    )
-    if (stateResult.rows.length === 0) {
-      throw new Error(`No state row for sync_id=${syncId} stream=${stream}`)
-    }
-
-    const existingCursor = stateResult.rows[0].cursor as string | null
-    const existingRecords = stateResult.rows[0].records as number
-
-    // Mark as syncing
-    await pool.query(
-      `UPDATE "${safeSchema}"._sync_state
-       SET status = 'syncing', updated_at = now()
-       WHERE sync_id = $1 AND stream = $2`,
-      [syncId, stream]
-    )
-
-    // Resolve list function for this stream
-    const config = findConfigByTableName(stream)
-    const listFn = config.listFn
-
-    // Paginate bounded number of pages
-    let cursor = existingCursor
-    let hasMore = true
-    let newRecords = 0
-
-    for (let page = 0; page < PAGES_PER_INVOCATION && hasMore; page++) {
-      const params: Stripe.PaginationParams = { limit: 100 }
-      if (cursor) params.starting_after = cursor
-
-      const response = await listFn(params)
-
-      if (response.data.length > 0) {
-        await upsertMany(pool, schemaName, stream, response.data as Record<string, unknown>[])
-        newRecords += response.data.length
-        const lastItem = response.data.at(-1) as { id?: string }
-        if (lastItem?.id) {
-          cursor = lastItem.id
-        }
-      }
-
-      hasMore = response.has_more
-    }
-
-    // Save cursor + record count
-    await pool.query(
-      `UPDATE "${safeSchema}"._sync_state
-       SET cursor = $1, status = $2, records = $3, updated_at = now()
-       WHERE sync_id = $4 AND stream = $5`,
-      [cursor, hasMore ? 'syncing' : 'complete', existingRecords + newRecords, syncId, stream]
-    )
-
-    if (hasMore) {
-      // More pages — self-reinvoke (fire-and-forget)
-      const supabaseUrl = Deno.env.get('SUPABASE_URL')
-      const backfillUrl = `${supabaseUrl}/functions/v1/stripe-sync/backfill`
-      const authHeader = req.headers.get('Authorization')!
-      fetch(backfillUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: authHeader,
-        },
-        body: JSON.stringify({ sync_id: syncId, stream }),
-      }).catch((err) => console.error(`Self-reinvoke failed for ${stream}:`, err))
-
-      console.log(
-        `Stream ${stream}: synced ${newRecords} records (${existingRecords + newRecords} total), continuing...`
-      )
-    } else {
-      // Stream complete — check if ALL streams are done
-      await checkCompletion()
-      console.log(`Stream ${stream}: complete — ${existingRecords + newRecords} total records`)
-    }
-
-    await pool.end()
-
-    return jsonResponse({
-      sync_id: syncId,
-      stream,
-      records: existingRecords + newRecords,
-      has_more: hasMore,
-    })
-  } catch (err) {
-    const errorMessage = err instanceof Error ? err.message : String(err)
-    console.error(`Worker error for stream ${stream}:`, errorMessage)
-
-    // Mark stream as error
-    await pool
-      .query(
-        `UPDATE "${safeSchema}"._sync_state
-         SET status = 'error', error = $1, updated_at = now()
-         WHERE sync_id = $2 AND stream = $3`,
-        [errorMessage, syncId, stream]
-      )
-      .catch((e) => console.error('Failed to update error state:', e))
-
-    // Still check completion — other streams may be done
-    await checkCompletion().catch((e) => console.error('Completion check failed:', e))
-
-    try {
-      await pool.end()
-    } catch {}
-
-    return jsonResponse({ error: errorMessage }, 500)
   }
 }
 
@@ -914,7 +713,7 @@ async function handleBackfill(req: Request): Promise<Response> {
 
 Deno.serve(async (req) => {
   const url = new URL(req.url)
-  // Last segment after /functions/v1/stripe-sync/
+  // Last segment after /functions/v1/stripe-worker/
   const path = url.pathname.split('/').pop()
 
   if (path === 'webhook') return handleWebhook(req)
@@ -927,7 +726,6 @@ Deno.serve(async (req) => {
   }
 
   if (path === 'sync') return handleSync(req)
-  if (path === 'backfill') return handleBackfill(req)
 
   return new Response('Not found', { status: 404 })
 })

--- a/apps/supabase/src/edge-functions/stripe-sync.ts
+++ b/apps/supabase/src/edge-functions/stripe-sync.ts
@@ -1,154 +1,26 @@
 /**
- * Consolidated Stripe Sync Edge Function
+ * Stripe Sync Edge Function
  *
- * Single Deno.serve() with path-based routing:
- *
- *   POST   /setup     → install (run migrations, create webhook, store secrets)
- *   GET    /setup     → status (installation status + sync runs)
- *   DELETE /setup     → uninstall (drop schema, delete webhooks/secrets/functions)
- *   POST   /webhook   → process Stripe webhook event
- *   POST   /sync      → cron-driven pipeline (source → destination with bounded checkpoints)
+ *   POST → cron-driven pipeline (source → destination with bounded checkpoints)
  */
 
-import {
-  runMigrationsFromContent,
-  migrations,
-  createScopedPgStateStore,
-} from '@stripe/sync-state-postgres'
+import { createScopedPgStateStore } from '@stripe/sync-state-postgres'
 import sourceStripe, {
   type Config as SourceConfig,
   DEFAULT_SYNC_OBJECTS,
 } from '@stripe/sync-source-stripe'
 import destinationPostgres, { type Config as DestConfig } from '@stripe/sync-destination-postgres'
-import Stripe from 'npm:stripe'
 import pg from 'npm:pg@8'
 
 // ---------------------------------------------------------------------------
-// Shared env + helpers (run once per cold start)
+// Helpers (inlined — edge functions must be self-contained)
 // ---------------------------------------------------------------------------
-
-// Inlined from schemaComment.ts — edge functions must be self-contained (no relative imports)
-type SchemaInstallationStatus =
-  | 'installing'
-  | 'installed'
-  | 'install error'
-  | 'uninstalling'
-  | 'uninstalled'
-  | 'uninstall error'
-
-interface StripeSchemaComment {
-  status: SchemaInstallationStatus
-  oldVersion?: string
-  newVersion?: string
-  errorMessage?: string
-  startTime?: number
-}
-
-function parseSchemaComment(comment: string | null | undefined): StripeSchemaComment {
-  if (!comment) return { status: 'uninstalled' }
-  try {
-    const parsed = JSON.parse(comment) as StripeSchemaComment
-    if (parsed.status) return parsed
-  } catch {
-    // fall through to legacy parsing
-  }
-  if (!comment.includes('stripe-sync')) return { status: 'uninstalled' }
-  const versionMatch = comment.match(/stripe-sync\s+v?([0-9]+\.[0-9]+\.[0-9]+)/)
-  const version = versionMatch?.[1]
-  let status: SchemaInstallationStatus
-  let errorMessage: string | undefined
-  if (comment.includes('uninstallation:error')) {
-    status = 'uninstall error'
-    errorMessage = comment.match(/uninstallation:error\s*-\s*(.+)$/)?.[1]
-  } else if (comment.includes('uninstallation:started')) {
-    status = 'uninstalling'
-  } else if (comment.includes('installation:error')) {
-    status = 'install error'
-    errorMessage = comment.match(/installation:error\s*-\s*(.+)$/)?.[1]
-  } else if (comment.includes('installation:started')) {
-    status = 'installing'
-  } else if (comment.includes('installed')) {
-    status = 'installed'
-  } else {
-    return { status: 'uninstalled' }
-  }
-  return { status, oldVersion: undefined, newVersion: version, errorMessage }
-}
-
-const VERSION = '0.1.0'
-
-const MGMT_API_BASE_RAW = Deno.env.get('MANAGEMENT_API_URL') || 'https://api.supabase.com'
-const MGMT_API_BASE = MGMT_API_BASE_RAW.match(/^https?:\/\//)
-  ? MGMT_API_BASE_RAW
-  : `https://${MGMT_API_BASE_RAW}`
 
 const jsonResponse = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), {
     status,
     headers: { 'Content-Type': 'application/json' },
   })
-
-async function deleteEdgeFunction(
-  projectRef: string,
-  functionSlug: string,
-  accessToken: string
-): Promise<void> {
-  const url = `${MGMT_API_BASE}/v1/projects/${projectRef}/functions/${functionSlug}`
-  const response = await fetch(url, {
-    method: 'DELETE',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-    },
-  })
-
-  if (!response.ok && response.status !== 404) {
-    const text = await response.text()
-    throw new Error(`Failed to delete function ${functionSlug}: ${response.status} ${text}`)
-  }
-}
-
-async function deleteSecret(
-  projectRef: string,
-  secretName: string,
-  accessToken: string
-): Promise<void> {
-  const url = `${MGMT_API_BASE}/v1/projects/${projectRef}/secrets`
-  const response = await fetch(url, {
-    method: 'DELETE',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify([secretName]),
-  })
-
-  if (!response.ok && response.status !== 404) {
-    const text = await response.text()
-    console.warn(`Failed to delete secret ${secretName}: ${response.status} ${text}`)
-  }
-}
-
-async function setSecrets(
-  projectRef: string,
-  secrets: Array<{ name: string; value: string }>,
-  accessToken: string
-): Promise<void> {
-  const url = `${MGMT_API_BASE}/v1/projects/${projectRef}/secrets`
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(secrets),
-  })
-
-  if (!response.ok) {
-    const text = await response.text()
-    throw new Error(`Failed to set secrets: ${response.status} ${text}`)
-  }
-}
 
 /**
  * Validate worker auth via vault-stored secret.
@@ -181,431 +53,15 @@ async function validateWorkerAuth(
 }
 
 // ---------------------------------------------------------------------------
-// Route: POST /setup — install (migrations + webhook)
-// ---------------------------------------------------------------------------
-
-async function handleSetupPost(req: Request): Promise<Response> {
-  const supabaseUrl = Deno.env.get('SUPABASE_URL')
-  if (!supabaseUrl) {
-    return jsonResponse({ error: 'SUPABASE_URL not set' }, 500)
-  }
-  const projectRef = new URL(supabaseUrl).hostname.split('.')[0]
-
-  const authHeader = req.headers.get('Authorization')
-  if (!authHeader?.startsWith('Bearer ')) {
-    return new Response('Unauthorized', { status: 401 })
-  }
-  const accessToken = authHeader.substring(7)
-
-  let pool: pg.Pool | null = null
-  try {
-    const dbUrl = Deno.env.get('SUPABASE_DB_URL')
-    if (!dbUrl) {
-      throw new Error('SUPABASE_DB_URL environment variable is not set')
-    }
-
-    const schemaName = Deno.env.get('SYNC_SCHEMA_NAME') ?? 'stripe'
-    const syncTablesSchemaName = Deno.env.get('SYNC_TABLES_SCHEMA_NAME') ?? schemaName
-
-    // Step 1: Run migrations
-    await runMigrationsFromContent(
-      {
-        databaseUrl: dbUrl,
-        schemaName,
-        syncTablesSchemaName,
-      },
-      migrations
-    )
-
-    pool = new pg.Pool({ connectionString: dbUrl, max: 2 })
-
-    // Release any stale advisory locks from previous timeouts
-    await pool.query('SELECT pg_advisory_unlock_all()')
-
-    const stripeKey = Deno.env.get('STRIPE_SECRET_KEY')!
-    const stripe = new Stripe(stripeKey)
-
-    // Step 2: Create managed webhook endpoint via Stripe SDK
-    const webhookUrl = `${supabaseUrl}/functions/v1/stripe-worker/webhook`
-
-    const existing = await stripe.webhookEndpoints.list({ limit: 100 })
-    const managed = existing.data.find(
-      (wh) => wh.url === webhookUrl && wh.metadata?.managed_by === 'stripe-sync'
-    )
-
-    let webhookSecret = ''
-    let webhookId = managed?.id
-    if (!managed || managed.status !== 'enabled') {
-      if (managed) {
-        await stripe.webhookEndpoints.del(managed.id)
-      }
-      const endpoint = await stripe.webhookEndpoints.create({
-        url: webhookUrl,
-        enabled_events: ['*'],
-        metadata: { managed_by: 'stripe-sync' },
-      })
-      webhookSecret = endpoint.secret!
-      webhookId = endpoint.id
-    }
-
-    // Step 3: Resolve account ID and store secrets
-    const account = await stripe.accounts.retrieve()
-    const secrets: Array<{ name: string; value: string }> = [
-      { name: 'STRIPE_ACCOUNT_ID', value: account.id },
-    ]
-    if (webhookSecret) {
-      secrets.push({ name: 'STRIPE_WEBHOOK_SECRET', value: webhookSecret })
-    }
-    await setSecrets(projectRef, secrets, accessToken)
-
-    await pool.end()
-    pool = null
-
-    return jsonResponse({
-      success: true,
-      message: 'Setup complete',
-      webhookId,
-    })
-  } catch (error: unknown) {
-    const err = error as Error
-    console.error('Setup error:', error)
-    if (pool) {
-      try {
-        await pool.query('SELECT pg_advisory_unlock_all()')
-        await pool.end()
-      } catch (cleanupErr) {
-        console.warn('Cleanup failed:', cleanupErr)
-      }
-    }
-    return jsonResponse({ success: false, error: err.message }, 500)
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Route: GET /setup — status
-// ---------------------------------------------------------------------------
-
-async function handleSetupGet(_req: Request): Promise<Response> {
-  const dbUrl = Deno.env.get('SUPABASE_DB_URL')
-  if (!dbUrl) {
-    return jsonResponse({ error: 'SUPABASE_DB_URL not set' }, 500)
-  }
-
-  const pool = new pg.Pool({ connectionString: dbUrl, max: 1 })
-
-  try {
-    const schemaName = Deno.env.get('SYNC_SCHEMA_NAME') ?? 'stripe'
-    const commentResult = await pool.query(
-      `SELECT obj_description(oid, 'pg_namespace') as comment
-       FROM pg_namespace
-       WHERE nspname = $1`,
-      [schemaName]
-    )
-
-    const comment = commentResult.rows[0]?.comment || null
-
-    let syncStatus: Array<Record<string, unknown>> = []
-    if (comment) {
-      try {
-        const syncSchema = Deno.env.get('SYNC_TABLES_SCHEMA_NAME') ?? schemaName
-        const safeSchema = syncSchema.replace(/"/g, '""')
-        const syncResult = await pool.query(`
-          SELECT DISTINCT ON (account_id)
-            account_id, started_at, closed_at, status, error_message,
-            total_processed, total_objects, complete_count, error_count,
-            running_count, pending_count, triggered_by, max_concurrent
-          FROM "${safeSchema}"."sync_runs"
-          ORDER BY account_id, started_at DESC
-        `)
-        syncStatus = syncResult.rows
-      } catch (err) {
-        console.warn('sync_runs query failed (may not exist yet):', err)
-      }
-    }
-
-    const parsedComment = parseSchemaComment(comment)
-
-    return new Response(
-      JSON.stringify({
-        package_version: VERSION,
-        installation_status: parsedComment.status,
-        sync_status: syncStatus,
-      }),
-      {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-          'Cache-Control': 'no-cache, no-store, must-revalidate',
-        },
-      }
-    )
-  } catch (error: unknown) {
-    const err = error as Error
-    console.error('Status query error:', error)
-    return jsonResponse(
-      {
-        error: err.message,
-        package_version: VERSION,
-        installation_status: 'not_installed',
-      },
-      500
-    )
-  } finally {
-    await pool.end()
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Route: DELETE /setup — uninstall
-// ---------------------------------------------------------------------------
-
-async function handleSetupDelete(req: Request): Promise<Response> {
-  const supabaseUrl = Deno.env.get('SUPABASE_URL')
-  if (!supabaseUrl) {
-    return jsonResponse({ error: 'SUPABASE_URL not set' }, 500)
-  }
-  const projectRef = new URL(supabaseUrl).hostname.split('.')[0]
-
-  const authHeader = req.headers.get('Authorization')
-  if (!authHeader?.startsWith('Bearer ')) {
-    return new Response('Unauthorized', { status: 401 })
-  }
-  const accessToken = authHeader.substring(7)
-
-  let pool: pg.Pool | null = null
-  try {
-    const dbUrl = Deno.env.get('SUPABASE_DB_URL')
-    if (!dbUrl) {
-      throw new Error('SUPABASE_DB_URL environment variable is not set')
-    }
-
-    const stripeKey = Deno.env.get('STRIPE_SECRET_KEY')
-    if (!stripeKey) {
-      throw new Error('STRIPE_SECRET_KEY environment variable is required for uninstall')
-    }
-
-    const schemaName = Deno.env.get('SYNC_SCHEMA_NAME') ?? 'stripe'
-    const syncTablesSchemaName = Deno.env.get('SYNC_TABLES_SCHEMA_NAME') ?? schemaName
-
-    pool = new pg.Pool({ connectionString: dbUrl, max: 2 })
-    const stripe = new Stripe(stripeKey)
-
-    // Step 1: Delete all managed webhooks via Stripe SDK
-    try {
-      const endpoints = await stripe.webhookEndpoints.list({ limit: 100 })
-      for (const wh of endpoints.data) {
-        if (wh.metadata?.managed_by === 'stripe-sync') {
-          try {
-            await stripe.webhookEndpoints.del(wh.id)
-            console.log(`Deleted webhook: ${wh.id}`)
-          } catch (err) {
-            console.warn(`Could not delete webhook ${wh.id}:`, err)
-          }
-        }
-      }
-    } catch (err) {
-      console.warn(`Could not get webhooks:`, err)
-    }
-
-    // Unschedule pg_cron jobs
-    try {
-      await pool.query(`
-        DO $$
-        BEGIN
-          IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'stripe-sync-worker') THEN
-            PERFORM cron.unschedule('stripe-sync-worker');
-          END IF;
-          IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'stripe-sigma-worker') THEN
-            PERFORM cron.unschedule('stripe-sigma-worker');
-          END IF;
-        END $$;
-      `)
-    } catch (err) {
-      console.warn('Could not unschedule pg_cron job:', err)
-    }
-
-    // Delete vault secrets
-    try {
-      await pool.query(`
-        DELETE FROM vault.secrets
-        WHERE name IN ('stripe_sync_worker_secret', 'stripe_sigma_worker_secret')
-      `)
-    } catch (err) {
-      console.warn('Could not delete vault secret:', err)
-    }
-
-    // Drop Sigma self-trigger function if present
-    try {
-      const dropSchema = syncTablesSchemaName.replace(/"/g, '""')
-      await pool.query(`DROP FUNCTION IF EXISTS "${dropSchema}".trigger_sigma_worker()`)
-    } catch (err) {
-      console.warn('Could not drop sigma trigger function:', err)
-    }
-
-    // Terminate connections holding locks on schema
-    try {
-      await pool.query(
-        `SELECT pg_terminate_backend(pid)
-         FROM pg_locks l
-         JOIN pg_class c ON l.relation = c.oid
-         JOIN pg_namespace n ON c.relnamespace = n.oid
-         WHERE n.nspname = $1 AND l.pid != pg_backend_pid()`,
-        [syncTablesSchemaName]
-      )
-    } catch (err) {
-      console.warn('Could not terminate connections:', err)
-    }
-
-    // Drop schema(s) with retry
-    const schemasToDrop = [...new Set([schemaName, syncTablesSchemaName])]
-    let dropAttempts = 0
-    const maxAttempts = 3
-    while (dropAttempts < maxAttempts) {
-      try {
-        for (const s of schemasToDrop) {
-          const safe = s.replace(/"/g, '""')
-          await pool.query(`DROP SCHEMA IF EXISTS "${safe}" CASCADE`)
-        }
-        break
-      } catch (err: unknown) {
-        const error = err as Error
-        dropAttempts++
-        if (dropAttempts >= maxAttempts) {
-          throw new Error(
-            `Failed to drop schema after ${maxAttempts} attempts. ` +
-              `There may be active connections or locks on the stripe schema. ` +
-              `Error: ${error.message}`
-          )
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1000))
-      }
-    }
-
-    await pool.end()
-    pool = null
-
-    // Step 2: Delete Supabase secrets
-    for (const secretName of [
-      'STRIPE_SECRET_KEY',
-      'MANAGEMENT_API_URL',
-      'ENABLE_SIGMA',
-      'STRIPE_ACCOUNT_ID',
-      'STRIPE_WEBHOOK_SECRET',
-    ]) {
-      try {
-        await deleteSecret(projectRef, secretName, accessToken)
-      } catch (err) {
-        console.warn(`Could not delete ${secretName} secret:`, err)
-      }
-    }
-
-    // Step 3: Delete edge functions (current + legacy from before consolidation)
-    for (const slug of [
-      'stripe-worker',
-      'stripe-setup',
-      'stripe-webhook',
-      'stripe-worker',
-      'stripe-backfill-worker',
-      'sigma-data-worker',
-    ]) {
-      try {
-        await deleteEdgeFunction(projectRef, slug, accessToken)
-      } catch (err) {
-        console.warn(`Could not delete ${slug} function:`, err)
-      }
-    }
-
-    return jsonResponse({ success: true, message: 'Uninstall complete' })
-  } catch (error: unknown) {
-    const err = error as Error
-    console.error('Uninstall error:', error)
-    if (pool) {
-      try {
-        await pool.end()
-      } catch (cleanupErr) {
-        console.warn('Cleanup failed:', cleanupErr)
-      }
-    }
-    return jsonResponse({ success: false, error: err.message }, 500)
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Route: POST /webhook — process Stripe webhook event
-// ---------------------------------------------------------------------------
-
-async function handleWebhook(req: Request): Promise<Response> {
-  if (req.method !== 'POST') {
-    return new Response('Method not allowed', { status: 405 })
-  }
-
-  const sig = req.headers.get('stripe-signature')
-  if (!sig) {
-    return new Response('Missing stripe-signature header', { status: 400 })
-  }
-
-  const dbUrl = Deno.env.get('SUPABASE_DB_URL')
-  const schemaName = Deno.env.get('SYNC_SCHEMA_NAME') ?? 'stripe'
-  if (!dbUrl) {
-    return jsonResponse({ error: 'SUPABASE_DB_URL not set' }, 500)
-  }
-
-  const stripeKey = Deno.env.get('STRIPE_SECRET_KEY')!
-  const webhookSecret = Deno.env.get('STRIPE_WEBHOOK_SECRET')!
-
-  const sourceConfig: SourceConfig = {
-    api_key: stripeKey,
-    webhook_secret: webhookSecret,
-  }
-  const destConfig: DestConfig = {
-    connection_string: dbUrl,
-    schema: schemaName,
-    port: 5432,
-    batch_size: 100,
-  }
-
-  const catalog = {
-    streams: DEFAULT_SYNC_OBJECTS.map((name) => ({
-      stream: { name, primary_key: [['id']] },
-      sync_mode: 'full_refresh' as const,
-      destination_sync_mode: 'append_dedup' as const,
-    })),
-  }
-
-  try {
-    const rawBody = new Uint8Array(await req.arrayBuffer())
-    const messages = sourceStripe.read(
-      { config: sourceConfig, catalog },
-      (async function* () {
-        yield { body: rawBody, signature: sig }
-      })()
-    )
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    for await (const _stateMsg of destinationPostgres.write(
-      { config: destConfig, catalog },
-      messages
-    )) {
-      // state messages indicate committed records
-    }
-    return jsonResponse({ received: true })
-  } catch (error: unknown) {
-    const err = error as Error & { type?: string }
-    console.error('Webhook processing error:', error)
-    const isSignatureError =
-      err.message?.includes('signature') || err.type === 'StripeSignatureVerificationError'
-    const status = isSignatureError ? 400 : 500
-    return jsonResponse({ error: err.message }, status)
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Route: POST /sync — cron-driven pipeline (source → destination with bounded checkpoints)
+// Configuration
 // ---------------------------------------------------------------------------
 
 const SYNC_INTERVAL = Number(Deno.env.get('SYNC_INTERVAL')) || 60 * 60 * 24 * 7
-const PAGES_PER_INVOCATION = Number(Deno.env.get('PAGES_PER_INVOCATION')) || 200
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
 
-async function handleSync(req: Request): Promise<Response> {
+Deno.serve(async (req) => {
   if (req.method !== 'POST') {
     return new Response('Method not allowed', { status: 405 })
   }
@@ -627,6 +83,29 @@ async function handleSync(req: Request): Promise<Response> {
       return authErr
     }
 
+    // Fast-path: if vault has a skip_until timestamp in the future, bail immediately
+    try {
+      const { rows: skipRows } = await pool.query(
+        `SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'stripe_sync_skip_until'`
+      )
+      if (skipRows.length > 0) {
+        const skipUntil = Number(skipRows[0].decrypted_secret)
+        const remaining = Math.round((skipUntil - Date.now()) / 1000)
+        if (skipUntil > Date.now()) {
+          console.log(`Skipping — skip_until is ${remaining}s in the future`)
+          await pool.end()
+          return jsonResponse({
+            skipped: true,
+            message: `Next sync in ${remaining}s`,
+          })
+        }
+        // skip_until has passed — delete it and continue with sync
+        await pool.query(`DELETE FROM vault.secrets WHERE name = 'stripe_sync_skip_until'`)
+      }
+    } catch (err) {
+      console.warn('Could not read skip_until from vault:', err)
+    }
+
     const stateStore = createScopedPgStateStore(pool, schemaName, 'default')
     let state = (await stateStore.get()) as
       | Record<string, { pageCursor: string | null; status: string }>
@@ -641,8 +120,18 @@ async function handleSync(req: Request): Promise<Response> {
       if (lastUpdate) {
         const elapsed = (Date.now() - new Date(lastUpdate).getTime()) / 1000
         if (elapsed < SYNC_INTERVAL) {
+          const skipUntilMs = String(Date.now() + (SYNC_INTERVAL - elapsed) * 1000)
+          try {
+            await pool.query(`DELETE FROM vault.secrets WHERE name = 'stripe_sync_skip_until'`)
+            await pool.query(`SELECT vault.create_secret($1, 'stripe_sync_skip_until')`, [
+              skipUntilMs,
+            ])
+          } catch (err) {
+            console.warn('Could not write skip_until to vault:', err)
+          }
+          const remainingSec = Math.round(SYNC_INTERVAL - elapsed)
           console.log(
-            `Skipping — all streams complete ${Math.round(elapsed)}s ago (within ${SYNC_INTERVAL}s window)`
+            `Skipping — all streams complete ${Math.round(elapsed)}s ago, next sync in ${remainingSec}s`
           )
           await pool.end()
           return jsonResponse({
@@ -688,7 +177,7 @@ async function handleSync(req: Request): Promise<Response> {
     })()
     const destOutput = destinationPostgres.write({ config: destConfig, catalog }, countedSource)
 
-    const MAX_WALL_MS = 25_000
+    const MAX_WALL_MS = 30_000
     const startedAt = Date.now()
     let checkpoints = 0
     let stopReason = 'complete'
@@ -696,10 +185,6 @@ async function handleSync(req: Request): Promise<Response> {
       if (msg.type === 'state' && msg.stream) {
         await stateStore.set(msg.stream, msg.data)
         checkpoints++
-        if (checkpoints >= PAGES_PER_INVOCATION) {
-          stopReason = 'checkpoint_limit'
-          break
-        }
         if (Date.now() - startedAt >= MAX_WALL_MS) {
           stopReason = 'time_limit'
           break
@@ -728,27 +213,4 @@ async function handleSync(req: Request): Promise<Response> {
     } catch {}
     return jsonResponse({ error: err.message }, 500)
   }
-}
-
-// ---------------------------------------------------------------------------
-// Main router
-// ---------------------------------------------------------------------------
-
-Deno.serve(async (req) => {
-  const url = new URL(req.url)
-  // Last segment after /functions/v1/stripe-worker/
-  const path = url.pathname.split('/').pop()
-
-  if (path === 'webhook') return handleWebhook(req)
-
-  if (path === 'setup') {
-    if (req.method === 'GET') return handleSetupGet(req)
-    if (req.method === 'POST') return handleSetupPost(req)
-    if (req.method === 'DELETE') return handleSetupDelete(req)
-    return new Response('Method not allowed', { status: 405 })
-  }
-
-  if (path === 'sync') return handleSync(req)
-
-  return new Response('Not found', { status: 404 })
 })

--- a/apps/supabase/src/edge-functions/stripe-sync.ts
+++ b/apps/supabase/src/edge-functions/stripe-sync.ts
@@ -603,7 +603,7 @@ async function handleWebhook(req: Request): Promise<Response> {
 // ---------------------------------------------------------------------------
 
 const SYNC_INTERVAL = Number(Deno.env.get('SYNC_INTERVAL')) || 60 * 60 * 24 * 7
-const PAGES_PER_INVOCATION = Number(Deno.env.get('PAGES_PER_INVOCATION')) || 10
+const PAGES_PER_INVOCATION = Number(Deno.env.get('PAGES_PER_INVOCATION')) || 1000
 
 async function handleSync(req: Request): Promise<Response> {
   if (req.method !== 'POST') {
@@ -678,25 +678,48 @@ async function handleSync(req: Request): Promise<Response> {
 
     await destinationPostgres.setup({ config: destConfig, catalog })
 
+    let records = 0
     const sourceMessages = sourceStripe.read({ config: sourceConfig, catalog, state })
-    const destOutput = destinationPostgres.write({ config: destConfig, catalog }, sourceMessages)
+    const countedSource = (async function* () {
+      for await (const msg of sourceMessages) {
+        if (msg.type === 'record') records++
+        yield msg
+      }
+    })()
+    const destOutput = destinationPostgres.write({ config: destConfig, catalog }, countedSource)
 
+    const MAX_WALL_MS = 25_000
+    const startedAt = Date.now()
     let checkpoints = 0
+    let stopReason = 'complete'
     for await (const msg of destOutput) {
       if (msg.type === 'state' && msg.stream) {
         await stateStore.set(msg.stream, msg.data)
         checkpoints++
         if (checkpoints >= PAGES_PER_INVOCATION) {
-          console.log(`Reached ${PAGES_PER_INVOCATION} checkpoints, yielding to next cron tick`)
+          stopReason = 'checkpoint_limit'
+          break
+        }
+        if (Date.now() - startedAt >= MAX_WALL_MS) {
+          stopReason = 'time_limit'
           break
         }
       }
     }
 
+    const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1)
     await pool.end()
-    console.log(`Sync pass done — ${checkpoints} checkpoints persisted`)
+    console.log(
+      `Sync pass done — ${records} rows, ${checkpoints} checkpoints, ${elapsed}s elapsed (${stopReason})`
+    )
 
-    return jsonResponse({ status: checkpoints > 0 ? 'syncing' : 'complete', checkpoints })
+    return jsonResponse({
+      status: stopReason === 'complete' ? 'complete' : 'syncing',
+      checkpoints,
+      records,
+      elapsed_s: Number(elapsed),
+      stop_reason: stopReason,
+    })
   } catch (error: unknown) {
     const err = error as Error
     console.error('Sync error:', error)

--- a/apps/supabase/src/edge-functions/stripe-webhook.ts
+++ b/apps/supabase/src/edge-functions/stripe-webhook.ts
@@ -1,0 +1,89 @@
+/**
+ * Stripe Webhook Edge Function
+ *
+ *   POST → process Stripe webhook event
+ */
+
+import sourceStripe, {
+  type Config as SourceConfig,
+  DEFAULT_SYNC_OBJECTS,
+} from '@stripe/sync-source-stripe'
+import destinationPostgres, { type Config as DestConfig } from '@stripe/sync-destination-postgres'
+
+// ---------------------------------------------------------------------------
+// Helpers (inlined — edge functions must be self-contained)
+// ---------------------------------------------------------------------------
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+Deno.serve(async (req) => {
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 })
+  }
+
+  const sig = req.headers.get('stripe-signature')
+  if (!sig) {
+    return new Response('Missing stripe-signature header', { status: 400 })
+  }
+
+  const dbUrl = Deno.env.get('SUPABASE_DB_URL')
+  const schemaName = Deno.env.get('SYNC_SCHEMA_NAME') ?? 'stripe'
+  if (!dbUrl) {
+    return jsonResponse({ error: 'SUPABASE_DB_URL not set' }, 500)
+  }
+
+  const stripeKey = Deno.env.get('STRIPE_SECRET_KEY')!
+  const webhookSecret = Deno.env.get('STRIPE_WEBHOOK_SECRET')!
+
+  const sourceConfig: SourceConfig = {
+    api_key: stripeKey,
+    webhook_secret: webhookSecret,
+  }
+  const destConfig: DestConfig = {
+    connection_string: dbUrl,
+    schema: schemaName,
+    port: 5432,
+    batch_size: 100,
+  }
+
+  const catalog = {
+    streams: DEFAULT_SYNC_OBJECTS.map((name) => ({
+      stream: { name, primary_key: [['id']] },
+      sync_mode: 'full_refresh' as const,
+      destination_sync_mode: 'append_dedup' as const,
+    })),
+  }
+
+  try {
+    const rawBody = new Uint8Array(await req.arrayBuffer())
+    const messages = sourceStripe.read(
+      { config: sourceConfig, catalog },
+      (async function* () {
+        yield { body: rawBody, signature: sig }
+      })()
+    )
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _stateMsg of destinationPostgres.write(
+      { config: destConfig, catalog },
+      messages
+    )) {
+      // state messages indicate committed records
+    }
+    return jsonResponse({ received: true })
+  } catch (error: unknown) {
+    const err = error as Error & { type?: string }
+    console.error('Webhook processing error:', error)
+    const isSignatureError =
+      err.message?.includes('signature') || err.type === 'StripeSignatureVerificationError'
+    const status = isSignatureError ? 400 : 500
+    return jsonResponse({ error: err.message }, status)
+  }
+})

--- a/apps/supabase/src/supabase.ts
+++ b/apps/supabase/src/supabase.ts
@@ -1,5 +1,5 @@
 import { SupabaseManagementAPI } from 'supabase-management-js'
-import { syncFunctionCode } from './edge-function-code.js'
+import { setupFunctionCode, webhookFunctionCode, syncFunctionCode } from './edge-function-code.js'
 import pkg from '../package.json' with { type: 'json' }
 import { parseSchemaComment, StripeSchemaComment } from './schemaComment.js'
 
@@ -160,7 +160,7 @@ export class SupabaseSetupClient {
         '${schedule}',
         $$
         SELECT net.http_post(
-          url := 'https://${this.projectRef}.${this.projectBaseUrl}/functions/v1/stripe-worker/sync',
+          url := 'https://${this.projectRef}.${this.projectBaseUrl}/functions/v1/stripe-worker',
           headers := jsonb_build_object(
             'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'stripe_sync_worker_secret')
           )
@@ -180,7 +180,7 @@ export class SupabaseSetupClient {
    * Get the webhook URL for this project
    */
   getWebhookUrl(): string {
-    return `https://${this.projectRef}.${this.projectBaseUrl}/functions/v1/stripe-worker/webhook`
+    return `https://${this.projectRef}.${this.projectBaseUrl}/functions/v1/stripe-webhook`
   }
 
   /**
@@ -387,12 +387,7 @@ export class SupabaseSetupClient {
         await this.updateComment({ status: 'uninstalling', startTime })
       }
 
-      // Invoke the DELETE endpoint on the consolidated stripe-sync function
-      const setupResult = await this.invokeFunction(
-        'stripe-worker/setup',
-        'DELETE',
-        this.accessToken
-      )
+      const setupResult = await this.invokeFunction('stripe-setup', 'DELETE', this.accessToken)
 
       if (!setupResult.success) {
         throw new Error(`Uninstall failed: ${setupResult.error}`)
@@ -457,12 +452,16 @@ export class SupabaseSetupClient {
       }
       await this.setSecrets(secrets)
 
-      // Deploy the single consolidated edge function
+      // Deploy edge functions
+      const versionedSetup = this.injectPackageVersion(setupFunctionCode, version)
+      const versionedWebhook = this.injectPackageVersion(webhookFunctionCode, version)
       const versionedSync = this.injectPackageVersion(syncFunctionCode, version)
+      await this.deployFunction('stripe-setup', versionedSetup, false)
+      await this.deployFunction('stripe-webhook', versionedWebhook, false)
       await this.deployFunction('stripe-worker', versionedSync, false)
 
-      // Run setup (migrations + webhook creation) via the /setup path
-      const setupResult = await this.invokeFunction('stripe-worker/setup', 'POST', this.accessToken)
+      // Run setup (migrations + webhook creation)
+      const setupResult = await this.invokeFunction('stripe-setup', 'POST', this.accessToken)
 
       if (!setupResult.success) {
         throw new Error(`Setup failed: ${setupResult.error}`)
@@ -482,10 +481,10 @@ export class SupabaseSetupClient {
       // if done before.
       if (!skipInitialSync) {
         try {
-          await this.invokeFunction('stripe-worker/sync', 'POST', this.workerSecret)
+          await this.invokeFunction('stripe-worker', 'POST', this.workerSecret)
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error)
-          console.warn(`Failed to invoke stripe-worker/sync: ${errorMessage}`)
+          console.warn(`Failed to invoke stripe-worker: ${errorMessage}`)
         }
       }
     } catch (error) {

--- a/apps/supabase/src/supabase.ts
+++ b/apps/supabase/src/supabase.ts
@@ -160,7 +160,7 @@ export class SupabaseSetupClient {
         '${schedule}',
         $$
         SELECT net.http_post(
-          url := 'https://${this.projectRef}.${this.projectBaseUrl}/functions/v1/stripe-sync/sync',
+          url := 'https://${this.projectRef}.${this.projectBaseUrl}/functions/v1/stripe-worker/sync',
           headers := jsonb_build_object(
             'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'stripe_sync_worker_secret')
           )
@@ -180,7 +180,7 @@ export class SupabaseSetupClient {
    * Get the webhook URL for this project
    */
   getWebhookUrl(): string {
-    return `https://${this.projectRef}.${this.projectBaseUrl}/functions/v1/stripe-sync/webhook`
+    return `https://${this.projectRef}.${this.projectBaseUrl}/functions/v1/stripe-worker/webhook`
   }
 
   /**
@@ -388,7 +388,11 @@ export class SupabaseSetupClient {
       }
 
       // Invoke the DELETE endpoint on the consolidated stripe-sync function
-      const setupResult = await this.invokeFunction('stripe-sync/setup', 'DELETE', this.accessToken)
+      const setupResult = await this.invokeFunction(
+        'stripe-worker/setup',
+        'DELETE',
+        this.accessToken
+      )
 
       if (!setupResult.success) {
         throw new Error(`Uninstall failed: ${setupResult.error}`)
@@ -455,10 +459,10 @@ export class SupabaseSetupClient {
 
       // Deploy the single consolidated edge function
       const versionedSync = this.injectPackageVersion(syncFunctionCode, version)
-      await this.deployFunction('stripe-sync', versionedSync, false)
+      await this.deployFunction('stripe-worker', versionedSync, false)
 
       // Run setup (migrations + webhook creation) via the /setup path
-      const setupResult = await this.invokeFunction('stripe-sync/setup', 'POST', this.accessToken)
+      const setupResult = await this.invokeFunction('stripe-worker/setup', 'POST', this.accessToken)
 
       if (!setupResult.success) {
         throw new Error(`Setup failed: ${setupResult.error}`)
@@ -478,10 +482,10 @@ export class SupabaseSetupClient {
       // if done before.
       if (!skipInitialSync) {
         try {
-          await this.invokeFunction('stripe-sync/sync', 'POST', this.workerSecret)
+          await this.invokeFunction('stripe-worker/sync', 'POST', this.workerSecret)
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error)
-          console.warn(`Failed to invoke stripe-sync/sync: ${errorMessage}`)
+          console.warn(`Failed to invoke stripe-worker/sync: ${errorMessage}`)
         }
       }
     } catch (error) {

--- a/apps/supabase/src/supabase.ts
+++ b/apps/supabase/src/supabase.ts
@@ -94,7 +94,7 @@ export class SupabaseSetupClient {
    * Setup pg_cron job to invoke worker function
    * @param intervalSeconds - How often to run the worker (default: 60 seconds)
    */
-  async setupPgCronJob(intervalSeconds: number = 60): Promise<void> {
+  async setupPgCronJob(intervalSeconds: number = 30): Promise<void> {
     // Validate interval
     if (!Number.isInteger(intervalSeconds) || intervalSeconds < 1) {
       throw new Error(`Invalid interval: ${intervalSeconds}. Must be a positive integer.`)

--- a/e2e/connector-loading.test.sh
+++ b/e2e/connector-loading.test.sh
@@ -33,6 +33,7 @@ cleanup() {
   rm -f "$REPO_ROOT"/stripe-sync-state-postgres-*.tgz
   rm -f "$REPO_ROOT"/stripe-sync-util-postgres-*.tgz
   rm -f "$REPO_ROOT"/stripe-sync-ts-cli-*.tgz
+  rm -f "$REPO_ROOT"/stripe-sync-integration-supabase-*.tgz
 }
 trap cleanup EXIT
 
@@ -54,9 +55,10 @@ DEST_SHEETS_TGZ=$(cd "$REPO_ROOT" && pnpm --filter @stripe/sync-destination-goog
 STATE_PG_TGZ=$(cd "$REPO_ROOT" && pnpm --filter @stripe/sync-state-postgres pack 2>/dev/null | tail -1)
 UTIL_PG_TGZ=$(cd "$REPO_ROOT" && pnpm --filter @stripe/sync-util-postgres pack 2>/dev/null | tail -1)
 TSCLI_TGZ=$(cd "$REPO_ROOT" && pnpm --filter @stripe/sync-ts-cli pack 2>/dev/null | tail -1)
+SUPABASE_TGZ=$(cd "$REPO_ROOT" && pnpm --filter @stripe/sync-integration-supabase pack 2>/dev/null | tail -1)
 
 for tgz in "$PROTOCOL_TGZ" "$OPENAPI_TGZ" "$ENGINE_TGZ" "$SOURCE_TGZ" "$DEST_TGZ" "$DEST_SHEETS_TGZ" \
-           "$STATE_PG_TGZ" "$UTIL_PG_TGZ" "$TSCLI_TGZ"; do
+           "$STATE_PG_TGZ" "$UTIL_PG_TGZ" "$TSCLI_TGZ" "$SUPABASE_TGZ"; do
   if [ ! -f "$tgz" ]; then
     echo "FAIL: tarball not found: $tgz"
     exit 1
@@ -94,14 +96,15 @@ cat > package.json <<EOF
       "@stripe/sync-destination-google-sheets": "$DEST_SHEETS_TGZ",
       "@stripe/sync-state-postgres": "$STATE_PG_TGZ",
       "@stripe/sync-util-postgres": "$UTIL_PG_TGZ",
-      "@stripe/sync-ts-cli": "$TSCLI_TGZ"
+      "@stripe/sync-ts-cli": "$TSCLI_TGZ",
+      "@stripe/sync-integration-supabase": "$SUPABASE_TGZ"
     }
   }
 }
 EOF
 
 pnpm add "$PROTOCOL_TGZ" "$OPENAPI_TGZ" "$ENGINE_TGZ" "$SOURCE_TGZ" "$DEST_TGZ" "$DEST_SHEETS_TGZ" \
-         "$STATE_PG_TGZ" "$UTIL_PG_TGZ" "$TSCLI_TGZ" \
+         "$STATE_PG_TGZ" "$UTIL_PG_TGZ" "$TSCLI_TGZ" "$SUPABASE_TGZ" \
          2>&1 | tail -5
 echo ""
 

--- a/packages/source-stripe/src/index.ts
+++ b/packages/source-stripe/src/index.ts
@@ -339,7 +339,7 @@ export default createStripeSource()
 
 // MARK: - Re-exports
 
-export { buildResourceRegistry } from './resourceRegistry.js'
+export { buildResourceRegistry, DEFAULT_SYNC_OBJECTS } from './resourceRegistry.js'
 export { catalogFromRegistry } from './catalog.js'
 export { SpecParser, OPENAPI_RESOURCE_TABLE_ALIASES } from './openapi/specParser.js'
 export type { ParsedResourceTable, ParsedOpenApiSpec } from './openapi/types.js'

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -139,22 +139,7 @@ async function* paginateSegment(opts: {
 
     const wait = await rateLimiter()
     if (wait > 0) await new Promise((r) => setTimeout(r, wait * 1000))
-    console.error({
-      msg: 'Starting Stripe list page',
-      stream: streamName,
-      segment: segment.index,
-      pageCursor,
-      created: params.created,
-    })
     const response = await listFn(params as Parameters<typeof listFn>[0])
-    console.error({
-      msg: 'Completed Stripe list page',
-      stream: streamName,
-      segment: segment.index,
-      pageCursor,
-      recordCount: response.data.length,
-      hasMore: response.has_more,
-    })
 
     for (const item of response.data) {
       yield toRecordMessage(streamName, item as Record<string, unknown>)
@@ -217,21 +202,9 @@ async function* sequentialBackfillStream(opts: {
 
     const wait = await rateLimiter()
     if (wait > 0) await new Promise((r) => setTimeout(r, wait * 1000))
-    console.error({
-      msg: 'Starting Stripe list page',
-      stream: streamName,
-      pageCursor,
-    })
     const response = await resourceConfig.listFn!(
       params as Parameters<NonNullable<typeof resourceConfig.listFn>>[0]
     )
-    console.error({
-      msg: 'Completed Stripe list page',
-      stream: streamName,
-      pageCursor,
-      recordCount: response.data.length,
-      hasMore: response.has_more,
-    })
 
     for (const item of response.data) {
       yield toRecordMessage(streamName, item as Record<string, unknown>)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       '@stripe/sync-destination-postgres':
         specifier: workspace:*
         version: link:../../packages/destination-postgres
+      '@stripe/sync-integration-supabase':
+        specifier: workspace:*
+        version: link:../supabase
       '@stripe/sync-protocol':
         specifier: workspace:*
         version: link:../../packages/protocol


### PR DESCRIPTION
## Summary

Fix Supabase-specific regressions from main: clean vault on install, use time-based limits for sync invocations, remove noisy error logs
Add supabase CLI command to apps/engine for managing Supabase deployments
Split the monolithic stripe-sync edge function into three separate functions: stripe-setup, stripe-sync, and stripe-webhook

## How to test (optional)

Tested by hand by deploying to supabase
