### PR TITLE
chore(dev): pnpm dev script, compose.dev.yml, and dashboard container

### DIFF
--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -1,0 +1,16 @@
+FROM node:24-alpine
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+WORKDIR /workspace
+RUN corepack enable
+
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/ packages/
+COPY apps/ apps/
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+
+WORKDIR /workspace/apps/dashboard
+EXPOSE 5173
+CMD ["pnpm", "run", "dev", "--", "--host"]

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -11,11 +11,11 @@ export default defineConfig({
   server: {
     proxy: {
       '/api/engine': {
-        target: 'http://localhost:4010',
+        target: process.env.ENGINE_URL ?? 'http://localhost:4010',
         rewrite: (p) => p.replace(/^\/api\/engine/, ''),
       },
       '/api/service': {
-        target: 'http://localhost:4020',
+        target: process.env.SERVICE_URL ?? 'http://localhost:4020',
         rewrite: (p) => p.replace(/^\/api\/service/, ''),
       },
     },

--- a/apps/engine/package.json
+++ b/apps/engine/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
+    "dev": "PORT=4010 tsx src/api/index.ts",
     "test": "vitest run",
     "generate:types": "openapi-typescript src/__generated__/openapi.json -o src/__generated__/openapi.d.ts"
   },

--- a/apps/service/package.json
+++ b/apps/service/package.json
@@ -16,7 +16,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch",
+    "dev:serve": "tsx src/bin/sync-service.ts serve --temporal-address localhost:7233 --port 4020",
+    "dev:worker": "tsx src/bin/sync-service.ts worker --temporal-address localhost:7233",
     "test": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "generate:types": "openapi-typescript src/__generated__/openapi.json -o src/__generated__/openapi.d.ts"

--- a/apps/service/src/cli.ts
+++ b/apps/service/src/cli.ts
@@ -1,4 +1,3 @@
-import path from 'node:path'
 import { Readable } from 'node:stream'
 import { defineCommand } from 'citty'
 import { createCliFromSpec } from '@stripe/sync-ts-cli/openapi'

--- a/apps/service/src/cli.ts
+++ b/apps/service/src/cli.ts
@@ -100,9 +100,17 @@ const workerCmd = defineCommand({
     const engineUrl = args['engine-url'] || 'http://localhost:4010'
     const temporalAddress = args['temporal-address']
 
-    // workflowsPath: resolve relative to the package dist directory
-    const pkgDir = path.resolve(import.meta.dirname ?? process.cwd(), '..')
-    const workflowsPath = path.resolve(pkgDir, 'dist/temporal/workflows.js')
+    // tsx strips rootDir:"src" from import.meta.url, so paths differ by context:
+    //   tsx:      file:///.../apps/service/bin/sync-service.ts  → ../src/temporal/workflows.ts
+    //   compiled: file:///.../apps/service/dist/bin/sync-service.js → ../temporal/workflows.js
+    const { fileURLToPath } = await import('node:url')
+    const isTsx = import.meta.url.endsWith('.ts')
+    const workflowsPath = fileURLToPath(
+      new URL(
+        isTsx ? '../src/temporal/workflows.ts' : '../temporal/workflows.js',
+        import.meta.url
+      )
+    )
 
     const worker = await createWorker({
       temporalAddress,

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,6 +1,6 @@
 # Application layer — engine + service API + Temporal worker.
 # Use together with compose.yml:
-#   docker compose -f compose.yml -f compose.service.yml up --build -d
+#   docker compose -f compose.yml -f compose.dev.yml up --build -d
 #
 # Requires pre-built dist/ in build context: run `pnpm build` first.
 
@@ -62,4 +62,19 @@ services:
       engine:
         condition: service_healthy
       temporal:
+        condition: service_healthy
+
+  dashboard:
+    build:
+      context: .
+      dockerfile: Dockerfile.dashboard
+    ports:
+      - '5173:5173'
+    environment:
+      ENGINE_URL: http://engine:3000
+      SERVICE_URL: http://service:4020
+    depends_on:
+      engine:
+        condition: service_healthy
+      service:
         condition: service_healthy

--- a/e2e/service-docker.test.ts
+++ b/e2e/service-docker.test.ts
@@ -17,7 +17,7 @@ const POSTGRES_HOST_URL =
   process.env.POSTGRES_URL ?? 'postgresql://postgres:postgres@localhost:55432/postgres'
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..')
-const COMPOSE_CMD = `docker compose -f compose.yml -f compose.service.yml`
+const COMPOSE_CMD = `docker compose -f compose.yml -f compose.dev.yml`
 
 const SKIP_CLEANUP = process.env.SKIP_CLEANUP === '1'
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "pnpm -r run lint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "dev": "concurrently -n engine,service,worker,dashboard -c cyan,green,yellow,magenta \"PORT=4010 tsx apps/engine/src/api/index.ts\" \"tsx apps/service/src/bin/sync-service.ts serve --temporal-address localhost:7233 --port 4020\" \"tsx apps/service/src/bin/sync-service.ts worker --temporal-address localhost:7233 --engine-url http://localhost:4010\" \"pnpm --filter @stripe/sync-dashboard dev\"",
+    "dev": "concurrently -n engine,service,worker,dashboard -c cyan,green,yellow,magenta \"pnpm --filter @stripe/sync-engine dev\" \"pnpm --filter @stripe/sync-service dev:serve\" \"pnpm --filter @stripe/sync-service dev:worker\" \"pnpm --filter @stripe/sync-dashboard dev\"",
     "visualizer": "pnpm --filter @stripe/sync-visualizer dev"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "pnpm -r run lint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "dev": "concurrently -n engine,service,worker,dashboard -c cyan,green,yellow,magenta \"PORT=4010 tsx apps/engine/src/api/index.ts\" \"tsx apps/service/src/bin/sync-service.ts serve --temporal-address localhost:7233 --port 4020\" \"tsx apps/service/src/bin/sync-service.ts worker --temporal-address localhost:7233 --engine-url http://localhost:4010\" \"pnpm --filter @stripe/sync-dashboard dev\"",
     "visualizer": "pnpm --filter @stripe/sync-visualizer dev"
   },
   "dependencies": {
@@ -25,6 +26,7 @@
     "@typescript-eslint/eslint-plugin": "^8.44.0",
     "@typescript-eslint/parser": "^8.44.0",
     "@webhooksite/cli": "^0.2.7",
+    "concurrently": "^9.2.1",
     "eslint": "^9.35.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       '@webhooksite/cli':
         specifier: ^0.2.7
         version: 0.2.7
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
       eslint:
         specifier: ^9.35.0
         version: 9.39.1(jiti@2.6.1)
@@ -3251,6 +3254,11 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -4468,6 +4476,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
+
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -4711,6 +4723,10 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -7180,6 +7196,7 @@ snapshots:
       - '@aws-sdk/rds-signer'
       - '@swc/helpers'
       - bufferutil
+      - debug
       - encoding
       - esbuild
       - pg-native
@@ -7653,6 +7670,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
+  '@vitest/mocker@3.2.4(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+
   '@vitest/mocker@3.2.4(vite@7.2.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -8001,6 +8026,15 @@ snapshots:
   component-inherit@0.0.3: {}
 
   concat-map@0.0.1: {}
+
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   consola@3.4.2: {}
 
@@ -9282,6 +9316,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.8.3: {}
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -9516,6 +9552,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  tree-kill@1.2.2: {}
+
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -9680,7 +9718,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.2.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4


### PR DESCRIPTION
## Summary

- **Rename** `compose.service.yml` → `compose.dev.yml` — more accurate since it contains engine + service + worker + dashboard
- **Add** `Dockerfile.dashboard` — dev-focused container: full workspace install, runs \`vite --host\`
- **Add** \`dashboard\` service to \`compose.dev.yml\` with \`ENGINE_URL\`/\`SERVICE_URL\` env vars pointing to sibling containers
- **Add** \`pnpm dev\` root script — starts engine, service, worker, and dashboard concurrently via \`tsx\`
- **Fix** \`workflowsPath\` in service CLI to work with \`tsx\` (tsx strips \`rootDir:"src"\` from \`import.meta.url\`)
- **Add** \`ENGINE_URL\`/\`SERVICE_URL\` env var support to vite proxy config for both local and Docker use

## Usage

\`\`\`sh
# Full Docker stack
pnpm build && docker compose -f compose.yml -f compose.dev.yml up --build -d

# Local dev (native, hot reload — run pnpm build once first for workspace packages)
docker compose up -d
pnpm dev   # engine :4010, service :4020, worker, dashboard :5173
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)