### PR TITLE
Destination column filtering

### DIFF
--- a/apps/engine/src/lib/destination-filter.test.ts
+++ b/apps/engine/src/lib/destination-filter.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  Destination,
+  ConfiguredCatalog,
+  DestinationInput,
+  DestinationOutput,
+} from '@stripe/sync-protocol'
+import { withCatalogFilter } from './destination-filter.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function drain<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = []
+  for await (const item of iter) result.push(item)
+  return result
+}
+
+async function* toAsync<T>(items: T[]): AsyncIterable<T> {
+  for (const item of items) yield item
+}
+
+function makeCatalog(
+  streams: Array<{
+    name: string
+    fields?: string[]
+    json_schema?: Record<string, unknown>
+  }>
+): ConfiguredCatalog {
+  return {
+    streams: streams.map((s) => ({
+      stream: { name: s.name, primary_key: [['id']], json_schema: s.json_schema },
+      sync_mode: 'full_refresh' as const,
+      destination_sync_mode: 'append' as const,
+      fields: s.fields,
+    })),
+  }
+}
+
+/**
+ * Create a mock destination that captures the catalog passed to setup() and write().
+ */
+function capturingDestination() {
+  const captured: { setup?: ConfiguredCatalog; write?: ConfiguredCatalog } = {}
+
+  const dest: Destination = {
+    spec: () => ({ config: {} }),
+    check: async () => ({ status: 'succeeded' }),
+    async setup({ catalog }) {
+      captured.setup = catalog
+    },
+    async *write({ catalog }, $stdin) {
+      captured.write = catalog
+      for await (const msg of $stdin) {
+        if (msg.type === 'state') yield msg
+      }
+    },
+  }
+
+  return { dest, captured }
+}
+
+// ---------------------------------------------------------------------------
+// withCatalogFilter()
+// ---------------------------------------------------------------------------
+
+describe('withCatalogFilter()', () => {
+  it('prunes json_schema.properties in setup() to selected fields plus primary key', async () => {
+    const { dest, captured } = capturingDestination()
+    const wrapped = withCatalogFilter(dest)
+
+    const catalog = makeCatalog([
+      {
+        name: 'customers',
+        fields: ['name', 'email'],
+        json_schema: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            email: { type: 'string' },
+            phone: { type: 'string' },
+          },
+        },
+      },
+    ])
+
+    await wrapped.setup!({ config: {}, catalog })
+
+    const props = captured.setup!.streams[0]!.stream.json_schema!.properties as Record<
+      string,
+      unknown
+    >
+    expect(Object.keys(props)).toEqual(['id', 'name', 'email'])
+  })
+
+  it('prunes json_schema.properties in write() to selected fields', async () => {
+    const { dest, captured } = capturingDestination()
+    const wrapped = withCatalogFilter(dest)
+
+    const catalog = makeCatalog([
+      {
+        name: 'invoices',
+        fields: ['amount', 'currency'],
+        json_schema: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            amount: { type: 'integer' },
+            currency: { type: 'string' },
+            description: { type: 'string' },
+          },
+        },
+      },
+    ])
+
+    const input: DestinationInput[] = [{ type: 'state', stream: 'invoices', data: { cursor: '1' } }]
+    await drain(wrapped.write({ config: {}, catalog }, toAsync(input)))
+
+    const props = captured.write!.streams[0]!.stream.json_schema!.properties as Record<
+      string,
+      unknown
+    >
+    expect(Object.keys(props)).toEqual(['id', 'amount', 'currency'])
+  })
+
+  it('passes catalog through unchanged when no fields configured', async () => {
+    const { dest, captured } = capturingDestination()
+    const wrapped = withCatalogFilter(dest)
+
+    const catalog = makeCatalog([
+      {
+        name: 'products',
+        json_schema: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            active: { type: 'boolean' },
+          },
+        },
+      },
+    ])
+
+    await wrapped.setup!({ config: {}, catalog })
+
+    const props = captured.setup!.streams[0]!.stream.json_schema!.properties as Record<
+      string,
+      unknown
+    >
+    expect(Object.keys(props)).toEqual(['id', 'name', 'active'])
+  })
+
+  it('passes stream through unchanged when json_schema is absent', async () => {
+    const { dest, captured } = capturingDestination()
+    const wrapped = withCatalogFilter(dest)
+
+    const catalog = makeCatalog([{ name: 'events', fields: ['id', 'type'] }])
+
+    await wrapped.setup!({ config: {}, catalog })
+
+    expect(captured.setup!.streams[0]!.stream.json_schema).toBeUndefined()
+  })
+
+  it('handles mixed streams: filters only those with fields set', async () => {
+    const { dest, captured } = capturingDestination()
+    const wrapped = withCatalogFilter(dest)
+
+    const catalog = makeCatalog([
+      {
+        name: 'customers',
+        fields: ['email'],
+        json_schema: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            email: { type: 'string' },
+            phone: { type: 'string' },
+          },
+        },
+      },
+      {
+        name: 'products',
+        json_schema: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+          },
+        },
+      },
+    ])
+
+    await wrapped.setup!({ config: {}, catalog })
+
+    const customerProps = captured.setup!.streams[0]!.stream.json_schema!.properties as Record<
+      string,
+      unknown
+    >
+    expect(Object.keys(customerProps)).toEqual(['id', 'email'])
+
+    const productProps = captured.setup!.streams[1]!.stream.json_schema!.properties as Record<
+      string,
+      unknown
+    >
+    expect(Object.keys(productProps)).toEqual(['id', 'name'])
+  })
+
+  it('omits setup when underlying destination has no setup', () => {
+    const dest: Destination = {
+      spec: () => ({ config: {} }),
+      check: async () => ({ status: 'succeeded' }),
+      async *write(_params, $stdin) {
+        for await (const msg of $stdin) {
+          if (msg.type === 'state') yield msg
+        }
+      },
+    }
+
+    const wrapped = withCatalogFilter(dest)
+    expect(wrapped.setup).toBeUndefined()
+  })
+
+  it('delegates spec() unchanged', () => {
+    const spec = { config: { type: 'object', properties: { url: { type: 'string' } } } }
+    const dest: Destination = {
+      spec: () => spec,
+      check: async () => ({ status: 'succeeded' }),
+      async *write(_params, $stdin) {
+        for await (const _ of $stdin) {
+          /* drain */
+        }
+      },
+    }
+
+    const wrapped = withCatalogFilter(dest)
+    expect(wrapped.spec()).toBe(spec)
+  })
+
+  it('delegates check() unchanged', async () => {
+    const dest: Destination = {
+      spec: () => ({ config: {} }),
+      check: async () => ({ status: 'failed', message: 'bad creds' }),
+      async *write(_params, $stdin) {
+        for await (const _ of $stdin) {
+          /* drain */
+        }
+      },
+    }
+
+    const wrapped = withCatalogFilter(dest)
+    const result = await wrapped.check({ config: {} })
+    expect(result).toEqual({ status: 'failed', message: 'bad creds' })
+  })
+
+  it('delegates teardown() unchanged', async () => {
+    let teardownCalled = false
+    const dest: Destination = {
+      spec: () => ({ config: {} }),
+      check: async () => ({ status: 'succeeded' }),
+      async *write(_params, $stdin) {
+        for await (const _ of $stdin) {
+          /* drain */
+        }
+      },
+      async teardown() {
+        teardownCalled = true
+      },
+    }
+
+    const wrapped = withCatalogFilter(dest)
+    await wrapped.teardown!({ config: {} })
+    expect(teardownCalled).toBe(true)
+  })
+})

--- a/apps/engine/src/lib/destination-filter.test.ts
+++ b/apps/engine/src/lib/destination-filter.test.ts
@@ -95,7 +95,7 @@ describe('withCatalogFilter()', () => {
     expect(Object.keys(props)).toEqual(['id', 'name', 'email'])
   })
 
-  it('prunes json_schema.properties in write() to selected fields', async () => {
+  it('prunes json_schema.properties in write() to selected fields plus primary key', async () => {
     const { dest, captured } = capturingDestination()
     const wrapped = withCatalogFilter(dest)
 

--- a/apps/engine/src/lib/destination-filter.ts
+++ b/apps/engine/src/lib/destination-filter.ts
@@ -1,0 +1,48 @@
+import type { Destination, ConfiguredCatalog } from '@stripe/sync-protocol'
+
+function filterCatalog(catalog: ConfiguredCatalog): ConfiguredCatalog {
+  return {
+    streams: catalog.streams.map((cs) => {
+      if (!cs.fields?.length) return cs
+      const props = cs.stream.json_schema?.properties as Record<string, unknown> | undefined
+      if (!props) return cs
+      const allowed = new Set(cs.fields)
+      for (const path of cs.stream.primary_key) {
+        if (path[0]) allowed.add(path[0])
+      }
+      return {
+        ...cs,
+        stream: {
+          ...cs.stream,
+          json_schema: {
+            ...cs.stream.json_schema,
+            properties: Object.fromEntries(Object.entries(props).filter(([k]) => allowed.has(k))),
+          },
+        },
+      }
+    }),
+  }
+}
+
+/**
+ * Wrap a Destination to prune each stream's json_schema.properties
+ * down to the fields selected in ConfiguredStream.fields.
+ * Streams without fields or without json_schema pass through unchanged.
+ */
+export function withCatalogFilter(dest: Destination): Destination {
+  return {
+    spec: () => dest.spec(),
+    check: (params) => dest.check(params),
+    write(params, $stdin) {
+      return dest.write({ ...params, catalog: filterCatalog(params.catalog) }, $stdin)
+    },
+    ...(dest.setup && {
+      async setup(params) {
+        return dest.setup!({ ...params, catalog: filterCatalog(params.catalog) })
+      },
+    }),
+    ...(dest.teardown && {
+      teardown: (params: { config: Record<string, unknown> }) => dest.teardown!(params),
+    }),
+  }
+}

--- a/apps/engine/src/lib/engine.ts
+++ b/apps/engine/src/lib/engine.ts
@@ -10,6 +10,7 @@ import {
 } from '@stripe/sync-protocol'
 import type { Destination, Source } from '@stripe/sync-protocol'
 import { enforceCatalog, filterType, log, persistState, pipe } from './pipeline.js'
+import { withCatalogFilter } from './destination-filter.js'
 import type { StateStore } from './state-store.js'
 import type { ConnectorResolver } from './resolver.js'
 import { logger } from '../logger.js'
@@ -135,6 +136,7 @@ export function createEngine(
     string,
     unknown
   >
+  const destination = withCatalogFilter(connectors.destination)
   const baseContext = engineLogContext(config, metadata)
 
   // Lazy-cached catalog — discover is called at most once per engine instance.
@@ -176,9 +178,9 @@ export function createEngine(
               connectors.source.setup!({ config: sourceConfig, catalog })
             )
           : Promise.resolve(),
-        connectors.destination.setup
+        destination.setup
           ? withLoggedStep('Engine destination setup', baseContext, () =>
-              connectors.destination.setup!({ config: destConfig, catalog })
+              destination.setup!({ config: destConfig, catalog })
             )
           : Promise.resolve(),
       ])
@@ -187,16 +189,16 @@ export function createEngine(
     async teardown() {
       await Promise.all([
         connectors.source.teardown?.({ config: sourceConfig }),
-        connectors.destination.teardown?.({ config: destConfig }),
+        destination.teardown?.({ config: destConfig }),
       ])
     },
 
     async check() {
-      const [source, destination] = await Promise.all([
+      const [source, dest] = await Promise.all([
         connectors.source.check({ config: sourceConfig }),
-        connectors.destination.check({ config: destConfig }),
+        destination.check({ config: destConfig }),
       ])
-      return { source, destination }
+      return { source, destination: dest }
     },
 
     async *read(input?: AsyncIterable<unknown>) {
@@ -222,7 +224,7 @@ export function createEngine(
     async *write(messages: AsyncIterable<Message>) {
       const catalog = await getCatalog()
       const destInput = pipe(messages, enforceCatalog(catalog), log, filterType('record', 'state'))
-      const destOutput = connectors.destination.write({ config: destConfig, catalog }, destInput)
+      const destOutput = destination.write({ config: destConfig, catalog }, destInput)
       for await (const msg of withLoggedStream(
         'Engine destination write',
         baseContext,

--- a/apps/engine/src/lib/index.ts
+++ b/apps/engine/src/lib/index.ts
@@ -18,6 +18,7 @@ export type {
 } from './resolver.js'
 export { createSourceFromExec } from './source-exec.js'
 export { createDestinationFromExec } from './destination-exec.js'
+export { withCatalogFilter } from './destination-filter.js'
 export { sourceTest, sourceTestSpec } from './source-test.js'
 export type { SourceTestConfig } from './source-test.js'
 export { destinationTest, destinationTestSpec } from './destination-test.js'

--- a/apps/engine/src/lib/pipeline.test.ts
+++ b/apps/engine/src/lib/pipeline.test.ts
@@ -65,7 +65,7 @@ describe('enforceCatalog()', () => {
     expect((result[0] as { data: unknown }).data).toEqual({ id: 'cus_1', name: 'Alice' })
   })
 
-  it('filters record fields to the configured allow-list', async () => {
+  it('does not filter record data even when fields is configured', async () => {
     const msgs: Message[] = [
       {
         type: 'record',
@@ -78,7 +78,11 @@ describe('enforceCatalog()', () => {
       enforceCatalog(catalog([{ name: 'subscriptions', fields: ['id', 'status'] }]))(toAsync(msgs))
     )
     expect(result).toHaveLength(1)
-    expect((result[0] as { data: unknown }).data).toEqual({ id: 'sub_1', status: 'active' })
+    expect((result[0] as { data: unknown }).data).toEqual({
+      id: 'sub_1',
+      status: 'active',
+      customer: 'cus_1',
+    })
   })
 
   it('drops record with unknown stream and logs error', async () => {
@@ -117,33 +121,6 @@ describe('enforceCatalog()', () => {
     expect(result[0]).toMatchObject({ type: 'log' })
     expect(result[1]).toMatchObject({ type: 'error' })
     expect(result[2]).toMatchObject({ type: 'stream_status' })
-  })
-
-  it('applies field filtering per-stream independently', async () => {
-    const msgs: Message[] = [
-      { type: 'record', stream: 'customers', data: { id: 'cus_1', name: 'Alice' }, emitted_at: 1 },
-      {
-        type: 'record',
-        stream: 'products',
-        data: { id: 'prod_1', name: 'Widget', active: true },
-        emitted_at: 2,
-      },
-    ]
-    const result = await drain(
-      enforceCatalog(
-        catalog([
-          { name: 'customers', fields: ['id'] },
-          { name: 'products' }, // no field filter
-        ])
-      )(toAsync(msgs))
-    )
-    expect(result).toHaveLength(2)
-    expect((result[0] as { data: unknown }).data).toEqual({ id: 'cus_1' })
-    expect((result[1] as { data: unknown }).data).toEqual({
-      id: 'prod_1',
-      name: 'Widget',
-      active: true,
-    })
   })
 })
 

--- a/apps/engine/src/lib/pipeline.ts
+++ b/apps/engine/src/lib/pipeline.ts
@@ -20,15 +20,7 @@ export function enforceCatalog(
           logger.error({ stream: msg.stream }, 'Unknown stream not in catalog')
           continue
         }
-        if (msg.type === 'record' && cs.fields?.length) {
-          const allowed = new Set(cs.fields)
-          yield {
-            ...msg,
-            data: Object.fromEntries(Object.entries(msg.data).filter(([k]) => allowed.has(k))),
-          }
-        } else {
-          yield msg
-        }
+        yield msg
       } else {
         yield msg
       }


### PR DESCRIPTION
## Summary

Users can now selectively sync specific tables and columns by setting fields on each stream in the pipeline config. Only the chosen columns are created in the db. 

# How it works
withCatalogFilter wraps a Destination and prunes json_schema.properties in the catalog before it reaches setup()

 
## How to test (optional)

```
node apps/engine/dist/cli/index.js sync \
  --x-pipeline '{"source":{"name":"stripe","api_key":"sk_..."},"destination":{"name":"postgres","connection_string":"postgresql://...","schema":"stripe"},"streams":[{"name":"customers","fields":["description","email"]}]}'
```

