### PR TITLE
supabase e2e ci test

### DIFF
--- a/.github/workflows/e2e-supabase.yml
+++ b/.github/workflows/e2e-supabase.yml
@@ -51,6 +51,6 @@ jobs:
         if: steps.check.outputs.skip == 'false'
         run: bash e2e/supabase.test.sh
         env:
-          STRIPE_API_KEY: ${{ secrets.STRIPE_SANDBOX_KEY }}
+          STRIPE_SANDBOX_KEY: ${{ secrets.STRIPE_SANDBOX_KEY }}
           E2E_SUPABASE_TOKEN: ${{ secrets.E2E_SUPABASE_TOKEN }}
           E2E_SUPABASE_PROJECT: ${{ secrets.E2E_SUPABASE_PROJECT }}

--- a/.github/workflows/e2e-supabase.yml
+++ b/.github/workflows/e2e-supabase.yml
@@ -16,15 +16,15 @@ jobs:
   e2e_supabase:
     name: Supabase install + sync
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Check required secrets
         id: check
         run: |
-          if [ -z "${{ secrets.E2E_SUPABASE_TOKEN }}" ] || [ -z "${{ secrets.E2E_SUPABASE_PROJECT }}" ] || [ -z "${{ secrets.STRIPE_API_KEY }}" ]; then
+          if [ -z "${{ secrets.E2E_SUPABASE_TOKEN }}" ] || [ -z "${{ secrets.E2E_SUPABASE_ORG }}" ] || [ -z "${{ secrets.STRIPE_SANDBOX_KEY }}" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Skipped — E2E_SUPABASE_TOKEN, E2E_SUPABASE_PROJECT, or STRIPE_API_KEY not set"
+            echo "::warning::Skipped — E2E_SUPABASE_TOKEN, E2E_SUPABASE_ORG, or STRIPE_SANDBOX_KEY not set"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
@@ -53,4 +53,4 @@ jobs:
         env:
           STRIPE_SANDBOX_KEY: ${{ secrets.STRIPE_SANDBOX_KEY }}
           E2E_SUPABASE_TOKEN: ${{ secrets.E2E_SUPABASE_TOKEN }}
-          E2E_SUPABASE_PROJECT: ${{ secrets.E2E_SUPABASE_PROJECT }}
+          E2E_SUPABASE_ORG: ${{ secrets.E2E_SUPABASE_ORG }}

--- a/.github/workflows/e2e-supabase.yml
+++ b/.github/workflows/e2e-supabase.yml
@@ -1,0 +1,56 @@
+name: E2E Supabase
+
+on:
+  pull_request:
+  push:
+    branches: [main, v2]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  STRIPE_NPM_REGISTRY: https://npm.pkg.github.com
+
+jobs:
+  e2e_supabase:
+    name: Supabase install + sync
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+
+    steps:
+      - name: Check required secrets
+        id: check
+        run: |
+          if [ -z "${{ secrets.E2E_SUPABASE_TOKEN }}" ] || [ -z "${{ secrets.E2E_SUPABASE_PROJECT }}" ] || [ -z "${{ secrets.STRIPE_API_KEY }}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Skipped — E2E_SUPABASE_TOKEN, E2E_SUPABASE_PROJECT, or STRIPE_API_KEY not set"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v5
+        if: steps.check.outputs.skip == 'false'
+
+      - name: Install pnpm
+        if: steps.check.outputs.skip == 'false'
+        uses: pnpm/action-setup@v5
+
+      - name: Set up Node
+        if: steps.check.outputs.skip == 'false'
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ./.nvmrc
+          cache: pnpm
+
+      - name: Install dependencies & build
+        if: steps.check.outputs.skip == 'false'
+        run: pnpm install --frozen-lockfile && pnpm build
+
+      - name: Supabase install + sync e2e
+        if: steps.check.outputs.skip == 'false'
+        run: bash e2e/supabase.test.sh
+        env:
+          STRIPE_API_KEY: ${{ secrets.STRIPE_SANDBOX_KEY }}
+          E2E_SUPABASE_TOKEN: ${{ secrets.E2E_SUPABASE_TOKEN }}
+          E2E_SUPABASE_PROJECT: ${{ secrets.E2E_SUPABASE_PROJECT }}

--- a/apps/engine/src/cli/supabase.ts
+++ b/apps/engine/src/cli/supabase.ts
@@ -48,6 +48,10 @@ const installCmd = defineCommand({
       default: false,
       description: 'Skip triggering the first sync immediately after install',
     },
+    backfillConcurrency: {
+      type: 'string',
+      description: 'Number of time-range segments for parallel backfill (default: 200)',
+    },
   },
   async run({ args }) {
     const token = args.token || process.env.SUPABASE_ACCESS_TOKEN
@@ -80,6 +84,9 @@ const installCmd = defineCommand({
       syncIntervalSeconds: parseInt(args.syncInterval),
       skipInitialSync: args.skipInitialSync,
       supabaseManagementUrl: managementUrl,
+      backfillConcurrency: args.backfillConcurrency
+        ? parseInt(args.backfillConcurrency)
+        : undefined,
     })
 
     console.log('Installation complete.')

--- a/apps/supabase/src/edge-functions/stripe-sync.ts
+++ b/apps/supabase/src/edge-functions/stripe-sync.ts
@@ -145,7 +145,8 @@ Deno.serve(async (req) => {
       state = undefined
     }
 
-    const sourceConfig: SourceConfig = { api_key: stripeKey }
+    const backfillConcurrency = Number(Deno.env.get('BACKFILL_CONCURRENCY')) || undefined
+    const sourceConfig: SourceConfig = { api_key: stripeKey, backfill_concurrency: backfillConcurrency }
     const destConfig: DestConfig = {
       connection_string: dbUrl,
       schema: schemaName,

--- a/apps/supabase/src/edge-functions/stripe-sync.ts
+++ b/apps/supabase/src/edge-functions/stripe-sync.ts
@@ -146,7 +146,10 @@ Deno.serve(async (req) => {
     }
 
     const backfillConcurrency = Number(Deno.env.get('BACKFILL_CONCURRENCY')) || undefined
-    const sourceConfig: SourceConfig = { api_key: stripeKey, backfill_concurrency: backfillConcurrency }
+    const sourceConfig: SourceConfig = {
+      api_key: stripeKey,
+      backfill_concurrency: backfillConcurrency,
+    }
     const destConfig: DestConfig = {
       connection_string: dbUrl,
       schema: schemaName,

--- a/apps/supabase/src/supabase.ts
+++ b/apps/supabase/src/supabase.ts
@@ -417,7 +417,8 @@ export class SupabaseSetupClient {
     rateLimit?: number,
     syncIntervalSeconds?: number,
     startTime?: number,
-    skipInitialSync?: boolean
+    skipInitialSync?: boolean,
+    backfillConcurrency?: number
   ): Promise<void> {
     const trimmedStripeKey = stripeKey.trim()
     if (!trimmedStripeKey.startsWith('sk_') && !trimmedStripeKey.startsWith('rk_')) {
@@ -449,6 +450,9 @@ export class SupabaseSetupClient {
       }
       if (syncIntervalSeconds != null) {
         secrets.push({ name: 'SYNC_INTERVAL', value: String(syncIntervalSeconds) })
+      }
+      if (backfillConcurrency != null) {
+        secrets.push({ name: 'BACKFILL_CONCURRENCY', value: String(backfillConcurrency) })
       }
       await this.setSecrets(secrets)
 
@@ -511,6 +515,7 @@ export async function install(params: {
   syncIntervalSeconds?: number
   startTime?: number
   skipInitialSync?: boolean
+  backfillConcurrency?: number
 }): Promise<void> {
   const {
     supabaseAccessToken,
@@ -522,6 +527,7 @@ export async function install(params: {
     syncIntervalSeconds,
     startTime,
     skipInitialSync,
+    backfillConcurrency,
   } = params
 
   const client = new SupabaseSetupClient({
@@ -538,7 +544,8 @@ export async function install(params: {
     rateLimit,
     syncIntervalSeconds,
     startTime,
-    skipInitialSync
+    skipInitialSync,
+    backfillConcurrency
   )
 }
 

--- a/e2e/supabase.test.sh
+++ b/e2e/supabase.test.sh
@@ -20,7 +20,7 @@ cd "$ROOT"
 # Load .env if present
 [ -f .env ] && set -a && source .env && set +a
 
-: "${STRIPE_API_KEY:?Set STRIPE_API_KEY}"
+: "${STRIPE_SANDBOX_KEY:?Set STRIPE_SANDBOX_KEY}"
 : "${E2E_SUPABASE_TOKEN:?Set E2E_SUPABASE_TOKEN}"
 : "${E2E_SUPABASE_PROJECT:?Set E2E_SUPABASE_PROJECT}"
 SKIP_DELETE="${SKIP_DELETE:-}"
@@ -82,7 +82,7 @@ echo "==> Running: sync-engine supabase install"
 $CLI supabase install \
   --token "$SUPABASE_ACCESS_TOKEN" \
   --project "$SUPABASE_PROJECT_REF" \
-  --stripe-key "$STRIPE_API_KEY" \
+  --stripe-key "$STRIPE_SANDBOX_KEY" \
   --worker-interval 30 \
   --rate-limit 20 \
   --backfill-concurrency 10

--- a/e2e/supabase.test.sh
+++ b/e2e/supabase.test.sh
@@ -1,127 +1,59 @@
 #!/usr/bin/env bash
-# E2E test: Remote Supabase → supabase install → backfill sync
+# E2E test: Ephemeral Supabase project → supabase install → backfill sync
 #
-# Connects to a real Supabase project, cleans any prior installation,
-# runs the standard `sync-engine supabase install` flow, waits for the
-# backfill sync to land data, and verifies rows in Postgres.
+# Creates a fresh Supabase project via the Management API, runs the standard
+# `sync-engine supabase install` flow, waits for the backfill sync to land
+# data, verifies rows in Postgres, then deletes the project.
 #
 # Required env:
-#   STRIPE_API_KEY
-#   E2E_SUPABASE_TOKEN     (personal access token / service-role)
-#   E2E_SUPABASE_PROJECT   (project ref, e.g. oozizgzdedxsxtiiyqtt)
+#   STRIPE_SANDBOX_KEY
+#   E2E_SUPABASE_TOKEN     (personal access token, starts with sbp_)
+#   E2E_SUPABASE_ORG       (organization ID for project creation)
 #
 # Optional env:
-#   SKIP_DELETE=1           skip final uninstall (leave data for inspection)
+#   SKIP_DELETE=1           skip project deletion (leave for inspection)
+#   MAX_TEST_PROJECTS=8     safety cap on concurrent e2e projects
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-# Load .env if present
 [ -f .env ] && set -a && source .env && set +a
 
 : "${STRIPE_SANDBOX_KEY:?Set STRIPE_SANDBOX_KEY}"
 : "${E2E_SUPABASE_TOKEN:?Set E2E_SUPABASE_TOKEN}"
-: "${E2E_SUPABASE_PROJECT:?Set E2E_SUPABASE_PROJECT}"
-SKIP_DELETE="${SKIP_DELETE:-}"
+: "${E2E_SUPABASE_ORG:?Set E2E_SUPABASE_ORG}"
 
-SUPABASE_ACCESS_TOKEN="$E2E_SUPABASE_TOKEN"
-SUPABASE_PROJECT_REF="$E2E_SUPABASE_PROJECT"
+SKIP_DELETE="${SKIP_DELETE:-}"
+MAX_TEST_PROJECTS="${MAX_TEST_PROJECTS:-8}"
+PROJECT_PREFIX="github-ci-spawned"
+PROJECT_NAME="${PROJECT_PREFIX}-${GITHUB_RUN_ID:-local-$(date +%s)}"
+PROJECT_REGION="us-east-1"
+DB_PASS="e2e-$(openssl rand -hex 16)"
 
 MGMT_API="https://api.supabase.com"
 CLI="node $ROOT/apps/engine/dist/cli/index.js"
+PROJECT_REF=""
 
 # ── Helpers ───────────────────────────────────────────────────────────
+
+parse_json_field() {
+  local field="$1"
+  node --input-type=module -e "
+    let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+      try { console.log(JSON.parse(d)['${field}'] ?? ''); } catch { console.log(''); }
+    })
+  "
+}
 
 run_sql() {
   local sql="$1"
   curl -sf --max-time 15 \
-    -X POST "$MGMT_API/v1/projects/$SUPABASE_PROJECT_REF/database/query" \
-    -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+    -X POST "$MGMT_API/v1/projects/$PROJECT_REF/database/query" \
+    -H "Authorization: Bearer $E2E_SUPABASE_TOKEN" \
     -H "Content-Type: application/json" \
     -d "{\"query\": \"$sql\"}"
 }
-
-# ── Cleanup on exit ───────────────────────────────────────────────────
-
-cleanup() {
-  local rc=$?
-  echo ""
-  echo "--- Cleanup ---"
-  if [ -z "$SKIP_DELETE" ]; then
-    echo "  Uninstalling..."
-    $CLI supabase uninstall \
-      --token "$SUPABASE_ACCESS_TOKEN" \
-      --project "$SUPABASE_PROJECT_REF" 2>&1 | sed 's/^/  /' || true
-  else
-    echo "  SKIP_DELETE set — leaving installation in place"
-  fi
-  [ "$rc" -ne 0 ] && echo "  Test FAILED (exit $rc)"
-  return "$rc"
-}
-trap cleanup EXIT
-
-echo "==> Supabase project: $SUPABASE_PROJECT_REF"
-echo "    Management API:   $MGMT_API"
-
-# ── 1. Clean slate: uninstall any prior installation ──────────────────
-
-echo ""
-echo "==> Ensuring clean slate (uninstall if installed)"
-$CLI supabase uninstall \
-  --token "$SUPABASE_ACCESS_TOKEN" \
-  --project "$SUPABASE_PROJECT_REF" 2>&1 | sed 's/^/  /' || true
-
-# Give the project a moment to settle after uninstall
-sleep 5
-
-# ── 2. Install via the standard CLI flow ──────────────────────────────
-
-echo ""
-echo "==> Running: sync-engine supabase install"
-$CLI supabase install \
-  --token "$SUPABASE_ACCESS_TOKEN" \
-  --project "$SUPABASE_PROJECT_REF" \
-  --stripe-key "$STRIPE_SANDBOX_KEY" \
-  --worker-interval 30 \
-  --rate-limit 20 \
-  --backfill-concurrency 10
-echo "  Install complete"
-
-# ── 3. Wait for backfill sync to land data ────────────────────────────
-
-echo ""
-echo "==> Waiting for sync to complete (polling every 15s, up to 5 min)..."
-
-SYNCED=0
-for i in $(seq 1 20); do
-  sleep 15
-
-  RESULT=$(run_sql "SELECT count(*)::int AS n FROM stripe.subscriptions" 2>/dev/null) || true
-  COUNT=$(echo "$RESULT" | node --input-type=module -e "
-    let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
-      try {
-        const rows = JSON.parse(d);
-        console.log(rows[0]?.n ?? rows[0]?.count ?? 0);
-      } catch { console.log(0); }
-    })
-  ")
-
-  echo "  Poll $i/20: subscriptions=$COUNT (expecting 555)"
-
-  if [ "$COUNT" -ge 555 ]; then
-    SYNCED=1
-    break
-  fi
-done
-
-[ "$SYNCED" -eq 1 ] || { echo "FAIL: subscriptions did not reach 555 after 5 minutes"; exit 1; }
-
-# ── 4. Verify exact row counts per table ──────────────────────────────
-
-echo ""
-echo "==> Verifying synced data (exact counts)"
-FAILURES=0
 
 parse_count() {
   node --input-type=module -e "
@@ -133,6 +65,155 @@ parse_count() {
     })
   "
 }
+
+# ── Cleanup on exit ───────────────────────────────────────────────────
+
+cleanup() {
+  local rc=$?
+  echo ""
+  echo "--- Cleanup ---"
+
+  if [ -n "$PROJECT_REF" ]; then
+    if [ -z "$SKIP_DELETE" ]; then
+      echo "  Uninstalling sync..."
+      $CLI supabase uninstall \
+        --token "$E2E_SUPABASE_TOKEN" \
+        --project "$PROJECT_REF" 2>&1 | sed 's/^/  /' || true
+
+      echo "  Deleting project $PROJECT_REF..."
+      curl -sf -X DELETE "$MGMT_API/v1/projects/$PROJECT_REF" \
+        -H "Authorization: Bearer $E2E_SUPABASE_TOKEN" || true
+      echo "  Project deleted."
+    else
+      echo "  SKIP_DELETE set — leaving project $PROJECT_REF alive"
+    fi
+  fi
+
+  [ "$rc" -ne 0 ] && echo "  Test FAILED (exit $rc)"
+  return "$rc"
+}
+trap cleanup EXIT
+
+# ── 0. Safety check: don't exceed MAX_TEST_PROJECTS ──────────────────
+
+echo "==> Checking for existing e2e test projects (max $MAX_TEST_PROJECTS)..."
+
+PROJECTS=$(curl -sf "$MGMT_API/v1/projects" \
+  -H "Authorization: Bearer $E2E_SUPABASE_TOKEN")
+
+TEST_COUNT=$(echo "$PROJECTS" | node --input-type=module -e "
+  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+    const projects = JSON.parse(d);
+    const active = projects.filter(p =>
+      p.name.startsWith('${PROJECT_PREFIX}-') &&
+      p.status !== 'REMOVED'
+    );
+    active.forEach(p => console.error('  ' + p.name + ' (' + p.id + ') status=' + p.status));
+    console.log(active.length);
+  })
+")
+
+echo "  Found $TEST_COUNT active e2e project(s)"
+if [ "$TEST_COUNT" -ge "$MAX_TEST_PROJECTS" ]; then
+  echo "FAIL: $TEST_COUNT e2e projects already exist (limit $MAX_TEST_PROJECTS)."
+  echo "      Clean up stale projects before running more tests."
+  exit 1
+fi
+
+# ── 1. Create ephemeral Supabase project ──────────────────────────────
+
+echo ""
+echo "==> Creating Supabase project: $PROJECT_NAME (region: $PROJECT_REGION)"
+
+CREATE_RESP=$(curl -sf -X POST "$MGMT_API/v1/projects" \
+  -H "Authorization: Bearer $E2E_SUPABASE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"name\": \"$PROJECT_NAME\",
+    \"organization_id\": \"$E2E_SUPABASE_ORG\",
+    \"region\": \"$PROJECT_REGION\",
+    \"db_pass\": \"$DB_PASS\"
+  }")
+
+PROJECT_REF=$(echo "$CREATE_RESP" | parse_json_field "id")
+
+if [ -z "$PROJECT_REF" ]; then
+  echo "FAIL: Could not create project. Response:"
+  echo "$CREATE_RESP"
+  exit 1
+fi
+
+echo "  Project ref: $PROJECT_REF"
+
+# ── 2. Wait for project to become ACTIVE_HEALTHY ─────────────────────
+
+echo ""
+echo "==> Waiting for project to become ACTIVE_HEALTHY (polling every 10s, up to 5 min)..."
+
+PROJECT_STATUS=""
+for i in $(seq 1 30); do
+  sleep 10
+
+  PROJECT_STATUS=$(curl -sf "$MGMT_API/v1/projects/$PROJECT_REF" \
+    -H "Authorization: Bearer $E2E_SUPABASE_TOKEN" \
+    | parse_json_field "status") || true
+
+  echo "  Poll $i/30: status=$PROJECT_STATUS"
+
+  if [ "$PROJECT_STATUS" = "ACTIVE_HEALTHY" ]; then
+    break
+  fi
+done
+
+if [ "$PROJECT_STATUS" != "ACTIVE_HEALTHY" ]; then
+  echo "FAIL: project never became ACTIVE_HEALTHY (last status: $PROJECT_STATUS)"
+  exit 1
+fi
+
+echo "  Project is ready."
+echo "    Management API:   $MGMT_API"
+echo "    Project URL:      https://${PROJECT_REF}.supabase.co"
+
+# ── 3. Install via the standard CLI flow ──────────────────────────────
+
+echo ""
+echo "==> Running: sync-engine supabase install"
+$CLI supabase install \
+  --token "$E2E_SUPABASE_TOKEN" \
+  --project "$PROJECT_REF" \
+  --stripe-key "$STRIPE_SANDBOX_KEY" \
+  --worker-interval 30 \
+  --rate-limit 20 \
+  --backfill-concurrency 10
+echo "  Install complete"
+
+# ── 4. Wait for backfill sync to land data ────────────────────────────
+
+echo ""
+echo "==> Waiting for sync to complete (polling every 15s, up to 5 min)..."
+
+SYNCED=0
+for i in $(seq 1 20); do
+  sleep 15
+
+  RESULT=$(run_sql "SELECT count(*)::int AS n FROM stripe.subscriptions" 2>/dev/null) || true
+  COUNT=$(echo "$RESULT" | parse_count)
+
+  echo "  Poll $i/20: subscriptions=$COUNT (expecting 555)"
+
+  if [ "$COUNT" -ge 555 ]; then
+    SYNCED=1
+    break
+  fi
+done
+
+[ "$SYNCED" -eq 1 ] || { echo "FAIL: subscriptions did not reach 555 after 5 minutes"; exit 1; }
+
+# ── 5. Verify exact row counts per table ──────────────────────────────
+
+echo ""
+echo "==> Verifying synced data (exact counts)"
+FAILURES=0
 
 check_table() {
   local table="$1"
@@ -164,13 +245,13 @@ check_table subscriptions           555
 
 [ "$FAILURES" -eq 0 ] || { echo "FAIL: $FAILURES table(s) had wrong counts"; exit 1; }
 
-# ── 5. Check installation status via stripe-setup GET ─────────────────
+# ── 6. Check installation status via stripe-setup GET ─────────────────
 
 echo ""
 echo "==> Checking installation status"
-STATUS_URL="https://${SUPABASE_PROJECT_REF}.supabase.co/functions/v1/stripe-setup"
+STATUS_URL="https://${PROJECT_REF}.supabase.co/functions/v1/stripe-setup"
 STATUS=$(curl -sf --max-time 15 "$STATUS_URL" \
-  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" 2>/dev/null) || true
+  -H "Authorization: Bearer $E2E_SUPABASE_TOKEN" 2>/dev/null) || true
 
 echo "  $STATUS" | head -1
 

--- a/e2e/supabase.test.sh
+++ b/e2e/supabase.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# E2E test: Remote Supabase → supabase install → backfill sync
+#
+# Connects to a real Supabase project, cleans any prior installation,
+# runs the standard `sync-engine supabase install` flow, waits for the
+# backfill sync to land data, and verifies rows in Postgres.
+#
+# Required env:
+#   STRIPE_API_KEY
+#   E2E_SUPABASE_TOKEN     (personal access token / service-role)
+#   E2E_SUPABASE_PROJECT   (project ref, e.g. oozizgzdedxsxtiiyqtt)
+#
+# Optional env:
+#   SKIP_DELETE=1           skip final uninstall (leave data for inspection)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# Load .env if present
+[ -f .env ] && set -a && source .env && set +a
+
+: "${STRIPE_API_KEY:?Set STRIPE_API_KEY}"
+: "${E2E_SUPABASE_TOKEN:?Set E2E_SUPABASE_TOKEN}"
+: "${E2E_SUPABASE_PROJECT:?Set E2E_SUPABASE_PROJECT}"
+SKIP_DELETE="${SKIP_DELETE:-}"
+
+SUPABASE_ACCESS_TOKEN="$E2E_SUPABASE_TOKEN"
+SUPABASE_PROJECT_REF="$E2E_SUPABASE_PROJECT"
+
+MGMT_API="https://api.supabase.com"
+CLI="node $ROOT/apps/engine/dist/cli/index.js"
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+run_sql() {
+  local sql="$1"
+  curl -sf --max-time 15 \
+    -X POST "$MGMT_API/v1/projects/$SUPABASE_PROJECT_REF/database/query" \
+    -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"query\": \"$sql\"}"
+}
+
+# ── Cleanup on exit ───────────────────────────────────────────────────
+
+cleanup() {
+  local rc=$?
+  echo ""
+  echo "--- Cleanup ---"
+  if [ -z "$SKIP_DELETE" ]; then
+    echo "  Uninstalling..."
+    $CLI supabase uninstall \
+      --token "$SUPABASE_ACCESS_TOKEN" \
+      --project "$SUPABASE_PROJECT_REF" 2>&1 | sed 's/^/  /' || true
+  else
+    echo "  SKIP_DELETE set — leaving installation in place"
+  fi
+  [ "$rc" -ne 0 ] && echo "  Test FAILED (exit $rc)"
+  return "$rc"
+}
+trap cleanup EXIT
+
+echo "==> Supabase project: $SUPABASE_PROJECT_REF"
+echo "    Management API:   $MGMT_API"
+
+# ── 1. Clean slate: uninstall any prior installation ──────────────────
+
+echo ""
+echo "==> Ensuring clean slate (uninstall if installed)"
+$CLI supabase uninstall \
+  --token "$SUPABASE_ACCESS_TOKEN" \
+  --project "$SUPABASE_PROJECT_REF" 2>&1 | sed 's/^/  /' || true
+
+# Give the project a moment to settle after uninstall
+sleep 5
+
+# ── 2. Install via the standard CLI flow ──────────────────────────────
+
+echo ""
+echo "==> Running: sync-engine supabase install"
+$CLI supabase install \
+  --token "$SUPABASE_ACCESS_TOKEN" \
+  --project "$SUPABASE_PROJECT_REF" \
+  --stripe-key "$STRIPE_API_KEY" \
+  --worker-interval 30 \
+  --rate-limit 20 \
+  --backfill-concurrency 10
+echo "  Install complete"
+
+# ── 3. Wait for backfill sync to land data ────────────────────────────
+
+echo ""
+echo "==> Waiting for sync to complete (polling every 15s, up to 5 min)..."
+
+SYNCED=0
+for i in $(seq 1 20); do
+  sleep 15
+
+  RESULT=$(run_sql "SELECT count(*)::int AS n FROM stripe.subscriptions" 2>/dev/null) || true
+  COUNT=$(echo "$RESULT" | node --input-type=module -e "
+    let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+      try {
+        const rows = JSON.parse(d);
+        console.log(rows[0]?.n ?? rows[0]?.count ?? 0);
+      } catch { console.log(0); }
+    })
+  ")
+
+  echo "  Poll $i/20: subscriptions=$COUNT (expecting 555)"
+
+  if [ "$COUNT" -ge 555 ]; then
+    SYNCED=1
+    break
+  fi
+done
+
+[ "$SYNCED" -eq 1 ] || { echo "FAIL: subscriptions did not reach 555 after 5 minutes"; exit 1; }
+
+# ── 4. Verify exact row counts per table ──────────────────────────────
+
+echo ""
+echo "==> Verifying synced data (exact counts)"
+FAILURES=0
+
+parse_count() {
+  node --input-type=module -e "
+    let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+      try {
+        const rows = JSON.parse(d);
+        console.log(rows[0]?.n ?? rows[0]?.count ?? 0);
+      } catch { console.log(0); }
+    })
+  "
+}
+
+check_table() {
+  local table="$1"
+  local expected="$2"
+  RESULT=$(run_sql "SELECT count(*)::int AS n FROM stripe.${table}" 2>/dev/null) || true
+  COUNT=$(echo "$RESULT" | parse_count)
+  if [ "$COUNT" -eq "$expected" ]; then
+    printf "  %-30s %s  ✓\n" "$table" "$COUNT"
+  else
+    printf "  %-30s %s  ✗ (expected %s)\n" "$table" "$COUNT" "$expected"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+check_table charges                 1110
+check_table checkout_sessions       555
+check_table coupons                 555
+check_table customers               555
+check_table disputes                555
+check_table invoices                1110
+check_table payment_intents         1942
+check_table plans                   833
+check_table prices                  1110
+check_table products                555
+check_table refunds                 555
+check_table setup_intents           555
+check_table subscription_schedules  555
+check_table subscriptions           555
+
+[ "$FAILURES" -eq 0 ] || { echo "FAIL: $FAILURES table(s) had wrong counts"; exit 1; }
+
+# ── 5. Check installation status via stripe-setup GET ─────────────────
+
+echo ""
+echo "==> Checking installation status"
+STATUS_URL="https://${SUPABASE_PROJECT_REF}.supabase.co/functions/v1/stripe-setup"
+STATUS=$(curl -sf --max-time 15 "$STATUS_URL" \
+  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" 2>/dev/null) || true
+
+echo "  $STATUS" | head -1
+
+INSTALL_STATUS=$(echo "$STATUS" | node --input-type=module -e "
+  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+    try { console.log(JSON.parse(d).installation_status) } catch { console.log('unknown') }
+  })
+")
+echo "  installation_status: $INSTALL_STATUS"
+[ "$INSTALL_STATUS" = "installed" ] || echo "  WARNING: expected 'installed', got '$INSTALL_STATUS'"
+
+echo ""
+echo "=== Supabase install + sync test passed ==="

--- a/packages/openapi/specFetchHelper.ts
+++ b/packages/openapi/specFetchHelper.ts
@@ -40,14 +40,20 @@ export async function resolveOpenApiSpec(
 
   // If the requested version matches what's bundled, serve from the filesystem
   // without any network calls or caching overhead.
+  // In environments where the file isn't on disk (e.g. Deno edge runtime after
+  // esbuild bundling), fall through to the CDN/network path below.
   if (extractDatePart(apiVersion) === extractDatePart(BUNDLED_API_VERSION)) {
-    const bundledPath = fileURLToPath(new URL('./bundled-spec.json', import.meta.url))
-    const spec = await readSpecFromPath(bundledPath)
-    return {
-      apiVersion,
-      spec,
-      source: 'bundled',
-      cachePath: bundledPath,
+    try {
+      const bundledPath = fileURLToPath(new URL('./bundled-spec.json', import.meta.url))
+      const spec = await readSpecFromPath(bundledPath)
+      return {
+        apiVersion,
+        spec,
+        source: 'bundled',
+        cachePath: bundledPath,
+      }
+    } catch {
+      // Bundled spec not available on disk — continue to CDN/network fetch
     }
   }
 

--- a/packages/util-postgres/src/sslConfigFromConnectionString.test.ts
+++ b/packages/util-postgres/src/sslConfigFromConnectionString.test.ts
@@ -50,10 +50,10 @@ describe('sslConfigFromConnectionString', () => {
     expect(sslConfigFromConnectionString('not-a-url')).toBe(false)
   })
 
-  it('sslmode=prefer → throws', () => {
-    expect(() =>
-      sslConfigFromConnectionString('postgres://user:pass@host:5432/mydb?sslmode=prefer')
-    ).toThrow(/Unsupported Postgres sslmode "prefer"/)
+  it('sslmode=prefer → rejectUnauthorized: false (same as require)', () => {
+    expect(sslConfigFromConnectionString(`${base}?sslmode=prefer`)).toEqual({
+      rejectUnauthorized: false,
+    })
   })
 
   it('sslmode=allow → throws', () => {

--- a/packages/util-postgres/src/sslConfigFromConnectionString.ts
+++ b/packages/util-postgres/src/sslConfigFromConnectionString.ts
@@ -40,7 +40,7 @@ export function sslConfigFromConnectionString(
     return false
   }
   if (sslmode === null || sslmode === 'disable') return false
-  if (sslmode === 'require') return { rejectUnauthorized: false }
+  if (sslmode === 'prefer' || sslmode === 'require') return { rejectUnauthorized: false }
   if (sslmode === 'verify-full') {
     return { rejectUnauthorized: true, ...(sslCaPem ? { ca: sslCaPem } : {}) }
   }


### PR DESCRIPTION
## Summary

- Adds an end-to-end CI test that exercises the full supabase 
   install → backfill sync → verify flow against a real Supabase project
   
- Each CI run spawns an ephemeral Supabase project via the Management API and tears
   it down on completion (no shared state, no race conditions between branches)
   
- Safety cap: if 8+ github-ci-spawned-* projects already exist,
   the test fails fast to prevent runaway resource usage
   
- Fixes sslmode=prefer handling and bundled OpenAPI spec fallback for Deno edge runtime

- Makes backfill_concurrency configurable via CLI (--backfill-concurrency)



#### Sandbox
(Outside this PR) Stripe sandbox is seeded with the fixed amount of data that we check against.

####  Object | count
charges | 1110
checkout_sessions | 555
coupons | 555
customers | 555
disputes | 555
invoices | 1110
payment_intents | 1942
plans | 833
prices | 1110
products | 555
refunds | 555
setup_intents | 555
subscription_schedules | 555
subscriptions | 555
