### PR TITLE
fix(protocol): change emitted_at from Unix ms integer to ISO 8601 string

### DIFF
--- a/apps/engine/src/__tests__/sync.test.ts
+++ b/apps/engine/src/__tests__/sync.test.ts
@@ -81,7 +81,7 @@ function record(stream: string, id: string, data?: Record<string, unknown>): Rec
     type: 'record',
     stream,
     data: { id, ...data },
-    emitted_at: Date.now(),
+    emitted_at: new Date().toISOString(),
   }
 }
 

--- a/apps/engine/src/api/app.test.ts
+++ b/apps/engine/src/api/app.test.ts
@@ -275,7 +275,7 @@ describe('POST /read', () => {
         type: 'record',
         stream: 'customers',
         data: { id: 'cus_1', name: 'Alice' },
-        emitted_at: Date.now(),
+        emitted_at: new Date().toISOString(),
       },
       { type: 'state', stream: 'customers', data: { status: 'complete' } },
     ])
@@ -304,7 +304,7 @@ describe('POST /write', () => {
         type: 'record',
         stream: 'customers',
         data: { id: 'cus_1' },
-        emitted_at: 1000,
+        emitted_at: '2024-01-01T00:00:00.000Z',
       },
       {
         type: 'state',
@@ -352,7 +352,7 @@ describe('POST /sync', () => {
         type: 'record',
         stream: 'customers',
         data: { id: 'cus_1', name: 'Alice' },
-        emitted_at: Date.now(),
+        emitted_at: new Date().toISOString(),
       },
       { type: 'state', stream: 'customers', data: { status: 'complete' } },
     ])
@@ -380,11 +380,26 @@ describe('X-State-Checkpoint-Limit', () => {
     const app = createApp(resolver)
 
     const body = toNdjson([
-      { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: 1 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_1' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'customers', data: { cursor: '1' } },
-      { type: 'record', stream: 'customers', data: { id: 'cus_2' }, emitted_at: 2 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_2' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'customers', data: { cursor: '2' } },
-      { type: 'record', stream: 'customers', data: { id: 'cus_3' }, emitted_at: 3 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_3' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
     ])
     const res = await app.request('/read', {
       method: 'POST',
@@ -408,9 +423,19 @@ describe('X-State-Checkpoint-Limit', () => {
     const app = createApp(resolver)
 
     const body = toNdjson([
-      { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: 1 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_1' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'customers', data: { cursor: '1' } },
-      { type: 'record', stream: 'customers', data: { id: 'cus_2' }, emitted_at: 2 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_2' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'customers', data: { cursor: '2' } },
     ])
     const res = await app.request('/sync', {
@@ -434,9 +459,19 @@ describe('X-State-Checkpoint-Limit', () => {
     const app = createApp(resolver)
 
     const body = toNdjson([
-      { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: 1 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_1' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'customers', data: { cursor: '1' } },
-      { type: 'record', stream: 'customers', data: { id: 'cus_2' }, emitted_at: 2 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_2' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'customers', data: { cursor: '2' } },
     ])
     const res = await app.request('/read', {

--- a/apps/engine/src/lib/engine.test.ts
+++ b/apps/engine/src/lib/engine.test.ts
@@ -166,7 +166,7 @@ describe('protocol schemas', () => {
         type: 'record',
         stream: 'customers',
         data: { id: 'cus_1' },
-        emitted_at: 1000,
+        emitted_at: '2024-01-01T00:00:00.000Z',
       })
       expect(msg.type).toBe('record')
       expect(msg.data).toEqual({ id: 'cus_1' })
@@ -216,12 +216,19 @@ describe('protocol schemas', () => {
     })
 
     it('rejects missing type', () => {
-      expect(() => RecordMessage.parse({ stream: 'x', data: {}, emitted_at: 1 })).toThrow()
+      expect(() =>
+        RecordMessage.parse({ stream: 'x', data: {}, emitted_at: '2024-01-01T00:00:00.000Z' })
+      ).toThrow()
     })
 
     it('rejects wrong type literal', () => {
       expect(() =>
-        RecordMessage.parse({ type: 'state', stream: 'x', data: {}, emitted_at: 1 })
+        RecordMessage.parse({
+          type: 'state',
+          stream: 'x',
+          data: {},
+          emitted_at: '2024-01-01T00:00:00.000Z',
+        })
       ).toThrow()
     })
   })
@@ -229,7 +236,7 @@ describe('protocol schemas', () => {
   describe('Message discriminated union', () => {
     it('parses all 6 message types', () => {
       const messages = [
-        { type: 'record', stream: 's', data: {}, emitted_at: 1 },
+        { type: 'record', stream: 's', data: {}, emitted_at: '2024-01-01T00:00:00.000Z' },
         { type: 'state', stream: 's', data: null },
         { type: 'catalog', streams: [{ name: 's', primary_key: [['id']] }] },
         { type: 'log', level: 'info', message: 'hi' },
@@ -249,7 +256,12 @@ describe('protocol schemas', () => {
   describe('DestinationInput', () => {
     it('accepts record and state', () => {
       expect(() =>
-        DestinationInput.parse({ type: 'record', stream: 's', data: {}, emitted_at: 1 })
+        DestinationInput.parse({
+          type: 'record',
+          stream: 's',
+          data: {},
+          emitted_at: '2024-01-01T00:00:00.000Z',
+        })
       ).not.toThrow()
       expect(() => DestinationInput.parse({ type: 'state', stream: 's', data: null })).not.toThrow()
     })
@@ -274,7 +286,12 @@ describe('protocol schemas', () => {
 
     it('rejects record message', () => {
       expect(() =>
-        DestinationOutput.parse({ type: 'record', stream: 's', data: {}, emitted_at: 1 })
+        DestinationOutput.parse({
+          type: 'record',
+          stream: 's',
+          data: {},
+          emitted_at: '2024-01-01T00:00:00.000Z',
+        })
       ).toThrow()
     })
   })
@@ -419,7 +436,12 @@ describe('engine message validation', () => {
     const results = await drain(
       engine.read(
         toAsync([
-          { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: Date.now() },
+          {
+            type: 'record',
+            stream: 'customers',
+            data: { id: 'cus_1' },
+            emitted_at: new Date().toISOString(),
+          },
           { type: 'state', stream: 'customers', data: { status: 'complete' } },
         ])
       )
@@ -478,7 +500,12 @@ describe('engine message validation', () => {
       drain(
         engine.sync(
           toAsync([
-            { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: Date.now() },
+            {
+              type: 'record',
+              stream: 'customers',
+              data: { id: 'cus_1' },
+              emitted_at: new Date().toISOString(),
+            },
             { type: 'state', stream: 'customers', data: { status: 'complete' } },
           ])
         )
@@ -505,7 +532,12 @@ describe('engine stream membership validation', () => {
     const results = await drain(
       engine.read(
         toAsync([
-          { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: Date.now() },
+          {
+            type: 'record',
+            stream: 'customers',
+            data: { id: 'cus_1' },
+            emitted_at: new Date().toISOString(),
+          },
           { type: 'state', stream: 'customers', data: { status: 'complete' } },
         ])
       )
@@ -566,19 +598,19 @@ describe('engine.sync() pipeline', () => {
             type: 'record',
             stream: 'customers',
             data: { id: 'cus_1', name: 'Alice' },
-            emitted_at: Date.now(),
+            emitted_at: new Date().toISOString(),
           },
           {
             type: 'record',
             stream: 'customers',
             data: { id: 'cus_2', name: 'Bob' },
-            emitted_at: Date.now(),
+            emitted_at: new Date().toISOString(),
           },
           {
             type: 'record',
             stream: 'customers',
             data: { id: 'cus_3', name: 'Charlie' },
-            emitted_at: Date.now(),
+            emitted_at: new Date().toISOString(),
           },
           { type: 'state', stream: 'customers', data: { status: 'complete' } },
         ])
@@ -607,9 +639,19 @@ describe('engine.sync() pipeline', () => {
     const results = await drain(
       engine.sync(
         toAsync([
-          { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: Date.now() },
+          {
+            type: 'record',
+            stream: 'customers',
+            data: { id: 'cus_1' },
+            emitted_at: new Date().toISOString(),
+          },
           { type: 'state', stream: 'customers', data: { status: 'complete' } },
-          { type: 'record', stream: 'invoices', data: { id: 'inv_1' }, emitted_at: Date.now() },
+          {
+            type: 'record',
+            stream: 'invoices',
+            data: { id: 'inv_1' },
+            emitted_at: new Date().toISOString(),
+          },
           { type: 'state', stream: 'invoices', data: { status: 'complete' } },
         ])
       )
@@ -649,7 +691,7 @@ describe('engine.sync() pipeline', () => {
           type: 'record' as const,
           stream: 'customers',
           data: { id: 'cus_1' },
-          emitted_at: 1000,
+          emitted_at: '2024-01-01T00:00:00.000Z',
         }
         yield {
           type: 'state' as const,

--- a/apps/engine/src/lib/pipeline.test.ts
+++ b/apps/engine/src/lib/pipeline.test.ts
@@ -60,7 +60,12 @@ async function* toAsync<T>(items: T[]): AsyncIterable<T> {
 describe('enforceCatalog()', () => {
   it('passes known record messages through unchanged when no fields configured', async () => {
     const msgs: Message[] = [
-      { type: 'record', stream: 'customers', data: { id: 'cus_1', name: 'Alice' }, emitted_at: 1 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_1', name: 'Alice' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
     ]
     const result = await drain(enforceCatalog(catalog([{ name: 'customers' }]))(toAsync(msgs)))
     expect(result).toHaveLength(1)
@@ -73,7 +78,7 @@ describe('enforceCatalog()', () => {
         type: 'record',
         stream: 'subscriptions',
         data: { id: 'sub_1', status: 'active', customer: 'cus_1' },
-        emitted_at: 1,
+        emitted_at: '2024-01-01T00:00:00.000Z',
       },
     ]
     const result = await drain(
@@ -99,7 +104,7 @@ describe('enforceCatalog()', () => {
         type: 'record',
         stream: 'subscriptions',
         data: { id: 'sub_1', status: 'active', customer: 'cus_1' },
-        emitted_at: 1,
+        emitted_at: '2024-01-01T00:00:00.000Z',
       },
     ]
     const result = await drain(enforceCatalog(catalog([{ name: 'subscriptions' }]))(toAsync(msgs)))
@@ -113,7 +118,12 @@ describe('enforceCatalog()', () => {
 
   it('drops record with unknown stream and logs error', async () => {
     const msgs: Message[] = [
-      { type: 'record', stream: 'unknown_stream', data: { id: '1' }, emitted_at: 1 },
+      {
+        type: 'record',
+        stream: 'unknown_stream',
+        data: { id: '1' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
     ]
     const result = await drain(enforceCatalog(catalog([{ name: 'customers' }]))(toAsync(msgs)))
     expect(result).toHaveLength(0)
@@ -157,7 +167,12 @@ describe('enforceCatalog()', () => {
 describe('log()', () => {
   it('passes all message types through unchanged', async () => {
     const msgs: Message[] = [
-      { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: 1 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_1' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'customers', data: { cursor: 'abc' } },
       { type: 'log', level: 'info', message: 'hello' },
       { type: 'error', failure_type: 'system_error', message: 'oops' },
@@ -198,7 +213,12 @@ describe('log()', () => {
 
   it('does not log record or state messages', async () => {
     const msgs: Message[] = [
-      { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: 1 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_1' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'customers', data: { cursor: 'abc' } },
     ]
     await drain(log(toAsync(msgs)))
@@ -215,7 +235,12 @@ describe('log()', () => {
 describe('filterType()', () => {
   it('filters to a single type', async () => {
     const msgs: Message[] = [
-      { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: 1 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_1' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'customers', data: { cursor: 'abc' } },
       { type: 'log', level: 'info', message: 'hello' },
     ]
@@ -226,7 +251,12 @@ describe('filterType()', () => {
 
   it('filters to multiple types', async () => {
     const msgs: Message[] = [
-      { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: 1 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_1' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'customers', data: { cursor: 'abc' } },
       { type: 'log', level: 'info', message: 'hello' },
       { type: 'error', failure_type: 'system_error', message: 'oops' },
@@ -324,11 +354,26 @@ describe('persistState()', () => {
 describe('takeStateCheckpoints()', () => {
   it('stops after the Nth state message', async () => {
     const msgs: Message[] = [
-      { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: 1 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_1' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'customers', data: { cursor: '1' } },
-      { type: 'record', stream: 'customers', data: { id: 'cus_2' }, emitted_at: 2 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_2' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'customers', data: { cursor: '2' } },
-      { type: 'record', stream: 'customers', data: { id: 'cus_3' }, emitted_at: 3 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_3' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
     ]
     const result = await drain(takeStateCheckpoints<Message>(1)(toAsync(msgs)))
     expect(result).toHaveLength(2)
@@ -338,7 +383,12 @@ describe('takeStateCheckpoints()', () => {
 
   it('yields everything when limit exceeds state message count', async () => {
     const msgs: Message[] = [
-      { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: 1 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_1' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'customers', data: { cursor: '1' } },
     ]
     const result = await drain(takeStateCheckpoints<Message>(5)(toAsync(msgs)))
@@ -347,11 +397,26 @@ describe('takeStateCheckpoints()', () => {
 
   it('counts state messages across multiple streams', async () => {
     const msgs: Message[] = [
-      { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: 1 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_1' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'customers', data: { cursor: 'a' } },
-      { type: 'record', stream: 'products', data: { id: 'prod_1' }, emitted_at: 2 },
+      {
+        type: 'record',
+        stream: 'products',
+        data: { id: 'prod_1' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'products', data: { cursor: 'b' } },
-      { type: 'record', stream: 'customers', data: { id: 'cus_2' }, emitted_at: 3 },
+      {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_2' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      },
       { type: 'state', stream: 'customers', data: { cursor: 'c' } },
     ]
     const result = await drain(takeStateCheckpoints<Message>(2)(toAsync(msgs)))

--- a/apps/engine/src/lib/remote-engine.test.ts
+++ b/apps/engine/src/lib/remote-engine.test.ts
@@ -122,7 +122,12 @@ describe('createRemoteEngine', () => {
     it('streams messages from input iterable', async () => {
       const engine = createRemoteEngine(engineUrl, pipeline)
       const input: Message[] = [
-        { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: 1 },
+        {
+          type: 'record',
+          stream: 'customers',
+          data: { id: 'cus_1' },
+          emitted_at: '2024-01-01T00:00:00.000Z',
+        },
         { type: 'state', stream: 'customers', data: { cursor: 'cus_1' } },
       ]
       const messages = await collect(engine.read(asIterable(input)))
@@ -143,7 +148,12 @@ describe('createRemoteEngine', () => {
     it('yields only state messages (destinationTest behaviour)', async () => {
       const engine = createRemoteEngine(engineUrl, pipeline)
       const messages: Message[] = [
-        { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: 1 },
+        {
+          type: 'record',
+          stream: 'customers',
+          data: { id: 'cus_1' },
+          emitted_at: '2024-01-01T00:00:00.000Z',
+        },
         { type: 'state', stream: 'customers', data: { cursor: 'cus_1' } },
       ]
       const output = await collect(engine.write(asIterable(messages)))
@@ -157,7 +167,12 @@ describe('createRemoteEngine', () => {
     it('runs full pipeline and yields state messages', async () => {
       const engine = createRemoteEngine(engineUrl, pipeline)
       const input: Message[] = [
-        { type: 'record', stream: 'customers', data: { id: 'cus_1' }, emitted_at: 1 },
+        {
+          type: 'record',
+          stream: 'customers',
+          data: { id: 'cus_1' },
+          emitted_at: '2024-01-01T00:00:00.000Z',
+        },
         { type: 'state', stream: 'customers', data: { cursor: 'cus_1' } },
       ]
       const output = await collect(engine.sync(asIterable(input)))

--- a/apps/visualizer/.gitignore
+++ b/apps/visualizer/.gitignore
@@ -2,3 +2,4 @@
 .next
 .env*.local
 tsconfig.tsbuildinfo
+out/

--- a/demo/write-to-postgres.sh
+++ b/demo/write-to-postgres.sh
@@ -22,8 +22,8 @@ if [ -t 0 ]; then
   CATALOG='{"streams":[{"stream":{"name":"demo","primary_key":[["id"]]},"sync_mode":"full_refresh","destination_sync_mode":"append"}]}'
   $DEST setup --config "$CONFIG" --catalog "$CATALOG"
   printf '%s\n' \
-    '{"type":"record","stream":"demo","data":{"id":"1","name":"Alice","email":"alice@example.com"},"emitted_at":0}' \
-    '{"type":"record","stream":"demo","data":{"id":"2","name":"Bob","email":"bob@example.com"},"emitted_at":0}' \
+    '{"type":"record","stream":"demo","data":{"id":"1","name":"Alice","email":"alice@example.com"},"emitted_at":"2024-01-01T00:00:00.000Z"}' \
+    '{"type":"record","stream":"demo","data":{"id":"2","name":"Bob","email":"bob@example.com"},"emitted_at":"2024-01-01T00:00:00.000Z"}' \
   | $DEST write --config "$CONFIG" --catalog "$CATALOG"
 else
   # Piped — buffer stdin, extract stream names, setup, then write

--- a/demo/write-to-sheets.sh
+++ b/demo/write-to-sheets.sh
@@ -25,8 +25,8 @@ CONFIG="{
 if [ -t 0 ]; then
   # No pipe — use sample data
   printf '%s\n' \
-    '{"type":"record","stream":"demo","data":{"id":"1","name":"Alice","email":"alice@example.com"},"emitted_at":0}' \
-    '{"type":"record","stream":"demo","data":{"id":"2","name":"Bob","email":"bob@example.com"},"emitted_at":0}' \
+    '{"type":"record","stream":"demo","data":{"id":"1","name":"Alice","email":"alice@example.com"},"emitted_at":"2024-01-01T00:00:00.000Z"}' \
+    '{"type":"record","stream":"demo","data":{"id":"2","name":"Bob","email":"bob@example.com"},"emitted_at":"2024-01-01T00:00:00.000Z"}' \
   | $RUN packages/destination-google-sheets/src/bin.ts write \
     --config "$CONFIG" --catalog '{"streams":[]}'
 else

--- a/docs/engine/ARCHITECTURE.md
+++ b/docs/engine/ARCHITECTURE.md
@@ -118,7 +118,7 @@ A single data record. The primary key is not a top-level field — it is extract
   "type": "record",
   "stream": "customers",
   "data": { "id": "cus_123", "name": "Acme" },
-  "emitted_at": 1710700000000
+  "emitted_at": "2024-03-17T00:00:00.000Z"
 }
 ```
 

--- a/docs/engine/sync-engine-examples.ts
+++ b/docs/engine/sync-engine-examples.ts
@@ -48,7 +48,7 @@ export const source: Source = {
         type: 'record',
         stream: 'users',
         data,
-        emitted_at: Date.now(),
+        emitted_at: new Date().toISOString(),
       } satisfies RecordMessage
     }
 

--- a/docs/engine/sync-engine-types.ts
+++ b/docs/engine/sync-engine-types.ts
@@ -43,8 +43,8 @@ export interface RecordMessage {
   stream: string
   /** Record payload. Schema varies by stream. */
   data: Readonly<Record<string, unknown>>
-  /** When this record was emitted by the source (epoch ms). */
-  emitted_at: number
+  /** When this record was emitted by the source (ISO 8601). */
+  emitted_at: string
 }
 
 /**

--- a/docs/slides/demo.md
+++ b/docs/slides/demo.md
@@ -17,7 +17,7 @@ No SDK. No framework. Just newline-delimited JSON.
 
 ```ts
 type Message =
-  | { type: 'record'; stream: string; data: Record<string, unknown>; emitted_at: number }
+  | { type: 'record'; stream: string; data: Record<string, unknown>; emitted_at: string }
   | { type: 'state'; stream: string; data: unknown } // cursor checkpoint
   | { type: 'log'; level: string; message: string } // diagnostic
   | { type: 'error'; failure_type: string; message: string }
@@ -27,7 +27,7 @@ type Message =
 A source produces this stream. A destination consumes it. The simplest transport is stdio.
 
 ```bash
-{"type":"record","stream":"products","data":{"id":"prod_1","name":"Widget"},"emitted_at":0}
+{"type":"record","stream":"products","data":{"id":"prod_1","name":"Widget"},"emitted_at":"2024-01-01T00:00:00.000Z"}
 {"type":"state","stream":"products","data":{"cursor":"evt_123"}}
 {"type":"log","level":"info","message":"Fetched page 1"}
 ```

--- a/docs/slides/step2-dest.sh
+++ b/docs/slides/step2-dest.sh
@@ -8,7 +8,7 @@ CATALOG='{"streams":[{"stream":{"name":"products"},"sync_mode":"full_refresh","d
 DST_CONFIG='{"connection_string":"'"$POSTGRES_URL"'","schema":"'"$SCHEMA"'"}'
 
 dest-postgres setup --config "$DST_CONFIG" --catalog "$CATALOG"
-echo '{"type":"record","stream":"products","data":{"id":"prod_1","name":"Widget"},"emitted_at":0}' \
+echo '{"type":"record","stream":"products","data":{"id":"prod_1","name":"Widget"},"emitted_at":"2024-01-01T00:00:00.000Z"}' \
   | dest-postgres write --config "$DST_CONFIG" --catalog "$CATALOG"
 
 psql "$POSTGRES_URL" -c "SELECT id, _raw_data->>'name' AS name FROM \"$SCHEMA\".products"

--- a/packages/destination-google-sheets/src/index.test.ts
+++ b/packages/destination-google-sheets/src/index.test.ts
@@ -16,7 +16,7 @@ async function* toAsyncIter<T>(items: T[]): AsyncIterableIterator<T> {
   for (const item of items) yield item
 }
 
-const now = Date.now()
+const now = new Date().toISOString()
 
 function record(stream: string, data: Record<string, unknown>): DestinationInput {
   return { type: 'record', stream, data, emitted_at: now }

--- a/packages/destination-postgres/src/index.test.ts
+++ b/packages/destination-postgres/src/index.test.ts
@@ -74,7 +74,7 @@ beforeEach(async () => {
 // ---------------------------------------------------------------------------
 
 function makeRecord(stream: string, data: Record<string, unknown>): RecordMessage {
-  return { type: 'record', stream, data, emitted_at: Date.now() }
+  return { type: 'record', stream, data, emitted_at: new Date().toISOString() }
 }
 
 function makeState(stream: string, data: unknown): StateMessage {

--- a/packages/protocol/src/__tests__/cli.test.ts
+++ b/packages/protocol/src/__tests__/cli.test.ts
@@ -11,7 +11,12 @@ const mockSource: Source = {
   check: async () => ({ status: 'succeeded' }) as CheckResult,
   discover: async () => ({ type: 'catalog', streams: [] }),
   async *read() {
-    yield { type: 'record', stream: 'test', data: { id: '1' }, emitted_at: Date.now() }
+    yield {
+      type: 'record',
+      stream: 'test',
+      data: { id: '1' },
+      emitted_at: new Date().toISOString(),
+    }
   },
 }
 

--- a/packages/protocol/src/helpers.ts
+++ b/packages/protocol/src/helpers.ts
@@ -17,7 +17,7 @@ export function toRecordMessage(stream: string, data: Record<string, unknown>): 
     type: 'record',
     stream,
     data,
-    emitted_at: Date.now(),
+    emitted_at: new Date().toISOString(),
   }
 }
 

--- a/packages/protocol/src/protocol.ts
+++ b/packages/protocol/src/protocol.ts
@@ -110,7 +110,7 @@ export const RecordMessage = z
     type: z.literal('record'),
     stream: z.string(),
     data: z.record(z.string(), z.unknown()),
-    emitted_at: z.number(),
+    emitted_at: z.string().datetime(),
   })
   .meta({ id: 'RecordMessage' })
 export type RecordMessage = z.infer<typeof RecordMessage>

--- a/packages/source-stripe/src/index.test.ts
+++ b/packages/source-stripe/src/index.test.ts
@@ -400,7 +400,7 @@ describe('StripeSource', () => {
         object: 'customer',
         name: 'Alice',
       })
-      expect(result!.record.emitted_at).toBeTypeOf('number')
+      expect(result!.record.emitted_at).toBeTypeOf('string')
 
       expect(result!.state.type).toBe('state')
       expect(result!.state.stream).toBe('customers')

--- a/packages/ts-cli/src/openapi/command.test.ts
+++ b/packages/ts-cli/src/openapi/command.test.ts
@@ -375,7 +375,8 @@ describe('ndjsonBodyStream', () => {
       )
     })
 
-    const ndjsonLine = '{"type":"record","stream":"test","data":{"id":"1"},"emitted_at":0}'
+    const ndjsonLine =
+      '{"type":"record","stream":"test","data":{"id":"1"},"emitted_at":"2024-01-01T00:00:00.000Z"}'
     const encoder = new TextEncoder()
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {


### PR DESCRIPTION
## Summary

- `emitted_at` on `RecordMessage` was `number` (epoch milliseconds, Airbyte-style) — changed to `string` (ISO 8601 via `z.string().datetime()`)
- Nothing in the engine or destinations acts on the value; it's pure metadata about when the source emitted the record
- ISO 8601 is strictly better: human-readable in NDJSON output, self-describing, no ambiguity about epoch/unit, maps cleanly to Postgres `timestamptz`
- Also adds `apps/visualizer/out/` to `.gitignore` (was missing)

## Files changed

- `packages/protocol/src/protocol.ts` — `z.number()` → `z.string().datetime()`
- `packages/protocol/src/helpers.ts` — `Date.now()` → `new Date().toISOString()`
- All connectors, tests, demos, and docs updated

## Test plan

- [ ] `pnpm build` passes
- [ ] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)