### PR TITLE
feat(visualizer): deploy to /visualizer suburl of docs site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,8 +425,7 @@ jobs:
       - name: Build visualizer
         run: |
           pnpm install --frozen-lockfile
-          pnpm --filter @stripe/sync-source-stripe build
-          pnpm --filter @stripe/sync-visualizer build
+          pnpm --filter '...@stripe/sync-visualizer' build
           mkdir -p docs/.vercel/output/static/visualizer
           cp -r apps/visualizer/out/. docs/.vercel/output/static/visualizer/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,6 +381,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ./.nvmrc
+          cache: pnpm
+
       - name: Install Vercel CLI
         run: npm install -g vercel
 
@@ -412,6 +421,14 @@ jobs:
             --base /slides/demo/ demo.md \
             --out ../.vercel/output/static/slides/demo
         working-directory: docs/slides
+
+      - name: Build visualizer
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter @stripe/sync-source-stripe build
+          pnpm --filter @stripe/sync-visualizer build
+          mkdir -p docs/.vercel/output/static/visualizer
+          cp -r apps/visualizer/out/. docs/.vercel/output/static/visualizer/
 
       - name: Deploy
         id: deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,7 +425,10 @@ jobs:
       - name: Build visualizer
         run: |
           pnpm install --frozen-lockfile
-          pnpm --filter '...@stripe/sync-visualizer' build
+          pnpm --filter @stripe/sync-protocol build
+          pnpm --filter @stripe/sync-openapi build
+          pnpm --filter @stripe/sync-source-stripe build
+          pnpm --filter @stripe/sync-visualizer build
           mkdir -p docs/.vercel/output/static/visualizer
           cp -r apps/visualizer/out/. docs/.vercel/output/static/visualizer/
 

--- a/apps/visualizer/next.config.ts
+++ b/apps/visualizer/next.config.ts
@@ -1,6 +1,8 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
+  output: 'export',
+  basePath: '/visualizer',
   typescript: {
     ignoreBuildErrors: false,
   },
@@ -16,23 +18,6 @@ const nextConfig: NextConfig = {
     })
 
     return config
-  },
-  async headers() {
-    return [
-      {
-        source: '/(.*)',
-        headers: [
-          {
-            key: 'Cross-Origin-Embedder-Policy',
-            value: 'require-corp',
-          },
-          {
-            key: 'Cross-Origin-Opener-Policy',
-            value: 'same-origin',
-          },
-        ],
-      },
-    ]
   },
 }
 

--- a/apps/visualizer/src/lib/pglite.ts
+++ b/apps/visualizer/src/lib/pglite.ts
@@ -195,7 +195,8 @@ function buildTableSql(schema: string, table: ParsedResourceTable): string {
 
   for (const col of table.columns) {
     const p = col.name.replace(/'/g, "''")
-    const pg = scalartypeToPg(col.type)
+    // Expandable references always resolve to an id string (text), regardless of declared type
+    const pg = col.expandableReference ? 'text' : scalartypeToPg(col.type)
     let expr: string
     if (col.expandableReference) {
       expr = `CASE WHEN jsonb_typeof(_raw_data->'${p}') = 'object' AND _raw_data->'${p}' ? 'id' THEN (_raw_data->'${p}'->>'id') ELSE (_raw_data->>'${p}') END`

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,5 +1,14 @@
 {
   "buildCommand": "npm run build",
   "outputDirectory": "out",
-  "trailingSlash": true
+  "trailingSlash": true,
+  "headers": [
+    {
+      "source": "/visualizer/(.*)",
+      "headers": [
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- **`apps/visualizer/next.config.ts`**: add `output: 'export'` and `basePath: '/visualizer'` to produce a static site rooted at `/visualizer`. Removes the `headers()` function (incompatible with static export; replaced by `vercel.json` headers).
- **`docs/vercel.json`**: add COOP/COEP headers on `/visualizer/(.*)` so PGlite's SharedArrayBuffer requirement is satisfied at the deployed URL.
- **`.github/workflows/ci.yml`** (`docs` job): add pnpm + Node.js setup, then a "Build visualizer" step that installs workspace deps, builds `@stripe/sync-source-stripe` + `@stripe/sync-visualizer`, and copies the static export into `.vercel/output/static/visualizer/` before the Vercel deploy.

After merging, the visualizer will be live at `https://stripe-sync.dev/visualizer`.

## Test plan

- [ ] CI `docs` job deploys successfully; confirm preview URL `/visualizer` loads the app
- [ ] Verify COOP/COEP headers are present on `/visualizer/*` responses (required for PGlite)
- [ ] Verify `/visualizer` loads the in-browser Postgres explorer (fetches Stripe OpenAPI spec, populates tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)