### PR TITLE
feat(engine): add POST /internal/query endpoint

### DIFF
--- a/apps/engine/src/api/app.test.ts
+++ b/apps/engine/src/api/app.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ConnectorResolver, Message, StateMessage } from '../lib/index.js'
 import { sourceTest, destinationTest } from '../lib/index.js'
 import { createApp } from './app.js'
+import pg from 'pg'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -443,5 +444,59 @@ describe('error handling', () => {
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body.error).toContain('Invalid JSON')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /internal/query
+// ---------------------------------------------------------------------------
+
+describe('POST /internal/query', () => {
+  it('executes SQL and returns rows and rowCount', async () => {
+    const mockQuery = vi.fn().mockResolvedValue({ rows: [{ n: 1 }], rowCount: 1 })
+    const mockEnd = vi.fn().mockResolvedValue(undefined)
+    vi.spyOn(pg, 'Pool').mockImplementation(
+      () => ({ query: mockQuery, end: mockEnd }) as unknown as pg.Pool
+    )
+
+    const app = createApp(resolver)
+    const res = await app.request('/internal/query', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        connection_string: 'postgres://user:pass@localhost:5432/db',
+        sql: 'SELECT 1 AS n',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json<{ rows: unknown[]; rowCount: number }>()
+    expect(body.rows).toEqual([{ n: 1 }])
+    expect(body.rowCount).toBe(1)
+    expect(mockEnd).toHaveBeenCalled()
+  })
+
+  it('closes pool even when query fails', async () => {
+    const mockEnd = vi.fn().mockResolvedValue(undefined)
+    vi.spyOn(pg, 'Pool').mockImplementation(
+      () =>
+        ({
+          query: vi.fn().mockRejectedValue(new Error('connection refused')),
+          end: mockEnd,
+        }) as unknown as pg.Pool
+    )
+
+    const app = createApp(resolver)
+    const res = await app.request('/internal/query', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        connection_string: 'postgres://user:pass@localhost:5432/db',
+        sql: 'SELECT 1',
+      }),
+    })
+
+    expect(res.status).toBe(500)
+    expect(mockEnd).toHaveBeenCalled()
   })
 })

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -651,6 +651,7 @@ export function createApp(resolver: ConnectorResolver) {
   app.get('/docs', apiReference({ url: '/openapi.json' }))
 
   // ── Internal utilities ───────────────────────────────────────────────────────
+  // NOTE: no HTTP auth on /internal/* — only safe on a trusted private network.
 
   app.post('/internal/query', async (c) => {
     const { connection_string, sql } = await c.req.json<{

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -22,7 +22,14 @@ import { ndjsonResponse } from '@stripe/sync-ts-cli/ndjson'
 import { logger } from '../logger.js'
 import { createStripeSource, DEFAULT_MAX_RPS } from '@stripe/sync-source-stripe'
 import type { RateLimiter } from '@stripe/sync-source-stripe'
-import { acquire, createRateLimiterTable, ident } from '@stripe/sync-util-postgres'
+import {
+  acquire,
+  createRateLimiterTable,
+  ident,
+  sslConfigFromConnectionString,
+  stripSslParams,
+  withPgConnectProxy,
+} from '@stripe/sync-util-postgres'
 import { createHash } from 'node:crypto'
 
 // ── Helpers ─────────────────────────────────────────────────────
@@ -642,6 +649,27 @@ export function createApp(resolver: ConnectorResolver) {
   })
 
   app.get('/docs', apiReference({ url: '/openapi.json' }))
+
+  // ── Internal utilities ───────────────────────────────────────────────────────
+
+  app.post('/internal/query', async (c) => {
+    const { connection_string, sql } = await c.req.json<{
+      connection_string: string
+      sql: string
+    }>()
+    const pool = new pg.Pool(
+      withPgConnectProxy({
+        connectionString: stripSslParams(connection_string),
+        ssl: sslConfigFromConnectionString(connection_string),
+      })
+    )
+    try {
+      const result = await pool.query(sql)
+      return c.json({ rows: result.rows, rowCount: result.rowCount })
+    } finally {
+      await pool.end()
+    }
+  })
 
   return app
 }

--- a/e2e/docker.test.sh
+++ b/e2e/docker.test.sh
@@ -125,4 +125,17 @@ else
   echo "==> Skipping Postgres write (POSTGRES_URL not set)"
 fi
 
+# --- 4) Internal Query ---
+if [ -n "${POSTGRES_URL:-}" ]; then
+  echo "==> Testing /internal/query"
+  QUERY_OUTPUT=$(curl -sf --max-time 30 -X POST "http://localhost:$PORT/internal/query" \
+    -H "Content-Type: application/json" \
+    -d "{\"connection_string\":\"$DOCKER_PG_URL\",\"sql\":\"SELECT 1 AS n\"}")
+  echo "    $QUERY_OUTPUT"
+  echo "$QUERY_OUTPUT" | grep -q rows || { echo "FAIL: /internal/query missing rows field"; exit 1; }
+  echo "    OK"
+else
+  echo "==> Skipping /internal/query test (POSTGRES_URL not set)"
+fi
+
 echo "==> Done"


### PR DESCRIPTION
## Summary

Adds a `POST /internal/query` endpoint to the engine HTTP server.

Takes a `connection_string` and `sql`, executes the query against Postgres, and returns `rows` and `rowCount`. Useful as a dumb proxy for ad-hoc queries without needing a direct DB connection.

```json
POST /internal/query
{
  "connection_string": "postgres://user:pass@host:5432/db?sslmode=require",
  "sql": "SELECT COUNT(*) FROM stripe.charges"
}
```

## Implementation notes

- Follows the same per-request pool pattern used by all other endpoints — `new pg.Pool()` at start, `pool.end()` in `finally`
- Reuses existing `stripSslParams` + `sslConfigFromConnectionString` + `withPgConnectProxy` from `@stripe/sync-util-postgres` so SSL and proxy behaviour is consistent with `/write`, `/read` etc.
- No connection pool caching — appropriate for a utility endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)