### PR TITLE
feat(protocol): eof terminal message + state_limit/time_limit query params

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,11 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Check generated OpenAPI files
+        run: ./scripts/generate-openapi.sh --check
+        env:
+          STRIPE_API_KEY: 'sk_test_placeholder'
+
       - name: Ensure all shell tests are wired up
         run: |
           missing=()

--- a/apps/engine/src/__generated__/openapi.d.ts
+++ b/apps/engine/src/__generated__/openapi.d.ts
@@ -4,819 +4,799 @@
  */
 
 export interface paths {
-  '/health': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Health check */
-    get: operations['health']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/setup': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /**
-     * Set up destination schema
-     * @description Creates destination tables and applies migrations. Safe to call multiple times.
-     */
-    post: operations['setup']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/teardown': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /**
-     * Tear down destination schema
-     * @description Drops destination tables. Irreversible.
-     */
-    post: operations['teardown']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/check': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /**
-     * Check connector connection
-     * @description Validates the source/destination config and tests connectivity.
-     */
-    get: operations['check']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/discover': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /**
-     * Discover available streams
-     * @description Returns the catalog of available streams for the configured source. Each stream includes its name, primary key, and optional JSON schema.
-     */
-    post: operations['discover']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/read': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /**
-     * Read records from source
-     * @description Streams NDJSON messages (records, state, catalog). Optional NDJSON body provides live events as input.
-     */
-    post: operations['read']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/write': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /**
-     * Write records to destination
-     * @description Reads NDJSON messages from the request body and writes them to the destination. Pipe /read output as input.
-     */
-    post: operations['write']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/sync': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /**
-     * Run sync pipeline (read → write)
-     * @description Without a request body, reads from the source connector and writes to the destination (backfill mode). With an NDJSON request body, uses the provided messages as input instead of reading from the source (push mode — e.g. piped webhook events).
-     */
-    post: operations['sync']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/connectors': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** List available connectors and their config schemas */
-    get: operations['listConnectors']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Health check */
+        get: operations["health"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/setup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Set up destination schema
+         * @description Creates destination tables and applies migrations. Safe to call multiple times.
+         */
+        post: operations["setup"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/teardown": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Tear down destination schema
+         * @description Drops destination tables. Irreversible.
+         */
+        post: operations["teardown"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/check": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Check connector connection
+         * @description Validates the source/destination config and tests connectivity.
+         */
+        get: operations["check"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/discover": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Discover available streams
+         * @description Returns the catalog of available streams for the configured source. Each stream includes its name, primary key, and optional JSON schema.
+         */
+        post: operations["discover"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/read": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Read records from source
+         * @description Streams NDJSON messages (records, state, catalog). Optional NDJSON body provides live events as input.
+         */
+        post: operations["read"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/write": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Write records to destination
+         * @description Reads NDJSON messages from the request body and writes them to the destination. Pipe /read output as input.
+         */
+        post: operations["write"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sync": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Run sync pipeline (read → write)
+         * @description Without a request body, reads from the source connector and writes to the destination (backfill mode). With an NDJSON request body, uses the provided messages as input instead of reading from the source (push mode — e.g. piped webhook events).
+         */
+        post: operations["sync"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/connectors": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List available connectors and their config schemas */
+        get: operations["listConnectors"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
-export type webhooks = Record<string, never>
+export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    Message:
-      | components['schemas']['RecordMessage']
-      | components['schemas']['StateMessage']
-      | components['schemas']['CatalogMessage']
-      | components['schemas']['LogMessage']
-      | components['schemas']['ErrorMessage']
-      | components['schemas']['StreamStatusMessage']
-      | components['schemas']['EofMessage']
-    RecordMessage: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'record'
-      stream: string
-      data: {
-        [key: string]: unknown
-      }
-      /** Format: date-time */
-      emitted_at: string
-    }
-    StateMessage: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'state'
-      stream: string
-      data: unknown
-    }
-    CatalogMessage: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'catalog'
-      streams: {
-        name: string
-        primary_key: string[][]
-        json_schema?: {
-          [key: string]: unknown
-        }
-        metadata?: {
-          [key: string]: unknown
-        }
-      }[]
-    }
-    LogMessage: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'log'
-      /** @enum {string} */
-      level: 'debug' | 'info' | 'warn' | 'error'
-      message: string
-    }
-    ErrorMessage: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'error'
-      /** @enum {string} */
-      failure_type: 'config_error' | 'system_error' | 'transient_error' | 'auth_error'
-      message: string
-      stream?: string
-      stack_trace?: string
-    }
-    StreamStatusMessage: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'stream_status'
-      stream: string
-      /** @enum {string} */
-      status: 'started' | 'running' | 'complete' | 'incomplete'
-    }
-    EofMessage: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'eof'
-      /** @enum {string} */
-      reason: 'complete' | 'state_limit' | 'time_limit' | 'error'
-    }
-    DestinationOutput:
-      | components['schemas']['StateMessageOutput']
-      | components['schemas']['ErrorMessageOutput']
-      | components['schemas']['LogMessageOutput']
-      | components['schemas']['EofMessageOutput']
-    CatalogMessageOutput: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'catalog'
-      streams: {
-        name: string
-        primary_key: string[][]
-        json_schema?: {
-          [key: string]: unknown
-        }
-        metadata?: {
-          [key: string]: unknown
-        }
-      }[]
-    }
-    MessageOutput:
-      | components['schemas']['RecordMessageOutput']
-      | components['schemas']['StateMessageOutput']
-      | components['schemas']['CatalogMessageOutput']
-      | components['schemas']['LogMessageOutput']
-      | components['schemas']['ErrorMessageOutput']
-      | components['schemas']['StreamStatusMessageOutput']
-      | components['schemas']['EofMessageOutput']
-    RecordMessageOutput: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'record'
-      stream: string
-      data: {
-        [key: string]: unknown
-      }
-      /** Format: date-time */
-      emitted_at: string
-    }
-    StateMessageOutput: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'state'
-      stream: string
-      data: unknown
-    }
-    LogMessageOutput: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'log'
-      /** @enum {string} */
-      level: 'debug' | 'info' | 'warn' | 'error'
-      message: string
-    }
-    ErrorMessageOutput: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'error'
-      /** @enum {string} */
-      failure_type: 'config_error' | 'system_error' | 'transient_error' | 'auth_error'
-      message: string
-      stream?: string
-      stack_trace?: string
-    }
-    StreamStatusMessageOutput: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'stream_status'
-      stream: string
-      /** @enum {string} */
-      status: 'started' | 'running' | 'complete' | 'incomplete'
-    }
-    EofMessageOutput: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'eof'
-      /** @enum {string} */
-      reason: 'complete' | 'state_limit' | 'time_limit' | 'error'
-    }
-    StripeSourceConfig: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'StripeSourceConfig'
-      /** @description Stripe API key (sk_test_... or sk_live_...) */
-      api_key: string
-      /** @description Stripe account ID (resolved from API if omitted) */
-      account_id?: string
-      /** @description Whether this is a live mode sync */
-      livemode?: boolean
-      /** @description Stripe API version (e.g. 2025-04-30.basil) */
-      api_version?: string
-      /**
-       * Format: uri
-       * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
-       */
-      base_url?: string
-      /**
-       * Format: uri
-       * @description URL for managed webhook endpoint registration
-       */
-      webhook_url?: string
-      /** @description Webhook signing secret (whsec_...) for signature verification */
-      webhook_secret?: string
-      /** @description Enable WebSocket streaming for live events */
-      websocket?: boolean
-      /** @description Enable events API polling for incremental sync after backfill */
-      poll_events?: boolean
-      /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
-      webhook_port?: number
-      /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
-      revalidate_objects?: string[]
-      /** @description Max objects to backfill per stream (useful for testing) */
-      backfill_limit?: number
-      /** @description Max Stripe API requests per second (default: 25) */
-      rate_limit?: number
-      /** @description Number of time-range segments for parallel backfill (default: 200) */
-      backfill_concurrency?: number
-    }
-    PostgresDestinationConfig: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'PostgresDestinationConfig'
-      /** @description Postgres connection string (alias for connection_string) */
-      url?: string
-      /** @description Postgres connection string */
-      connection_string?: string
-      /** @description Postgres host (required for AWS IAM) */
-      host?: string
-      /**
-       * @description Postgres port
-       * @default 5432
-       */
-      port: number
-      /** @description Database name (required for AWS IAM) */
-      database?: string
-      /** @description Database user (required for AWS IAM) */
-      user?: string
-      /** @description Target schema name (e.g. "stripe_sync") */
-      schema: string
-      /**
-       * @description Records to buffer before flushing
-       * @default 100
-       */
-      batch_size: number
-      /** @description AWS RDS IAM authentication config */
-      aws?: {
-        /** @description AWS region for RDS instance */
-        region: string
-        /** @description IAM role ARN to assume (cross-account) */
-        role_arn?: string
-        /** @description External ID for STS AssumeRole */
-        external_id?: string
-      }
-      /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
-      ssl_ca_pem?: string
-    }
-    GoogleSheetsDestinationConfig: {
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: 'GoogleSheetsDestinationConfig'
-      /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
-      client_id?: string
-      /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
-      client_secret?: string
-      /** @description OAuth2 access token */
-      access_token: string
-      /** @description OAuth2 refresh token */
-      refresh_token: string
-      /** @description Target spreadsheet ID (created if omitted) */
-      spreadsheet_id?: string
-      /**
-       * @description Title when creating a new spreadsheet
-       * @default Stripe Sync
-       */
-      spreadsheet_title: string
-      /**
-       * @description Rows per Sheets API append call
-       * @default 50
-       */
-      batch_size: number
-    }
-    SourceConfig: components['schemas']['StripeSourceConfig']
-    DestinationConfig:
-      | components['schemas']['PostgresDestinationConfig']
-      | components['schemas']['GoogleSheetsDestinationConfig']
-    PipelineConfig: {
-      source: components['schemas']['SourceConfig']
-      destination: components['schemas']['DestinationConfig']
-      streams?: {
-        name: string
-        /** @enum {string} */
-        sync_mode?: 'incremental' | 'full_refresh'
-        fields?: string[]
-      }[]
-    }
-  }
-  responses: never
-  parameters: never
-  requestBodies: never
-  headers: never
-  pathItems: never
+    schemas: {
+        Message: components["schemas"]["RecordMessage"] | components["schemas"]["StateMessage"] | components["schemas"]["CatalogMessage"] | components["schemas"]["LogMessage"] | components["schemas"]["ErrorMessage"] | components["schemas"]["StreamStatusMessage"] | components["schemas"]["EofMessage"];
+        RecordMessage: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "record";
+            stream: string;
+            data: {
+                [key: string]: unknown;
+            };
+            /** Format: date-time */
+            emitted_at: string;
+        };
+        StateMessage: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "state";
+            stream: string;
+            data: unknown;
+        };
+        CatalogMessage: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "catalog";
+            streams: {
+                name: string;
+                primary_key: string[][];
+                json_schema?: {
+                    [key: string]: unknown;
+                };
+                metadata?: {
+                    [key: string]: unknown;
+                };
+            }[];
+        };
+        LogMessage: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "log";
+            /** @enum {string} */
+            level: "debug" | "info" | "warn" | "error";
+            message: string;
+        };
+        ErrorMessage: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "error";
+            /** @enum {string} */
+            failure_type: "config_error" | "system_error" | "transient_error" | "auth_error";
+            message: string;
+            stream?: string;
+            stack_trace?: string;
+        };
+        StreamStatusMessage: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "stream_status";
+            stream: string;
+            /** @enum {string} */
+            status: "started" | "running" | "complete" | "incomplete";
+        };
+        EofMessage: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "eof";
+            /** @enum {string} */
+            reason: "complete" | "state_limit" | "time_limit" | "error";
+        };
+        DestinationOutput: components["schemas"]["StateMessageOutput"] | components["schemas"]["ErrorMessageOutput"] | components["schemas"]["LogMessageOutput"] | components["schemas"]["EofMessageOutput"];
+        CatalogMessageOutput: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "catalog";
+            streams: {
+                name: string;
+                primary_key: string[][];
+                json_schema?: {
+                    [key: string]: unknown;
+                };
+                metadata?: {
+                    [key: string]: unknown;
+                };
+            }[];
+        };
+        MessageOutput: components["schemas"]["RecordMessageOutput"] | components["schemas"]["StateMessageOutput"] | components["schemas"]["CatalogMessageOutput"] | components["schemas"]["LogMessageOutput"] | components["schemas"]["ErrorMessageOutput"] | components["schemas"]["StreamStatusMessageOutput"] | components["schemas"]["EofMessageOutput"];
+        RecordMessageOutput: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "record";
+            stream: string;
+            data: {
+                [key: string]: unknown;
+            };
+            /** Format: date-time */
+            emitted_at: string;
+        };
+        StateMessageOutput: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "state";
+            stream: string;
+            data: unknown;
+        };
+        LogMessageOutput: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "log";
+            /** @enum {string} */
+            level: "debug" | "info" | "warn" | "error";
+            message: string;
+        };
+        ErrorMessageOutput: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "error";
+            /** @enum {string} */
+            failure_type: "config_error" | "system_error" | "transient_error" | "auth_error";
+            message: string;
+            stream?: string;
+            stack_trace?: string;
+        };
+        StreamStatusMessageOutput: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "stream_status";
+            stream: string;
+            /** @enum {string} */
+            status: "started" | "running" | "complete" | "incomplete";
+        };
+        EofMessageOutput: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "eof";
+            /** @enum {string} */
+            reason: "complete" | "state_limit" | "time_limit" | "error";
+        };
+        StripeSourceConfig: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "StripeSourceConfig";
+            /** @description Stripe API key (sk_test_... or sk_live_...) */
+            api_key: string;
+            /** @description Stripe account ID (resolved from API if omitted) */
+            account_id?: string;
+            /** @description Whether this is a live mode sync */
+            livemode?: boolean;
+            /** @description Stripe API version (e.g. 2025-04-30.basil) */
+            api_version?: string;
+            /**
+             * Format: uri
+             * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
+             */
+            base_url?: string;
+            /**
+             * Format: uri
+             * @description URL for managed webhook endpoint registration
+             */
+            webhook_url?: string;
+            /** @description Webhook signing secret (whsec_...) for signature verification */
+            webhook_secret?: string;
+            /** @description Enable WebSocket streaming for live events */
+            websocket?: boolean;
+            /** @description Enable events API polling for incremental sync after backfill */
+            poll_events?: boolean;
+            /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
+            webhook_port?: number;
+            /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
+            revalidate_objects?: string[];
+            /** @description Max objects to backfill per stream (useful for testing) */
+            backfill_limit?: number;
+            /** @description Max Stripe API requests per second (default: 25) */
+            rate_limit?: number;
+            /** @description Number of time-range segments for parallel backfill (default: 200) */
+            backfill_concurrency?: number;
+        };
+        PostgresDestinationConfig: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "PostgresDestinationConfig";
+            /** @description Postgres connection string (alias for connection_string) */
+            url?: string;
+            /** @description Postgres connection string */
+            connection_string?: string;
+            /** @description Postgres host (required for AWS IAM) */
+            host?: string;
+            /**
+             * @description Postgres port
+             * @default 5432
+             */
+            port: number;
+            /** @description Database name (required for AWS IAM) */
+            database?: string;
+            /** @description Database user (required for AWS IAM) */
+            user?: string;
+            /** @description Target schema name (e.g. "stripe_sync") */
+            schema: string;
+            /**
+             * @description Records to buffer before flushing
+             * @default 100
+             */
+            batch_size: number;
+            /** @description AWS RDS IAM authentication config */
+            aws?: {
+                /** @description AWS region for RDS instance */
+                region: string;
+                /** @description IAM role ARN to assume (cross-account) */
+                role_arn?: string;
+                /** @description External ID for STS AssumeRole */
+                external_id?: string;
+            };
+            /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
+            ssl_ca_pem?: string;
+        };
+        GoogleSheetsDestinationConfig: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "GoogleSheetsDestinationConfig";
+            /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
+            client_id?: string;
+            /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
+            client_secret?: string;
+            /** @description OAuth2 access token */
+            access_token: string;
+            /** @description OAuth2 refresh token */
+            refresh_token: string;
+            /** @description Target spreadsheet ID (created if omitted) */
+            spreadsheet_id?: string;
+            /**
+             * @description Title when creating a new spreadsheet
+             * @default Stripe Sync
+             */
+            spreadsheet_title: string;
+            /**
+             * @description Rows per Sheets API append call
+             * @default 50
+             */
+            batch_size: number;
+        };
+        SourceConfig: components["schemas"]["StripeSourceConfig"];
+        DestinationConfig: components["schemas"]["PostgresDestinationConfig"] | components["schemas"]["GoogleSheetsDestinationConfig"];
+        PipelineConfig: {
+            source: components["schemas"]["SourceConfig"];
+            destination: components["schemas"]["DestinationConfig"];
+            streams?: {
+                name: string;
+                /** @enum {string} */
+                sync_mode?: "incremental" | "full_refresh";
+                fields?: string[];
+            }[];
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
-export type $defs = Record<string, never>
+export type $defs = Record<string, never>;
 export interface operations {
-  health: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Server is healthy */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            /** @constant */
-            ok: true
-          }
-        }
-      }
-    }
-  }
-  setup: {
-    parameters: {
-      query?: never
-      header?: {
-        /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
-        'x-pipeline'?: string
-      }
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Setup complete */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            [key: string]: unknown
-          }
-        }
-      }
-      /** @description Invalid params */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            error: unknown
-          }
-        }
-      }
-    }
-  }
-  teardown: {
-    parameters: {
-      query?: never
-      header?: {
-        /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
-        'x-pipeline'?: string
-      }
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Teardown complete */
-      204: {
-        headers: {
-          [name: string]: unknown
-        }
-        content?: never
-      }
-      /** @description Invalid params */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            error: unknown
-          }
-        }
-      }
-    }
-  }
-  check: {
-    parameters: {
-      query?: never
-      header?: {
-        /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
-        'x-pipeline'?: string
-      }
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Connection check result */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            source: {
-              /** @enum {string} */
-              status: 'succeeded' | 'failed'
-              message?: string
-            }
-            destination: {
-              /** @enum {string} */
-              status: 'succeeded' | 'failed'
-              message?: string
-            }
-          }
-        }
-      }
-      /** @description Invalid params */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            error: unknown
-          }
-        }
-      }
-    }
-  }
-  discover: {
-    parameters: {
-      query?: never
-      header?: {
-        /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
-        'x-pipeline'?: string
-      }
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Available streams */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['CatalogMessageOutput']
-        }
-      }
-      /** @description Invalid params */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            error: unknown
-          }
-        }
-      }
-    }
-  }
-  read: {
-    parameters: {
-      query?: {
-        /** @description Stop streaming after N state messages. */
-        state_limit?: number
-        /** @description Stop streaming after N seconds. */
-        time_limit?: number
-      }
-      header?: {
-        /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
-        'x-pipeline'?: string
-        /** @description JSON-encoded per-stream cursor state. Engine uses this if present, falls back to StateStore. */
-        'x-state'?: string
-      }
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description NDJSON stream of sync messages */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/x-ndjson': components['schemas']['MessageOutput']
-        }
-      }
-      /** @description Invalid params */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            error: unknown
-          }
-        }
-      }
-    }
-  }
-  write: {
-    parameters: {
-      query?: never
-      header?: {
-        /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
-        'x-pipeline'?: string
-      }
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        'application/x-ndjson': components['schemas']['Message']
-      }
-    }
-    responses: {
-      /** @description NDJSON stream of write result messages */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/x-ndjson': components['schemas']['DestinationOutput']
-        }
-      }
-      /** @description Invalid params */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            error: unknown
-          }
-        }
-      }
-    }
-  }
-  sync: {
-    parameters: {
-      query?: {
-        /** @description Stop streaming after N state messages. */
-        state_limit?: number
-        /** @description Stop streaming after N seconds. */
-        time_limit?: number
-      }
-      header?: {
-        /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
-        'x-pipeline'?: string
-        /** @description JSON-encoded per-stream cursor state. Engine uses this if present, falls back to StateStore. */
-        'x-state'?: string
-      }
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description NDJSON stream of sync messages */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/x-ndjson': components['schemas']['DestinationOutput']
-        }
-      }
-      /** @description Invalid params */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            error: unknown
-          }
-        }
-      }
-    }
-  }
-  listConnectors: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Available connectors with their JSON Schema configs */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            sources: {
-              [key: string]: {
-                config_schema: {
-                  [key: string]: unknown
-                }
-              }
-            }
-            destinations: {
-              [key: string]: {
-                config_schema: {
-                  [key: string]: unknown
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
+    health: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Server is healthy */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        ok: true;
+                    };
+                };
+            };
+        };
+    };
+    setup: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
+                "x-pipeline"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Setup complete */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Invalid params */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: unknown;
+                    };
+                };
+            };
+        };
+    };
+    teardown: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
+                "x-pipeline"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Teardown complete */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid params */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: unknown;
+                    };
+                };
+            };
+        };
+    };
+    check: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
+                "x-pipeline"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Connection check result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        source: {
+                            /** @enum {string} */
+                            status: "succeeded" | "failed";
+                            message?: string;
+                        };
+                        destination: {
+                            /** @enum {string} */
+                            status: "succeeded" | "failed";
+                            message?: string;
+                        };
+                    };
+                };
+            };
+            /** @description Invalid params */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: unknown;
+                    };
+                };
+            };
+        };
+    };
+    discover: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
+                "x-pipeline"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Available streams */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CatalogMessageOutput"];
+                };
+            };
+            /** @description Invalid params */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: unknown;
+                    };
+                };
+            };
+        };
+    };
+    read: {
+        parameters: {
+            query?: {
+                /** @description Stop streaming after N state messages. */
+                state_limit?: number;
+                /** @description Stop streaming after N seconds. */
+                time_limit?: number;
+            };
+            header?: {
+                /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
+                "x-pipeline"?: string;
+                /** @description JSON-encoded per-stream cursor state. Engine uses this if present, falls back to StateStore. */
+                "x-state"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description NDJSON stream of sync messages */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/x-ndjson": components["schemas"]["MessageOutput"];
+                };
+            };
+            /** @description Invalid params */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: unknown;
+                    };
+                };
+            };
+        };
+    };
+    write: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
+                "x-pipeline"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/x-ndjson": components["schemas"]["Message"];
+            };
+        };
+        responses: {
+            /** @description NDJSON stream of write result messages */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/x-ndjson": components["schemas"]["DestinationOutput"];
+                };
+            };
+            /** @description Invalid params */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: unknown;
+                    };
+                };
+            };
+        };
+    };
+    sync: {
+        parameters: {
+            query?: {
+                /** @description Stop streaming after N state messages. */
+                state_limit?: number;
+                /** @description Stop streaming after N seconds. */
+                time_limit?: number;
+            };
+            header?: {
+                /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
+                "x-pipeline"?: string;
+                /** @description JSON-encoded per-stream cursor state. Engine uses this if present, falls back to StateStore. */
+                "x-state"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description NDJSON stream of sync messages */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/x-ndjson": components["schemas"]["DestinationOutput"];
+                };
+            };
+            /** @description Invalid params */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: unknown;
+                    };
+                };
+            };
+        };
+    };
+    listConnectors: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Available connectors with their JSON Schema configs */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        sources: {
+                            [key: string]: {
+                                config_schema: {
+                                    [key: string]: unknown;
+                                };
+                            };
+                        };
+                        destinations: {
+                            [key: string]: {
+                                config_schema: {
+                                    [key: string]: unknown;
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+    };
 }

--- a/apps/engine/src/__generated__/openapi.d.ts
+++ b/apps/engine/src/__generated__/openapi.d.ts
@@ -189,6 +189,7 @@ export interface components {
       | components['schemas']['LogMessage']
       | components['schemas']['ErrorMessage']
       | components['schemas']['StreamStatusMessage']
+      | components['schemas']['EofMessage']
     RecordMessage: {
       /**
        * @description discriminator enum property added by openapi-typescript
@@ -199,7 +200,8 @@ export interface components {
       data: {
         [key: string]: unknown
       }
-      emitted_at: number
+      /** Format: date-time */
+      emitted_at: string
     }
     StateMessage: {
       /**
@@ -259,10 +261,20 @@ export interface components {
       /** @enum {string} */
       status: 'started' | 'running' | 'complete' | 'incomplete'
     }
+    EofMessage: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'eof'
+      /** @enum {string} */
+      reason: 'complete' | 'state_limit' | 'time_limit' | 'error'
+    }
     DestinationOutput:
       | components['schemas']['StateMessageOutput']
       | components['schemas']['ErrorMessageOutput']
       | components['schemas']['LogMessageOutput']
+      | components['schemas']['EofMessageOutput']
     CatalogMessageOutput: {
       /**
        * @description discriminator enum property added by openapi-typescript
@@ -287,6 +299,7 @@ export interface components {
       | components['schemas']['LogMessageOutput']
       | components['schemas']['ErrorMessageOutput']
       | components['schemas']['StreamStatusMessageOutput']
+      | components['schemas']['EofMessageOutput']
     RecordMessageOutput: {
       /**
        * @description discriminator enum property added by openapi-typescript
@@ -297,7 +310,8 @@ export interface components {
       data: {
         [key: string]: unknown
       }
-      emitted_at: number
+      /** Format: date-time */
+      emitted_at: string
     }
     StateMessageOutput: {
       /**
@@ -339,6 +353,15 @@ export interface components {
       stream: string
       /** @enum {string} */
       status: 'started' | 'running' | 'complete' | 'incomplete'
+    }
+    EofMessageOutput: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'eof'
+      /** @enum {string} */
+      reason: 'complete' | 'state_limit' | 'time_limit' | 'error'
     }
     StripeSourceConfig: {
       /**
@@ -643,14 +666,17 @@ export interface operations {
   }
   read: {
     parameters: {
-      query?: never
+      query?: {
+        /** @description Stop streaming after N state messages. */
+        state_limit?: number
+        /** @description Stop streaming after N seconds. */
+        time_limit?: number
+      }
       header?: {
         /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
         'x-pipeline'?: string
         /** @description JSON-encoded per-stream cursor state. Engine uses this if present, falls back to StateStore. */
         'x-state'?: string
-        /** @description When set, stops streaming after N state checkpoint messages. Enables page-at-a-time sync. */
-        'x-state-checkpoint-limit'?: number
       }
       path?: never
       cookie?: never
@@ -719,14 +745,17 @@ export interface operations {
   }
   sync: {
     parameters: {
-      query?: never
+      query?: {
+        /** @description Stop streaming after N state messages. */
+        state_limit?: number
+        /** @description Stop streaming after N seconds. */
+        time_limit?: number
+      }
       header?: {
         /** @description JSON-encoded PipelineConfig: { source: { type, ...config }, destination: { type, ...config }, streams } */
         'x-pipeline'?: string
         /** @description JSON-encoded per-stream cursor state. Engine uses this if present, falls back to StateStore. */
         'x-state'?: string
-        /** @description When set, stops streaming after N state checkpoint messages. Enables page-at-a-time sync. */
-        'x-state-checkpoint-limit'?: number
       }
       path?: never
       cookie?: never

--- a/apps/engine/src/__generated__/openapi.json
+++ b/apps/engine/src/__generated__/openapi.json
@@ -243,16 +243,27 @@
             }
           },
           {
-            "in": "header",
-            "name": "x-state-checkpoint-limit",
+            "in": "query",
+            "name": "state_limit",
             "schema": {
-              "description": "When set, stops streaming after N state checkpoint messages. Enables page-at-a-time sync.",
-              "example": "1",
+              "description": "Stop streaming after N state messages.",
+              "example": "100",
               "type": "integer",
               "exclusiveMinimum": 0,
               "maximum": 9007199254740991
             },
-            "description": "When set, stops streaming after N state checkpoint messages. Enables page-at-a-time sync."
+            "description": "Stop streaming after N state messages."
+          },
+          {
+            "in": "query",
+            "name": "time_limit",
+            "schema": {
+              "description": "Stop streaming after N seconds.",
+              "example": "10",
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "description": "Stop streaming after N seconds."
           }
         ],
         "responses": {
@@ -355,16 +366,27 @@
             }
           },
           {
-            "in": "header",
-            "name": "x-state-checkpoint-limit",
+            "in": "query",
+            "name": "state_limit",
             "schema": {
-              "description": "When set, stops streaming after N state checkpoint messages. Enables page-at-a-time sync.",
-              "example": "1",
+              "description": "Stop streaming after N state messages.",
+              "example": "100",
               "type": "integer",
               "exclusiveMinimum": 0,
               "maximum": 9007199254740991
             },
-            "description": "When set, stops streaming after N state checkpoint messages. Enables page-at-a-time sync."
+            "description": "Stop streaming after N state messages."
+          },
+          {
+            "in": "query",
+            "name": "time_limit",
+            "schema": {
+              "description": "Stop streaming after N seconds.",
+              "example": "10",
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "description": "Stop streaming after N seconds."
           }
         ],
         "responses": {
@@ -457,7 +479,8 @@
           { "$ref": "#/components/schemas/CatalogMessage" },
           { "$ref": "#/components/schemas/LogMessage" },
           { "$ref": "#/components/schemas/ErrorMessage" },
-          { "$ref": "#/components/schemas/StreamStatusMessage" }
+          { "$ref": "#/components/schemas/StreamStatusMessage" },
+          { "$ref": "#/components/schemas/EofMessage" }
         ],
         "type": "object",
         "discriminator": {
@@ -468,7 +491,8 @@
             "catalog": "#/components/schemas/CatalogMessage",
             "log": "#/components/schemas/LogMessage",
             "error": "#/components/schemas/ErrorMessage",
-            "stream_status": "#/components/schemas/StreamStatusMessage"
+            "stream_status": "#/components/schemas/StreamStatusMessage",
+            "eof": "#/components/schemas/EofMessage"
           }
         }
       },
@@ -482,7 +506,11 @@
             "propertyNames": { "type": "string" },
             "additionalProperties": {}
           },
-          "emitted_at": { "type": "number" }
+          "emitted_at": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+          }
         },
         "required": ["type", "stream", "data", "emitted_at"]
       },
@@ -558,11 +586,20 @@
         },
         "required": ["type", "stream", "status"]
       },
+      "EofMessage": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "const": "eof" },
+          "reason": { "type": "string", "enum": ["complete", "state_limit", "time_limit", "error"] }
+        },
+        "required": ["type", "reason"]
+      },
       "DestinationOutput": {
         "oneOf": [
           { "$ref": "#/components/schemas/StateMessageOutput" },
           { "$ref": "#/components/schemas/ErrorMessageOutput" },
-          { "$ref": "#/components/schemas/LogMessageOutput" }
+          { "$ref": "#/components/schemas/LogMessageOutput" },
+          { "$ref": "#/components/schemas/EofMessageOutput" }
         ],
         "type": "object",
         "discriminator": {
@@ -570,7 +607,8 @@
           "mapping": {
             "state": "#/components/schemas/StateMessageOutput",
             "error": "#/components/schemas/ErrorMessageOutput",
-            "log": "#/components/schemas/LogMessageOutput"
+            "log": "#/components/schemas/LogMessageOutput",
+            "eof": "#/components/schemas/EofMessageOutput"
           }
         }
       },
@@ -614,7 +652,8 @@
           { "$ref": "#/components/schemas/CatalogMessageOutput" },
           { "$ref": "#/components/schemas/LogMessageOutput" },
           { "$ref": "#/components/schemas/ErrorMessageOutput" },
-          { "$ref": "#/components/schemas/StreamStatusMessageOutput" }
+          { "$ref": "#/components/schemas/StreamStatusMessageOutput" },
+          { "$ref": "#/components/schemas/EofMessageOutput" }
         ],
         "type": "object",
         "discriminator": {
@@ -625,7 +664,8 @@
             "catalog": "#/components/schemas/CatalogMessageOutput",
             "log": "#/components/schemas/LogMessageOutput",
             "error": "#/components/schemas/ErrorMessageOutput",
-            "stream_status": "#/components/schemas/StreamStatusMessageOutput"
+            "stream_status": "#/components/schemas/StreamStatusMessageOutput",
+            "eof": "#/components/schemas/EofMessageOutput"
           }
         }
       },
@@ -639,7 +679,11 @@
             "propertyNames": { "type": "string" },
             "additionalProperties": {}
           },
-          "emitted_at": { "type": "number" }
+          "emitted_at": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+          }
         },
         "required": ["type", "stream", "data", "emitted_at"],
         "additionalProperties": false
@@ -687,6 +731,15 @@
           "status": { "type": "string", "enum": ["started", "running", "complete", "incomplete"] }
         },
         "required": ["type", "stream", "status"],
+        "additionalProperties": false
+      },
+      "EofMessageOutput": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "const": "eof" },
+          "reason": { "type": "string", "enum": ["complete", "state_limit", "time_limit", "error"] }
+        },
+        "required": ["type", "reason"],
         "additionalProperties": false
       },
       "StripeSourceConfig": {

--- a/apps/engine/src/api/app.test.ts
+++ b/apps/engine/src/api/app.test.ts
@@ -139,11 +139,14 @@ describe('GET /openapi.json', () => {
 
     // Message union
     expect(schemas.Message.discriminator.propertyName).toBe('type')
-    expect(schemas.Message.oneOf).toHaveLength(6)
+    expect(schemas.Message.oneOf).toHaveLength(7)
 
-    // DestinationOutput union
+    // DestinationOutput union (state, error, log, eof)
     expect(schemas.DestinationOutput.discriminator.propertyName).toBe('type')
-    expect(schemas.DestinationOutput.oneOf).toHaveLength(3)
+    expect(schemas.DestinationOutput.oneOf).toHaveLength(4)
+
+    // EofMessage
+    expect(schemas.EofMessage.properties.type.const).toBe('eof')
 
     // NDJSON responses reference schemas (zod-openapi adds Output suffix for response-only types)
     const readNdjson =
@@ -289,9 +292,10 @@ describe('POST /read', () => {
     expect(res.headers.get('Content-Type')).toBe('application/x-ndjson')
 
     const events = await readNdjson<Message>(res)
-    expect(events).toHaveLength(2)
+    expect(events).toHaveLength(3)
     expect(events[0]!.type).toBe('record')
     expect(events[1]!.type).toBe('state')
+    expect(events[2]).toMatchObject({ type: 'eof', reason: 'complete' })
   })
 })
 
@@ -365,18 +369,19 @@ describe('POST /sync', () => {
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toBe('application/x-ndjson')
 
-    const events = await readNdjson<StateMessage>(res)
-    expect(events).toHaveLength(1)
+    const events = await readNdjson<Record<string, unknown>>(res)
+    expect(events).toHaveLength(2)
     expect(events[0]!.type).toBe('state')
+    expect(events[1]).toMatchObject({ type: 'eof', reason: 'complete' })
   })
 })
 
 // ---------------------------------------------------------------------------
-// X-State-Checkpoint-Limit
+// state_limit and time_limit query params
 // ---------------------------------------------------------------------------
 
-describe('X-State-Checkpoint-Limit', () => {
-  it('POST /read stops after N state messages', async () => {
+describe('state_limit and time_limit', () => {
+  it('POST /read?state_limit=1 stops after 1 state message and emits eof', async () => {
     const app = createApp(resolver)
 
     const body = toNdjson([
@@ -401,11 +406,10 @@ describe('X-State-Checkpoint-Limit', () => {
         emitted_at: '2024-01-01T00:00:00.000Z',
       },
     ])
-    const res = await app.request('/read', {
+    const res = await app.request('/read?state_limit=1', {
       method: 'POST',
       headers: {
         'X-Pipeline': syncParams,
-        'X-State-Checkpoint-Limit': '1',
         ...bodyHeaders(body),
       },
       body,
@@ -413,13 +417,14 @@ describe('X-State-Checkpoint-Limit', () => {
 
     expect(res.status).toBe(200)
     const events = await readNdjson<Message>(res)
-    // Should get 1 record + 1 state, then stop
-    expect(events).toHaveLength(2)
+    // 1 record + 1 state + 1 eof
+    expect(events).toHaveLength(3)
     expect(events[0]!.type).toBe('record')
     expect(events[1]!.type).toBe('state')
+    expect(events[2]).toMatchObject({ type: 'eof', reason: 'state_limit' })
   })
 
-  it('POST /sync stops after N state messages', async () => {
+  it('POST /sync?state_limit=1 stops after 1 state message and emits eof', async () => {
     const app = createApp(resolver)
 
     const body = toNdjson([
@@ -438,11 +443,10 @@ describe('X-State-Checkpoint-Limit', () => {
       },
       { type: 'state', stream: 'customers', data: { cursor: '2' } },
     ])
-    const res = await app.request('/sync', {
+    const res = await app.request('/sync?state_limit=1', {
       method: 'POST',
       headers: {
         'X-Pipeline': syncParams,
-        'X-State-Checkpoint-Limit': '1',
         ...bodyHeaders(body),
       },
       body,
@@ -450,12 +454,13 @@ describe('X-State-Checkpoint-Limit', () => {
 
     expect(res.status).toBe(200)
     const events = await readNdjson<Message>(res)
-    // destinationTest only yields state messages, so we get 1 state then stop
-    expect(events).toHaveLength(1)
+    // destinationTest only yields state messages, so we get 1 state + 1 eof
+    expect(events).toHaveLength(2)
     expect(events[0]!.type).toBe('state')
+    expect(events[1]).toMatchObject({ type: 'eof', reason: 'state_limit' })
   })
 
-  it('POST /read without limit returns all messages', async () => {
+  it('POST /read without limits returns all messages plus eof:complete', async () => {
     const app = createApp(resolver)
 
     const body = toNdjson([
@@ -482,7 +487,9 @@ describe('X-State-Checkpoint-Limit', () => {
 
     expect(res.status).toBe(200)
     const events = await readNdjson<Message>(res)
-    expect(events).toHaveLength(4)
+    // 4 original messages + eof
+    expect(events).toHaveLength(5)
+    expect(events[4]).toMatchObject({ type: 'eof', reason: 'complete' })
   })
 })
 

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -16,7 +16,7 @@ import {
   DestinationOutput as DestinationOutputSchema,
   CatalogMessage as CatalogMessageSchema,
 } from '@stripe/sync-protocol'
-import { takeStateCheckpoints } from '../lib/pipeline.js'
+import { takeLimits } from '../lib/pipeline.js'
 import { ndjsonResponse } from '@stripe/sync-ts-cli/ndjson'
 import { logger } from '../logger.js'
 import {
@@ -85,9 +85,12 @@ export function createApp(resolver: ConnectorResolver) {
     return false
   }
 
-  /** Parse all sync headers (X-Pipeline, X-State, X-State-Checkpoint-Limit) into SyncParams. */
+  /** Parse sync headers (X-Pipeline, X-State) and query params (state_limit, time_limit) into SyncParams. */
   function parseSyncParams(c: {
-    req: { header: (name: string) => string | undefined }
+    req: {
+      header: (name: string) => string | undefined
+      query: (name: string) => string | undefined
+    }
   }): SyncParams {
     const pipelineHeader = c.req.header('X-Pipeline')
     if (!pipelineHeader) {
@@ -110,10 +113,12 @@ export function createApp(resolver: ConnectorResolver) {
       }
     }
 
-    const limitHeader = c.req.header('X-State-Checkpoint-Limit')
-    const stateCheckpointLimit = limitHeader ? Number(limitHeader) : undefined
+    const stateLimitStr = c.req.query('state_limit')
+    const stateLimit = stateLimitStr ? Number(stateLimitStr) : undefined
+    const timeLimitStr = c.req.query('time_limit')
+    const timeLimitMs = timeLimitStr ? Number(timeLimitStr) * 1000 : undefined
 
-    return { pipeline, state, stateCheckpointLimit }
+    return { pipeline, state, stateLimit, timeLimitMs }
   }
 
   /** Wraps an async iterable to call `fn()` after iteration completes or throws. */
@@ -152,17 +157,21 @@ export function createApp(resolver: ConnectorResolver) {
       example: JSON.stringify({ products: { cursor: 'prod_xyz' } }),
     })
 
-  const xCheckpointLimitHeader = z.coerce.number().int().positive().optional().meta({
-    description:
-      'When set, stops streaming after N state checkpoint messages. Enables page-at-a-time sync.',
-    example: '1',
-  })
-
   const pipelineHeaders = z.object({ 'x-pipeline': xPipelineHeader })
   const allSyncHeaders = z.object({
     'x-pipeline': xPipelineHeader,
     'x-state': xStateHeader,
-    'x-state-checkpoint-limit': xCheckpointLimitHeader,
+  })
+
+  const syncQueryParams = z.object({
+    state_limit: z.coerce.number().int().positive().optional().meta({
+      description: 'Stop streaming after N state messages.',
+      example: '100',
+    }),
+    time_limit: z.coerce.number().positive().optional().meta({
+      description: 'Stop streaming after N seconds.',
+      example: '10',
+    }),
   })
 
   const errorResponse = {
@@ -336,7 +345,7 @@ export function createApp(resolver: ConnectorResolver) {
       summary: 'Read records from source',
       description:
         'Streams NDJSON messages (records, state, catalog). Optional NDJSON body provides live events as input.',
-      requestParams: { header: allSyncHeaders },
+      requestParams: { header: allSyncHeaders, query: syncQueryParams },
       responses: {
         200: {
           description: 'NDJSON stream of sync messages',
@@ -359,10 +368,10 @@ export function createApp(resolver: ConnectorResolver) {
       )
 
       const input = inputPresent ? parseNdjsonStream(c.req.raw.body!) : undefined
-      let output: AsyncIterable<Message> = engine.read(input)
-      if (params.stateCheckpointLimit) {
-        output = takeStateCheckpoints<Message>(params.stateCheckpointLimit)(output)
-      }
+      const output = takeLimits<Message>({
+        stateLimit: params.stateLimit,
+        timeLimitMs: params.timeLimitMs,
+      })(engine.read(input))
       return ndjsonResponse(logApiStream('Engine API /read', output, context, startedAt))
     }) as any
   )
@@ -417,7 +426,7 @@ export function createApp(resolver: ConnectorResolver) {
       description:
         'Without a request body, reads from the source connector and writes to the destination (backfill mode). ' +
         'With an NDJSON request body, uses the provided messages as input instead of reading from the source (push mode — e.g. piped webhook events).',
-      requestParams: { header: allSyncHeaders },
+      requestParams: { header: allSyncHeaders, query: syncQueryParams },
       responses: {
         200: {
           description: 'NDJSON stream of sync messages',
@@ -433,10 +442,10 @@ export function createApp(resolver: ConnectorResolver) {
       const engine = await createEngineFromParams(params.pipeline, resolver, stateStore)
 
       const input = hasBody(c) ? parseNdjsonStream(c.req.raw.body!) : undefined
-      let output: AsyncIterable<DestinationOutput> = engine.sync(input)
-      if (params.stateCheckpointLimit) {
-        output = takeStateCheckpoints<DestinationOutput>(params.stateCheckpointLimit)(output)
-      }
+      const output = takeLimits<DestinationOutput>({
+        stateLimit: params.stateLimit,
+        timeLimitMs: params.timeLimitMs,
+      })(engine.sync(input))
       return ndjsonResponse(output)
     }) as any
   )

--- a/apps/engine/src/lib/pipeline.test.ts
+++ b/apps/engine/src/lib/pipeline.test.ts
@@ -1,13 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import type { ConfiguredCatalog, DestinationOutput, Message } from '@stripe/sync-protocol'
-import {
-  enforceCatalog,
-  filterType,
-  log,
-  persistState,
-  pipe,
-  takeStateCheckpoints,
-} from './pipeline.js'
+import { enforceCatalog, filterType, log, persistState, pipe, takeLimits } from './pipeline.js'
 import type { StateStore } from './state-store.js'
 
 vi.mock('../logger.js', () => ({
@@ -348,11 +341,11 @@ describe('persistState()', () => {
 })
 
 // ---------------------------------------------------------------------------
-// takeStateCheckpoints()
+// takeLimits()
 // ---------------------------------------------------------------------------
 
-describe('takeStateCheckpoints()', () => {
-  it('stops after the Nth state message', async () => {
+describe('takeLimits()', () => {
+  it('stops after N state messages and emits eof with state_limit reason', async () => {
     const msgs: Message[] = [
       {
         type: 'record',
@@ -368,20 +361,15 @@ describe('takeStateCheckpoints()', () => {
         emitted_at: '2024-01-01T00:00:00.000Z',
       },
       { type: 'state', stream: 'customers', data: { cursor: '2' } },
-      {
-        type: 'record',
-        stream: 'customers',
-        data: { id: 'cus_3' },
-        emitted_at: '2024-01-01T00:00:00.000Z',
-      },
     ]
-    const result = await drain(takeStateCheckpoints<Message>(1)(toAsync(msgs)))
-    expect(result).toHaveLength(2)
+    const result = await drain(takeLimits<Message>({ stateLimit: 1 })(toAsync(msgs)))
+    expect(result).toHaveLength(3)
     expect(result[0]).toMatchObject({ type: 'record', data: { id: 'cus_1' } })
     expect(result[1]).toMatchObject({ type: 'state', data: { cursor: '1' } })
+    expect(result[2]).toMatchObject({ type: 'eof', reason: 'state_limit' })
   })
 
-  it('yields everything when limit exceeds state message count', async () => {
+  it('emits eof with complete reason when source exhausts', async () => {
     const msgs: Message[] = [
       {
         type: 'record',
@@ -391,8 +379,16 @@ describe('takeStateCheckpoints()', () => {
       },
       { type: 'state', stream: 'customers', data: { cursor: '1' } },
     ]
-    const result = await drain(takeStateCheckpoints<Message>(5)(toAsync(msgs)))
+    const result = await drain(takeLimits<Message>({ stateLimit: 5 })(toAsync(msgs)))
+    expect(result).toHaveLength(3)
+    expect(result[2]).toMatchObject({ type: 'eof', reason: 'complete' })
+  })
+
+  it('emits eof complete with no limits set', async () => {
+    const msgs: Message[] = [{ type: 'state', stream: 'customers', data: { cursor: '1' } }]
+    const result = await drain(takeLimits<Message>()(toAsync(msgs)))
     expect(result).toHaveLength(2)
+    expect(result[1]).toMatchObject({ type: 'eof', reason: 'complete' })
   })
 
   it('counts state messages across multiple streams', async () => {
@@ -419,16 +415,54 @@ describe('takeStateCheckpoints()', () => {
       },
       { type: 'state', stream: 'customers', data: { cursor: 'c' } },
     ]
-    const result = await drain(takeStateCheckpoints<Message>(2)(toAsync(msgs)))
-    expect(result).toHaveLength(4)
+    const result = await drain(takeLimits<Message>({ stateLimit: 2 })(toAsync(msgs)))
+    expect(result).toHaveLength(5)
     expect(result[3]).toMatchObject({ type: 'state', stream: 'products' })
+    expect(result[4]).toMatchObject({ type: 'eof', reason: 'state_limit' })
   })
 
-  it('yields the state message itself before stopping', async () => {
-    const msgs: Message[] = [{ type: 'state', stream: 'customers', data: { cursor: '1' } }]
-    const result = await drain(takeStateCheckpoints<Message>(1)(toAsync(msgs)))
+  it('stops on time limit at any message boundary', async () => {
+    async function* slowMessages(): AsyncIterable<Message> {
+      yield {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_1' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      }
+      await new Promise((r) => setTimeout(r, 60))
+      yield {
+        type: 'record',
+        stream: 'customers',
+        data: { id: 'cus_2' },
+        emitted_at: '2024-01-01T00:00:00.000Z',
+      }
+      yield { type: 'state', stream: 'customers', data: { cursor: '2' } }
+    }
+
+    const result = await drain(takeLimits<Message>({ timeLimitMs: 30 })(slowMessages()))
+    // Should get first record + eof (time expired before second record)
+    expect(result.at(-1)).toMatchObject({ type: 'eof', reason: 'time_limit' })
+    // Should have stopped before all 3 messages were yielded
+    expect(result.length).toBeLessThanOrEqual(3)
+  })
+
+  it('time limit and state limit: whichever fires first wins', async () => {
+    const msgs: Message[] = [
+      { type: 'state', stream: 'customers', data: { cursor: '1' } },
+      { type: 'state', stream: 'customers', data: { cursor: '2' } },
+      { type: 'state', stream: 'customers', data: { cursor: '3' } },
+    ]
+    // State limit of 1 fires before any time limit
+    const result = await drain(
+      takeLimits<Message>({ stateLimit: 1, timeLimitMs: 60_000 })(toAsync(msgs))
+    )
+    expect(result.at(-1)).toMatchObject({ type: 'eof', reason: 'state_limit' })
+  })
+
+  it('emits eof for empty stream', async () => {
+    const result = await drain(takeLimits<Message>()(toAsync([])))
     expect(result).toHaveLength(1)
-    expect(result[0]).toMatchObject({ type: 'state' })
+    expect(result[0]).toMatchObject({ type: 'eof', reason: 'complete' })
   })
 })
 

--- a/apps/engine/src/lib/pipeline.ts
+++ b/apps/engine/src/lib/pipeline.ts
@@ -89,21 +89,35 @@ export function persistState(
   }
 }
 
-// MARK: - takeStateCheckpoints
+// MARK: - takeLimits
 
 /**
- * Stops streaming after yielding `limit` state messages (across all streams).
- * All non-state messages before and between state messages pass through.
+ * Applies stream limits and emits an `eof` terminal message as the final item.
+ *
+ * - `stateLimit`: stop after N state messages (state message boundary)
+ * - `timeLimitMs`: stop after N milliseconds (any message boundary)
+ *
+ * When both are set, whichever fires first wins. All non-matching messages
+ * pass through unchanged. The last yielded item is always `{ type: 'eof', reason }`.
  */
-export function takeStateCheckpoints<T extends { type: string }>(
-  limit: number
+export function takeLimits<T extends { type: string }>(
+  opts: { stateLimit?: number; timeLimitMs?: number } = {}
 ): (msgs: AsyncIterable<T>) => AsyncIterable<T> {
   return async function* (messages) {
-    let count = 0
+    const deadline = opts.timeLimitMs ? Date.now() + opts.timeLimitMs : undefined
+    let stateCount = 0
     for await (const msg of messages) {
       yield msg
-      if (msg.type === 'state' && ++count >= limit) return
+      if (deadline && Date.now() >= deadline) {
+        yield { type: 'eof', reason: 'time_limit' } as unknown as T
+        return
+      }
+      if (msg.type === 'state' && opts.stateLimit && ++stateCount >= opts.stateLimit) {
+        yield { type: 'eof', reason: 'state_limit' } as unknown as T
+        return
+      }
     }
+    yield { type: 'eof', reason: 'complete' } as unknown as T
   }
 }
 

--- a/apps/engine/src/lib/remote-engine.test.ts
+++ b/apps/engine/src/lib/remote-engine.test.ts
@@ -131,16 +131,18 @@ describe('createRemoteEngine', () => {
         { type: 'state', stream: 'customers', data: { cursor: 'cus_1' } },
       ]
       const messages = await collect(engine.read(asIterable(input)))
-      expect(messages).toHaveLength(2)
+      expect(messages).toHaveLength(3)
       expect(messages[0]!.type).toBe('record')
       expect(messages[1]!.type).toBe('state')
+      expect(messages[2]).toMatchObject({ type: 'eof', reason: 'complete' })
     })
 
-    it('returns empty stream when called without input', async () => {
+    it('returns eof:complete when called without input', async () => {
       const engine = createRemoteEngine(engineUrl, pipeline)
-      // sourceTest yields nothing when $stdin is absent
+      // sourceTest yields nothing when $stdin is absent — only eof
       const messages = await collect(engine.read())
-      expect(messages).toHaveLength(0)
+      expect(messages).toHaveLength(1)
+      expect(messages[0]).toMatchObject({ type: 'eof', reason: 'complete' })
     })
   })
 
@@ -176,14 +178,16 @@ describe('createRemoteEngine', () => {
         { type: 'state', stream: 'customers', data: { cursor: 'cus_1' } },
       ]
       const output = await collect(engine.sync(asIterable(input)))
-      expect(output).toHaveLength(1)
+      expect(output).toHaveLength(2)
       expect(output[0]!.type).toBe('state')
+      expect(output[1]).toMatchObject({ type: 'eof', reason: 'complete' })
     })
 
-    it('returns empty stream without input (no source data)', async () => {
+    it('returns eof:complete without input (no source data)', async () => {
       const engine = createRemoteEngine(engineUrl, pipeline)
       const output = await collect(engine.sync())
-      expect(output).toHaveLength(0)
+      expect(output).toHaveLength(1)
+      expect(output[0]).toMatchObject({ type: 'eof', reason: 'complete' })
     })
   })
 

--- a/apps/engine/src/lib/remote-engine.ts
+++ b/apps/engine/src/lib/remote-engine.ts
@@ -28,7 +28,7 @@ type StreamPost = (path: string, init: Record<string, unknown>) => Promise<{ res
 export function createRemoteEngine(
   engineUrl: string,
   pipeline: PipelineConfig,
-  opts?: { state?: Record<string, unknown>; stateLimit?: number; timeLimitSeconds?: number }
+  opts?: { state?: Record<string, unknown>; stateLimit?: number; timeLimit?: number }
 ): Engine {
   const client = createClient<paths>({ baseUrl: engineUrl })
   const ph = JSON.stringify(pipeline)
@@ -47,7 +47,7 @@ export function createRemoteEngine(
   function queryParams(): Record<string, string> {
     const q: Record<string, string> = {}
     if (opts?.stateLimit != null) q.state_limit = String(opts.stateLimit)
-    if (opts?.timeLimitSeconds != null) q.time_limit = String(opts.timeLimitSeconds)
+    if (opts?.timeLimit != null) q.time_limit = String(opts.timeLimit)
     return q
   }
 
@@ -56,9 +56,8 @@ export function createRemoteEngine(
     body?: ReadableStream<Uint8Array>
   ): Promise<Response> {
     const headers = { ...extraHeaders() }
-    const q = queryParams()
     const { response } = await streamPost(path, {
-      params: { header: { 'x-pipeline': ph }, ...(Object.keys(q).length > 0 ? { query: q } : {}) },
+      params: { header: { 'x-pipeline': ph }, query: queryParams() },
       parseAs: 'stream',
       headers,
       ...(body

--- a/apps/engine/src/lib/remote-engine.ts
+++ b/apps/engine/src/lib/remote-engine.ts
@@ -28,7 +28,7 @@ type StreamPost = (path: string, init: Record<string, unknown>) => Promise<{ res
 export function createRemoteEngine(
   engineUrl: string,
   pipeline: PipelineConfig,
-  opts?: { state?: Record<string, unknown>; stateLimit?: number }
+  opts?: { state?: Record<string, unknown>; stateLimit?: number; timeLimitSeconds?: number }
 ): Engine {
   const client = createClient<paths>({ baseUrl: engineUrl })
   const ph = JSON.stringify(pipeline)
@@ -41,10 +41,14 @@ export function createRemoteEngine(
     if (opts?.state && Object.keys(opts.state).length > 0) {
       h['x-state'] = JSON.stringify(opts.state)
     }
-    if (opts?.stateLimit != null) {
-      h['x-state-checkpoint-limit'] = String(opts.stateLimit)
-    }
     return h
+  }
+
+  function queryParams(): Record<string, string> {
+    const q: Record<string, string> = {}
+    if (opts?.stateLimit != null) q.state_limit = String(opts.stateLimit)
+    if (opts?.timeLimitSeconds != null) q.time_limit = String(opts.timeLimitSeconds)
+    return q
   }
 
   async function post(
@@ -52,8 +56,9 @@ export function createRemoteEngine(
     body?: ReadableStream<Uint8Array>
   ): Promise<Response> {
     const headers = { ...extraHeaders() }
+    const q = queryParams()
     const { response } = await streamPost(path, {
-      params: { header: { 'x-pipeline': ph } },
+      params: { header: { 'x-pipeline': ph }, ...(Object.keys(q).length > 0 ? { query: q } : {}) },
       parseAs: 'stream',
       headers,
       ...(body

--- a/apps/service/src/__generated__/openapi.d.ts
+++ b/apps/service/src/__generated__/openapi.d.ts
@@ -4,1298 +4,1282 @@
  */
 
 export interface paths {
-  '/health': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Health check */
-    get: operations['health']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/pipelines': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** List pipelines */
-    get: operations['pipelines.list']
-    put?: never
-    /** Create pipeline */
-    post: operations['pipelines.create']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/pipelines/{id}': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Retrieve pipeline */
-    get: operations['pipelines.get']
-    put?: never
-    post?: never
-    /** Delete pipeline */
-    delete: operations['pipelines.delete']
-    options?: never
-    head?: never
-    /** Update pipeline */
-    patch: operations['pipelines.update']
-    trace?: never
-  }
-  '/pipelines/{id}/pause': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Pause pipeline */
-    post: operations['pipelines.pause']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/pipelines/{id}/resume': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Resume pipeline */
-    post: operations['pipelines.resume']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  '/webhooks/{pipeline_id}': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /**
-     * Ingest a Stripe webhook event
-     * @description Receives a raw Stripe webhook event, verifies its signature using the pipeline's webhook secret, and enqueues it for processing by the active pipeline.
-     */
-    post: operations['webhooks.push']
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Health check */
+        get: operations["health"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/pipelines": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List pipelines */
+        get: operations["pipelines.list"];
+        put?: never;
+        /** Create pipeline */
+        post: operations["pipelines.create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/pipelines/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Retrieve pipeline */
+        get: operations["pipelines.get"];
+        put?: never;
+        post?: never;
+        /** Delete pipeline */
+        delete: operations["pipelines.delete"];
+        options?: never;
+        head?: never;
+        /** Update pipeline */
+        patch: operations["pipelines.update"];
+        trace?: never;
+    };
+    "/pipelines/{id}/pause": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Pause pipeline */
+        post: operations["pipelines.pause"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/pipelines/{id}/resume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Resume pipeline */
+        post: operations["pipelines.resume"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/webhooks/{pipeline_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Ingest a Stripe webhook event
+         * @description Receives a raw Stripe webhook event, verifies its signature using the pipeline's webhook secret, and enqueues it for processing by the active pipeline.
+         */
+        post: operations["webhooks.push"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
-export type webhooks = Record<string, never>
+export type webhooks = Record<string, never>;
 export interface components {
-  schemas: never
-  responses: never
-  parameters: never
-  requestBodies: never
-  headers: never
-  pathItems: never
+    schemas: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
-export type $defs = Record<string, never>
+export type $defs = Record<string, never>;
 export interface operations {
-  health: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Server is healthy */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            /** @constant */
-            ok: true
-          }
-        }
-      }
-    }
-  }
-  'pipelines.list': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description List of pipelines */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            data: {
-              id: string
-              source: {
-                /** @description Stripe API key (sk_test_... or sk_live_...) */
-                api_key: string
-                /** @description Stripe account ID (resolved from API if omitted) */
-                account_id?: string
-                /** @description Whether this is a live mode sync */
-                livemode?: boolean
-                /** @description Stripe API version (e.g. 2025-04-30.basil) */
-                api_version?: string
-                /**
-                 * Format: uri
-                 * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
-                 */
-                base_url?: string
-                /**
-                 * Format: uri
-                 * @description URL for managed webhook endpoint registration
-                 */
-                webhook_url?: string
-                /** @description Webhook signing secret (whsec_...) for signature verification */
-                webhook_secret?: string
-                /** @description Enable WebSocket streaming for live events */
-                websocket?: boolean
-                /** @description Enable events API polling for incremental sync after backfill */
-                poll_events?: boolean
-                /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
-                webhook_port?: number
-                /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
-                revalidate_objects?: string[]
-                /** @description Max objects to backfill per stream (useful for testing) */
-                backfill_limit?: number
-                /** @description Max Stripe API requests per second (default: 25) */
-                rate_limit?: number
-                /** @description Number of time-range segments for parallel backfill (default: 200) */
-                backfill_concurrency?: number
-                /** @constant */
-                type: 'stripe'
-              }
-              destination:
-                | {
-                    /** @description Postgres connection string (alias for connection_string) */
-                    url?: string
-                    /** @description Postgres connection string */
-                    connection_string?: string
-                    /** @description Postgres host (required for AWS IAM) */
-                    host?: string
-                    /**
-                     * @description Postgres port
-                     * @default 5432
-                     */
-                    port: number
-                    /** @description Database name (required for AWS IAM) */
-                    database?: string
-                    /** @description Database user (required for AWS IAM) */
-                    user?: string
-                    /** @description Target schema name (e.g. "stripe_sync") */
-                    schema: string
-                    /**
-                     * @description Records to buffer before flushing
-                     * @default 100
-                     */
-                    batch_size: number
-                    /** @description AWS RDS IAM authentication config */
-                    aws?: {
-                      /** @description AWS region for RDS instance */
-                      region: string
-                      /** @description IAM role ARN to assume (cross-account) */
-                      role_arn?: string
-                      /** @description External ID for STS AssumeRole */
-                      external_id?: string
-                    }
-                    /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
-                    ssl_ca_pem?: string
-                    /** @constant */
-                    type: 'postgres'
-                  }
-                | {
-                    /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
-                    client_id?: string
-                    /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
-                    client_secret?: string
-                    /** @description OAuth2 access token */
-                    access_token: string
-                    /** @description OAuth2 refresh token */
-                    refresh_token: string
-                    /** @description Target spreadsheet ID (created if omitted) */
-                    spreadsheet_id?: string
-                    /**
-                     * @description Title when creating a new spreadsheet
-                     * @default Stripe Sync
-                     */
-                    spreadsheet_title: string
-                    /**
-                     * @description Rows per Sheets API append call
-                     * @default 50
-                     */
-                    batch_size: number
-                    /** @constant */
-                    type: 'google-sheets'
-                  }
-              streams?: {
-                name: string
-                /** @enum {string} */
-                sync_mode?: 'incremental' | 'full_refresh'
-                backfill_limit?: number
-              }[]
-              status?: {
-                phase: string
-                paused: boolean
-                iteration: number
-              }
-            }[]
-            has_more: boolean
-          }
-        }
-      }
-    }
-  }
-  'pipelines.create': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: {
-      content: {
-        'application/json': {
-          source: {
-            /** @description Stripe API key (sk_test_... or sk_live_...) */
-            api_key: string
-            /** @description Stripe account ID (resolved from API if omitted) */
-            account_id?: string
-            /** @description Whether this is a live mode sync */
-            livemode?: boolean
-            /** @description Stripe API version (e.g. 2025-04-30.basil) */
-            api_version?: string
-            /**
-             * Format: uri
-             * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
-             */
-            base_url?: string
-            /**
-             * Format: uri
-             * @description URL for managed webhook endpoint registration
-             */
-            webhook_url?: string
-            /** @description Webhook signing secret (whsec_...) for signature verification */
-            webhook_secret?: string
-            /** @description Enable WebSocket streaming for live events */
-            websocket?: boolean
-            /** @description Enable events API polling for incremental sync after backfill */
-            poll_events?: boolean
-            /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
-            webhook_port?: number
-            /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
-            revalidate_objects?: string[]
-            /** @description Max objects to backfill per stream (useful for testing) */
-            backfill_limit?: number
-            /** @description Max Stripe API requests per second (default: 25) */
-            rate_limit?: number
-            /** @description Number of time-range segments for parallel backfill (default: 200) */
-            backfill_concurrency?: number
-            /** @constant */
-            type: 'stripe'
-          }
-          destination:
-            | {
-                /** @description Postgres connection string (alias for connection_string) */
-                url?: string
-                /** @description Postgres connection string */
-                connection_string?: string
-                /** @description Postgres host (required for AWS IAM) */
-                host?: string
-                /**
-                 * @description Postgres port
-                 * @default 5432
-                 */
-                port?: number
-                /** @description Database name (required for AWS IAM) */
-                database?: string
-                /** @description Database user (required for AWS IAM) */
-                user?: string
-                /** @description Target schema name (e.g. "stripe_sync") */
-                schema: string
-                /**
-                 * @description Records to buffer before flushing
-                 * @default 100
-                 */
-                batch_size?: number
-                /** @description AWS RDS IAM authentication config */
-                aws?: {
-                  /** @description AWS region for RDS instance */
-                  region: string
-                  /** @description IAM role ARN to assume (cross-account) */
-                  role_arn?: string
-                  /** @description External ID for STS AssumeRole */
-                  external_id?: string
-                }
-                /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
-                ssl_ca_pem?: string
-                /** @constant */
-                type: 'postgres'
-              }
-            | {
-                /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
-                client_id?: string
-                /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
-                client_secret?: string
-                /** @description OAuth2 access token */
-                access_token: string
-                /** @description OAuth2 refresh token */
-                refresh_token: string
-                /** @description Target spreadsheet ID (created if omitted) */
-                spreadsheet_id?: string
-                /**
-                 * @description Title when creating a new spreadsheet
-                 * @default Stripe Sync
-                 */
-                spreadsheet_title?: string
-                /**
-                 * @description Rows per Sheets API append call
-                 * @default 50
-                 */
-                batch_size?: number
-                /** @constant */
-                type: 'google-sheets'
-              }
-          streams?: {
-            name: string
-            /** @enum {string} */
-            sync_mode?: 'incremental' | 'full_refresh'
-            backfill_limit?: number
-          }[]
-        }
-      }
-    }
-    responses: {
-      /** @description Created pipeline */
-      201: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            id: string
-            source: {
-              /** @description Stripe API key (sk_test_... or sk_live_...) */
-              api_key: string
-              /** @description Stripe account ID (resolved from API if omitted) */
-              account_id?: string
-              /** @description Whether this is a live mode sync */
-              livemode?: boolean
-              /** @description Stripe API version (e.g. 2025-04-30.basil) */
-              api_version?: string
-              /**
-               * Format: uri
-               * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
-               */
-              base_url?: string
-              /**
-               * Format: uri
-               * @description URL for managed webhook endpoint registration
-               */
-              webhook_url?: string
-              /** @description Webhook signing secret (whsec_...) for signature verification */
-              webhook_secret?: string
-              /** @description Enable WebSocket streaming for live events */
-              websocket?: boolean
-              /** @description Enable events API polling for incremental sync after backfill */
-              poll_events?: boolean
-              /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
-              webhook_port?: number
-              /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
-              revalidate_objects?: string[]
-              /** @description Max objects to backfill per stream (useful for testing) */
-              backfill_limit?: number
-              /** @description Max Stripe API requests per second (default: 25) */
-              rate_limit?: number
-              /** @description Number of time-range segments for parallel backfill (default: 200) */
-              backfill_concurrency?: number
-              /** @constant */
-              type: 'stripe'
-            }
-            destination:
-              | {
-                  /** @description Postgres connection string (alias for connection_string) */
-                  url?: string
-                  /** @description Postgres connection string */
-                  connection_string?: string
-                  /** @description Postgres host (required for AWS IAM) */
-                  host?: string
-                  /**
-                   * @description Postgres port
-                   * @default 5432
-                   */
-                  port: number
-                  /** @description Database name (required for AWS IAM) */
-                  database?: string
-                  /** @description Database user (required for AWS IAM) */
-                  user?: string
-                  /** @description Target schema name (e.g. "stripe_sync") */
-                  schema: string
-                  /**
-                   * @description Records to buffer before flushing
-                   * @default 100
-                   */
-                  batch_size: number
-                  /** @description AWS RDS IAM authentication config */
-                  aws?: {
-                    /** @description AWS region for RDS instance */
-                    region: string
-                    /** @description IAM role ARN to assume (cross-account) */
-                    role_arn?: string
-                    /** @description External ID for STS AssumeRole */
-                    external_id?: string
-                  }
-                  /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
-                  ssl_ca_pem?: string
-                  /** @constant */
-                  type: 'postgres'
-                }
-              | {
-                  /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
-                  client_id?: string
-                  /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
-                  client_secret?: string
-                  /** @description OAuth2 access token */
-                  access_token: string
-                  /** @description OAuth2 refresh token */
-                  refresh_token: string
-                  /** @description Target spreadsheet ID (created if omitted) */
-                  spreadsheet_id?: string
-                  /**
-                   * @description Title when creating a new spreadsheet
-                   * @default Stripe Sync
-                   */
-                  spreadsheet_title: string
-                  /**
-                   * @description Rows per Sheets API append call
-                   * @default 50
-                   */
-                  batch_size: number
-                  /** @constant */
-                  type: 'google-sheets'
-                }
-            streams?: {
-              name: string
-              /** @enum {string} */
-              sync_mode?: 'incremental' | 'full_refresh'
-              backfill_limit?: number
-            }[]
-          }
-        }
-      }
-      /** @description Invalid input */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            error: unknown
-          }
-        }
-      }
-    }
-  }
-  'pipelines.get': {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Retrieved pipeline with status */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            id: string
-            source: {
-              /** @description Stripe API key (sk_test_... or sk_live_...) */
-              api_key: string
-              /** @description Stripe account ID (resolved from API if omitted) */
-              account_id?: string
-              /** @description Whether this is a live mode sync */
-              livemode?: boolean
-              /** @description Stripe API version (e.g. 2025-04-30.basil) */
-              api_version?: string
-              /**
-               * Format: uri
-               * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
-               */
-              base_url?: string
-              /**
-               * Format: uri
-               * @description URL for managed webhook endpoint registration
-               */
-              webhook_url?: string
-              /** @description Webhook signing secret (whsec_...) for signature verification */
-              webhook_secret?: string
-              /** @description Enable WebSocket streaming for live events */
-              websocket?: boolean
-              /** @description Enable events API polling for incremental sync after backfill */
-              poll_events?: boolean
-              /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
-              webhook_port?: number
-              /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
-              revalidate_objects?: string[]
-              /** @description Max objects to backfill per stream (useful for testing) */
-              backfill_limit?: number
-              /** @description Max Stripe API requests per second (default: 25) */
-              rate_limit?: number
-              /** @description Number of time-range segments for parallel backfill (default: 200) */
-              backfill_concurrency?: number
-              /** @constant */
-              type: 'stripe'
-            }
-            destination:
-              | {
-                  /** @description Postgres connection string (alias for connection_string) */
-                  url?: string
-                  /** @description Postgres connection string */
-                  connection_string?: string
-                  /** @description Postgres host (required for AWS IAM) */
-                  host?: string
-                  /**
-                   * @description Postgres port
-                   * @default 5432
-                   */
-                  port: number
-                  /** @description Database name (required for AWS IAM) */
-                  database?: string
-                  /** @description Database user (required for AWS IAM) */
-                  user?: string
-                  /** @description Target schema name (e.g. "stripe_sync") */
-                  schema: string
-                  /**
-                   * @description Records to buffer before flushing
-                   * @default 100
-                   */
-                  batch_size: number
-                  /** @description AWS RDS IAM authentication config */
-                  aws?: {
-                    /** @description AWS region for RDS instance */
-                    region: string
-                    /** @description IAM role ARN to assume (cross-account) */
-                    role_arn?: string
-                    /** @description External ID for STS AssumeRole */
-                    external_id?: string
-                  }
-                  /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
-                  ssl_ca_pem?: string
-                  /** @constant */
-                  type: 'postgres'
-                }
-              | {
-                  /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
-                  client_id?: string
-                  /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
-                  client_secret?: string
-                  /** @description OAuth2 access token */
-                  access_token: string
-                  /** @description OAuth2 refresh token */
-                  refresh_token: string
-                  /** @description Target spreadsheet ID (created if omitted) */
-                  spreadsheet_id?: string
-                  /**
-                   * @description Title when creating a new spreadsheet
-                   * @default Stripe Sync
-                   */
-                  spreadsheet_title: string
-                  /**
-                   * @description Rows per Sheets API append call
-                   * @default 50
-                   */
-                  batch_size: number
-                  /** @constant */
-                  type: 'google-sheets'
-                }
-            streams?: {
-              name: string
-              /** @enum {string} */
-              sync_mode?: 'incremental' | 'full_refresh'
-              backfill_limit?: number
-            }[]
-            status?: {
-              phase: string
-              paused: boolean
-              iteration: number
-            }
-          }
-        }
-      }
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            error: unknown
-          }
-        }
-      }
-    }
-  }
-  'pipelines.delete': {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Deleted pipeline */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            id: string
-            /** @constant */
-            deleted: true
-          }
-        }
-      }
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            error: unknown
-          }
-        }
-      }
-      /** @description Teardown or deletion failed */
-      500: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            error: unknown
-          }
-        }
-      }
-    }
-  }
-  'pipelines.update': {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        id: string
-      }
-      cookie?: never
-    }
-    requestBody?: {
-      content: {
-        'application/json': {
-          source?: {
-            /** @description Stripe API key (sk_test_... or sk_live_...) */
-            api_key: string
-            /** @description Stripe account ID (resolved from API if omitted) */
-            account_id?: string
-            /** @description Whether this is a live mode sync */
-            livemode?: boolean
-            /** @description Stripe API version (e.g. 2025-04-30.basil) */
-            api_version?: string
-            /**
-             * Format: uri
-             * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
-             */
-            base_url?: string
-            /**
-             * Format: uri
-             * @description URL for managed webhook endpoint registration
-             */
-            webhook_url?: string
-            /** @description Webhook signing secret (whsec_...) for signature verification */
-            webhook_secret?: string
-            /** @description Enable WebSocket streaming for live events */
-            websocket?: boolean
-            /** @description Enable events API polling for incremental sync after backfill */
-            poll_events?: boolean
-            /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
-            webhook_port?: number
-            /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
-            revalidate_objects?: string[]
-            /** @description Max objects to backfill per stream (useful for testing) */
-            backfill_limit?: number
-            /** @description Max Stripe API requests per second (default: 25) */
-            rate_limit?: number
-            /** @description Number of time-range segments for parallel backfill (default: 200) */
-            backfill_concurrency?: number
-            /** @constant */
-            type: 'stripe'
-          }
-          destination?:
-            | {
-                /** @description Postgres connection string (alias for connection_string) */
-                url?: string
-                /** @description Postgres connection string */
-                connection_string?: string
-                /** @description Postgres host (required for AWS IAM) */
-                host?: string
-                /**
-                 * @description Postgres port
-                 * @default 5432
-                 */
-                port?: number
-                /** @description Database name (required for AWS IAM) */
-                database?: string
-                /** @description Database user (required for AWS IAM) */
-                user?: string
-                /** @description Target schema name (e.g. "stripe_sync") */
-                schema: string
-                /**
-                 * @description Records to buffer before flushing
-                 * @default 100
-                 */
-                batch_size?: number
-                /** @description AWS RDS IAM authentication config */
-                aws?: {
-                  /** @description AWS region for RDS instance */
-                  region: string
-                  /** @description IAM role ARN to assume (cross-account) */
-                  role_arn?: string
-                  /** @description External ID for STS AssumeRole */
-                  external_id?: string
-                }
-                /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
-                ssl_ca_pem?: string
-                /** @constant */
-                type: 'postgres'
-              }
-            | {
-                /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
-                client_id?: string
-                /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
-                client_secret?: string
-                /** @description OAuth2 access token */
-                access_token: string
-                /** @description OAuth2 refresh token */
-                refresh_token: string
-                /** @description Target spreadsheet ID (created if omitted) */
-                spreadsheet_id?: string
-                /**
-                 * @description Title when creating a new spreadsheet
-                 * @default Stripe Sync
-                 */
-                spreadsheet_title?: string
-                /**
-                 * @description Rows per Sheets API append call
-                 * @default 50
-                 */
-                batch_size?: number
-                /** @constant */
-                type: 'google-sheets'
-              }
-          streams?: {
-            name: string
-            /** @enum {string} */
-            sync_mode?: 'incremental' | 'full_refresh'
-            backfill_limit?: number
-          }[]
-        }
-      }
-    }
-    responses: {
-      /** @description Updated pipeline */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            id: string
-            source: {
-              /** @description Stripe API key (sk_test_... or sk_live_...) */
-              api_key: string
-              /** @description Stripe account ID (resolved from API if omitted) */
-              account_id?: string
-              /** @description Whether this is a live mode sync */
-              livemode?: boolean
-              /** @description Stripe API version (e.g. 2025-04-30.basil) */
-              api_version?: string
-              /**
-               * Format: uri
-               * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
-               */
-              base_url?: string
-              /**
-               * Format: uri
-               * @description URL for managed webhook endpoint registration
-               */
-              webhook_url?: string
-              /** @description Webhook signing secret (whsec_...) for signature verification */
-              webhook_secret?: string
-              /** @description Enable WebSocket streaming for live events */
-              websocket?: boolean
-              /** @description Enable events API polling for incremental sync after backfill */
-              poll_events?: boolean
-              /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
-              webhook_port?: number
-              /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
-              revalidate_objects?: string[]
-              /** @description Max objects to backfill per stream (useful for testing) */
-              backfill_limit?: number
-              /** @description Max Stripe API requests per second (default: 25) */
-              rate_limit?: number
-              /** @description Number of time-range segments for parallel backfill (default: 200) */
-              backfill_concurrency?: number
-              /** @constant */
-              type: 'stripe'
-            }
-            destination:
-              | {
-                  /** @description Postgres connection string (alias for connection_string) */
-                  url?: string
-                  /** @description Postgres connection string */
-                  connection_string?: string
-                  /** @description Postgres host (required for AWS IAM) */
-                  host?: string
-                  /**
-                   * @description Postgres port
-                   * @default 5432
-                   */
-                  port: number
-                  /** @description Database name (required for AWS IAM) */
-                  database?: string
-                  /** @description Database user (required for AWS IAM) */
-                  user?: string
-                  /** @description Target schema name (e.g. "stripe_sync") */
-                  schema: string
-                  /**
-                   * @description Records to buffer before flushing
-                   * @default 100
-                   */
-                  batch_size: number
-                  /** @description AWS RDS IAM authentication config */
-                  aws?: {
-                    /** @description AWS region for RDS instance */
-                    region: string
-                    /** @description IAM role ARN to assume (cross-account) */
-                    role_arn?: string
-                    /** @description External ID for STS AssumeRole */
-                    external_id?: string
-                  }
-                  /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
-                  ssl_ca_pem?: string
-                  /** @constant */
-                  type: 'postgres'
-                }
-              | {
-                  /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
-                  client_id?: string
-                  /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
-                  client_secret?: string
-                  /** @description OAuth2 access token */
-                  access_token: string
-                  /** @description OAuth2 refresh token */
-                  refresh_token: string
-                  /** @description Target spreadsheet ID (created if omitted) */
-                  spreadsheet_id?: string
-                  /**
-                   * @description Title when creating a new spreadsheet
-                   * @default Stripe Sync
-                   */
-                  spreadsheet_title: string
-                  /**
-                   * @description Rows per Sheets API append call
-                   * @default 50
-                   */
-                  batch_size: number
-                  /** @constant */
-                  type: 'google-sheets'
-                }
-            streams?: {
-              name: string
-              /** @enum {string} */
-              sync_mode?: 'incremental' | 'full_refresh'
-              backfill_limit?: number
-            }[]
-            status?: {
-              phase: string
-              paused: boolean
-              iteration: number
-            }
-          }
-        }
-      }
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            error: unknown
-          }
-        }
-      }
-    }
-  }
-  'pipelines.pause': {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Paused pipeline */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            id: string
-            source: {
-              /** @description Stripe API key (sk_test_... or sk_live_...) */
-              api_key: string
-              /** @description Stripe account ID (resolved from API if omitted) */
-              account_id?: string
-              /** @description Whether this is a live mode sync */
-              livemode?: boolean
-              /** @description Stripe API version (e.g. 2025-04-30.basil) */
-              api_version?: string
-              /**
-               * Format: uri
-               * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
-               */
-              base_url?: string
-              /**
-               * Format: uri
-               * @description URL for managed webhook endpoint registration
-               */
-              webhook_url?: string
-              /** @description Webhook signing secret (whsec_...) for signature verification */
-              webhook_secret?: string
-              /** @description Enable WebSocket streaming for live events */
-              websocket?: boolean
-              /** @description Enable events API polling for incremental sync after backfill */
-              poll_events?: boolean
-              /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
-              webhook_port?: number
-              /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
-              revalidate_objects?: string[]
-              /** @description Max objects to backfill per stream (useful for testing) */
-              backfill_limit?: number
-              /** @description Max Stripe API requests per second (default: 25) */
-              rate_limit?: number
-              /** @description Number of time-range segments for parallel backfill (default: 200) */
-              backfill_concurrency?: number
-              /** @constant */
-              type: 'stripe'
-            }
-            destination:
-              | {
-                  /** @description Postgres connection string (alias for connection_string) */
-                  url?: string
-                  /** @description Postgres connection string */
-                  connection_string?: string
-                  /** @description Postgres host (required for AWS IAM) */
-                  host?: string
-                  /**
-                   * @description Postgres port
-                   * @default 5432
-                   */
-                  port: number
-                  /** @description Database name (required for AWS IAM) */
-                  database?: string
-                  /** @description Database user (required for AWS IAM) */
-                  user?: string
-                  /** @description Target schema name (e.g. "stripe_sync") */
-                  schema: string
-                  /**
-                   * @description Records to buffer before flushing
-                   * @default 100
-                   */
-                  batch_size: number
-                  /** @description AWS RDS IAM authentication config */
-                  aws?: {
-                    /** @description AWS region for RDS instance */
-                    region: string
-                    /** @description IAM role ARN to assume (cross-account) */
-                    role_arn?: string
-                    /** @description External ID for STS AssumeRole */
-                    external_id?: string
-                  }
-                  /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
-                  ssl_ca_pem?: string
-                  /** @constant */
-                  type: 'postgres'
-                }
-              | {
-                  /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
-                  client_id?: string
-                  /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
-                  client_secret?: string
-                  /** @description OAuth2 access token */
-                  access_token: string
-                  /** @description OAuth2 refresh token */
-                  refresh_token: string
-                  /** @description Target spreadsheet ID (created if omitted) */
-                  spreadsheet_id?: string
-                  /**
-                   * @description Title when creating a new spreadsheet
-                   * @default Stripe Sync
-                   */
-                  spreadsheet_title: string
-                  /**
-                   * @description Rows per Sheets API append call
-                   * @default 50
-                   */
-                  batch_size: number
-                  /** @constant */
-                  type: 'google-sheets'
-                }
-            streams?: {
-              name: string
-              /** @enum {string} */
-              sync_mode?: 'incremental' | 'full_refresh'
-              backfill_limit?: number
-            }[]
-            status?: {
-              phase: string
-              paused: boolean
-              iteration: number
-            }
-          }
-        }
-      }
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            error: unknown
-          }
-        }
-      }
-    }
-  }
-  'pipelines.resume': {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Resumed pipeline */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            id: string
-            source: {
-              /** @description Stripe API key (sk_test_... or sk_live_...) */
-              api_key: string
-              /** @description Stripe account ID (resolved from API if omitted) */
-              account_id?: string
-              /** @description Whether this is a live mode sync */
-              livemode?: boolean
-              /** @description Stripe API version (e.g. 2025-04-30.basil) */
-              api_version?: string
-              /**
-               * Format: uri
-               * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
-               */
-              base_url?: string
-              /**
-               * Format: uri
-               * @description URL for managed webhook endpoint registration
-               */
-              webhook_url?: string
-              /** @description Webhook signing secret (whsec_...) for signature verification */
-              webhook_secret?: string
-              /** @description Enable WebSocket streaming for live events */
-              websocket?: boolean
-              /** @description Enable events API polling for incremental sync after backfill */
-              poll_events?: boolean
-              /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
-              webhook_port?: number
-              /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
-              revalidate_objects?: string[]
-              /** @description Max objects to backfill per stream (useful for testing) */
-              backfill_limit?: number
-              /** @description Max Stripe API requests per second (default: 25) */
-              rate_limit?: number
-              /** @description Number of time-range segments for parallel backfill (default: 200) */
-              backfill_concurrency?: number
-              /** @constant */
-              type: 'stripe'
-            }
-            destination:
-              | {
-                  /** @description Postgres connection string (alias for connection_string) */
-                  url?: string
-                  /** @description Postgres connection string */
-                  connection_string?: string
-                  /** @description Postgres host (required for AWS IAM) */
-                  host?: string
-                  /**
-                   * @description Postgres port
-                   * @default 5432
-                   */
-                  port: number
-                  /** @description Database name (required for AWS IAM) */
-                  database?: string
-                  /** @description Database user (required for AWS IAM) */
-                  user?: string
-                  /** @description Target schema name (e.g. "stripe_sync") */
-                  schema: string
-                  /**
-                   * @description Records to buffer before flushing
-                   * @default 100
-                   */
-                  batch_size: number
-                  /** @description AWS RDS IAM authentication config */
-                  aws?: {
-                    /** @description AWS region for RDS instance */
-                    region: string
-                    /** @description IAM role ARN to assume (cross-account) */
-                    role_arn?: string
-                    /** @description External ID for STS AssumeRole */
-                    external_id?: string
-                  }
-                  /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
-                  ssl_ca_pem?: string
-                  /** @constant */
-                  type: 'postgres'
-                }
-              | {
-                  /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
-                  client_id?: string
-                  /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
-                  client_secret?: string
-                  /** @description OAuth2 access token */
-                  access_token: string
-                  /** @description OAuth2 refresh token */
-                  refresh_token: string
-                  /** @description Target spreadsheet ID (created if omitted) */
-                  spreadsheet_id?: string
-                  /**
-                   * @description Title when creating a new spreadsheet
-                   * @default Stripe Sync
-                   */
-                  spreadsheet_title: string
-                  /**
-                   * @description Rows per Sheets API append call
-                   * @default 50
-                   */
-                  batch_size: number
-                  /** @constant */
-                  type: 'google-sheets'
-                }
-            streams?: {
-              name: string
-              /** @enum {string} */
-              sync_mode?: 'incremental' | 'full_refresh'
-              backfill_limit?: number
-            }[]
-            status?: {
-              phase: string
-              paused: boolean
-              iteration: number
-            }
-          }
-        }
-      }
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': {
-            error: unknown
-          }
-        }
-      }
-    }
-  }
-  'webhooks.push': {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        pipeline_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Event accepted */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'text/plain': 'ok'
-        }
-      }
-    }
-  }
+    health: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Server is healthy */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        ok: true;
+                    };
+                };
+            };
+        };
+    };
+    "pipelines.list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of pipelines */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: {
+                            id: string;
+                            source: {
+                                /** @description Stripe API key (sk_test_... or sk_live_...) */
+                                api_key: string;
+                                /** @description Stripe account ID (resolved from API if omitted) */
+                                account_id?: string;
+                                /** @description Whether this is a live mode sync */
+                                livemode?: boolean;
+                                /** @description Stripe API version (e.g. 2025-04-30.basil) */
+                                api_version?: string;
+                                /**
+                                 * Format: uri
+                                 * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
+                                 */
+                                base_url?: string;
+                                /**
+                                 * Format: uri
+                                 * @description URL for managed webhook endpoint registration
+                                 */
+                                webhook_url?: string;
+                                /** @description Webhook signing secret (whsec_...) for signature verification */
+                                webhook_secret?: string;
+                                /** @description Enable WebSocket streaming for live events */
+                                websocket?: boolean;
+                                /** @description Enable events API polling for incremental sync after backfill */
+                                poll_events?: boolean;
+                                /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
+                                webhook_port?: number;
+                                /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
+                                revalidate_objects?: string[];
+                                /** @description Max objects to backfill per stream (useful for testing) */
+                                backfill_limit?: number;
+                                /** @description Max Stripe API requests per second (default: 25) */
+                                rate_limit?: number;
+                                /** @description Number of time-range segments for parallel backfill (default: 200) */
+                                backfill_concurrency?: number;
+                                /** @constant */
+                                type: "stripe";
+                            };
+                            destination: {
+                                /** @description Postgres connection string (alias for connection_string) */
+                                url?: string;
+                                /** @description Postgres connection string */
+                                connection_string?: string;
+                                /** @description Postgres host (required for AWS IAM) */
+                                host?: string;
+                                /**
+                                 * @description Postgres port
+                                 * @default 5432
+                                 */
+                                port: number;
+                                /** @description Database name (required for AWS IAM) */
+                                database?: string;
+                                /** @description Database user (required for AWS IAM) */
+                                user?: string;
+                                /** @description Target schema name (e.g. "stripe_sync") */
+                                schema: string;
+                                /**
+                                 * @description Records to buffer before flushing
+                                 * @default 100
+                                 */
+                                batch_size: number;
+                                /** @description AWS RDS IAM authentication config */
+                                aws?: {
+                                    /** @description AWS region for RDS instance */
+                                    region: string;
+                                    /** @description IAM role ARN to assume (cross-account) */
+                                    role_arn?: string;
+                                    /** @description External ID for STS AssumeRole */
+                                    external_id?: string;
+                                };
+                                /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
+                                ssl_ca_pem?: string;
+                                /** @constant */
+                                type: "postgres";
+                            } | {
+                                /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
+                                client_id?: string;
+                                /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
+                                client_secret?: string;
+                                /** @description OAuth2 access token */
+                                access_token: string;
+                                /** @description OAuth2 refresh token */
+                                refresh_token: string;
+                                /** @description Target spreadsheet ID (created if omitted) */
+                                spreadsheet_id?: string;
+                                /**
+                                 * @description Title when creating a new spreadsheet
+                                 * @default Stripe Sync
+                                 */
+                                spreadsheet_title: string;
+                                /**
+                                 * @description Rows per Sheets API append call
+                                 * @default 50
+                                 */
+                                batch_size: number;
+                                /** @constant */
+                                type: "google-sheets";
+                            };
+                            streams?: {
+                                name: string;
+                                /** @enum {string} */
+                                sync_mode?: "incremental" | "full_refresh";
+                                backfill_limit?: number;
+                            }[];
+                            status?: {
+                                phase: string;
+                                paused: boolean;
+                                iteration: number;
+                            };
+                        }[];
+                        has_more: boolean;
+                    };
+                };
+            };
+        };
+    };
+    "pipelines.create": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    source: {
+                        /** @description Stripe API key (sk_test_... or sk_live_...) */
+                        api_key: string;
+                        /** @description Stripe account ID (resolved from API if omitted) */
+                        account_id?: string;
+                        /** @description Whether this is a live mode sync */
+                        livemode?: boolean;
+                        /** @description Stripe API version (e.g. 2025-04-30.basil) */
+                        api_version?: string;
+                        /**
+                         * Format: uri
+                         * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
+                         */
+                        base_url?: string;
+                        /**
+                         * Format: uri
+                         * @description URL for managed webhook endpoint registration
+                         */
+                        webhook_url?: string;
+                        /** @description Webhook signing secret (whsec_...) for signature verification */
+                        webhook_secret?: string;
+                        /** @description Enable WebSocket streaming for live events */
+                        websocket?: boolean;
+                        /** @description Enable events API polling for incremental sync after backfill */
+                        poll_events?: boolean;
+                        /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
+                        webhook_port?: number;
+                        /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
+                        revalidate_objects?: string[];
+                        /** @description Max objects to backfill per stream (useful for testing) */
+                        backfill_limit?: number;
+                        /** @description Max Stripe API requests per second (default: 25) */
+                        rate_limit?: number;
+                        /** @description Number of time-range segments for parallel backfill (default: 200) */
+                        backfill_concurrency?: number;
+                        /** @constant */
+                        type: "stripe";
+                    };
+                    destination: {
+                        /** @description Postgres connection string (alias for connection_string) */
+                        url?: string;
+                        /** @description Postgres connection string */
+                        connection_string?: string;
+                        /** @description Postgres host (required for AWS IAM) */
+                        host?: string;
+                        /**
+                         * @description Postgres port
+                         * @default 5432
+                         */
+                        port?: number;
+                        /** @description Database name (required for AWS IAM) */
+                        database?: string;
+                        /** @description Database user (required for AWS IAM) */
+                        user?: string;
+                        /** @description Target schema name (e.g. "stripe_sync") */
+                        schema: string;
+                        /**
+                         * @description Records to buffer before flushing
+                         * @default 100
+                         */
+                        batch_size?: number;
+                        /** @description AWS RDS IAM authentication config */
+                        aws?: {
+                            /** @description AWS region for RDS instance */
+                            region: string;
+                            /** @description IAM role ARN to assume (cross-account) */
+                            role_arn?: string;
+                            /** @description External ID for STS AssumeRole */
+                            external_id?: string;
+                        };
+                        /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
+                        ssl_ca_pem?: string;
+                        /** @constant */
+                        type: "postgres";
+                    } | {
+                        /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
+                        client_id?: string;
+                        /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
+                        client_secret?: string;
+                        /** @description OAuth2 access token */
+                        access_token: string;
+                        /** @description OAuth2 refresh token */
+                        refresh_token: string;
+                        /** @description Target spreadsheet ID (created if omitted) */
+                        spreadsheet_id?: string;
+                        /**
+                         * @description Title when creating a new spreadsheet
+                         * @default Stripe Sync
+                         */
+                        spreadsheet_title?: string;
+                        /**
+                         * @description Rows per Sheets API append call
+                         * @default 50
+                         */
+                        batch_size?: number;
+                        /** @constant */
+                        type: "google-sheets";
+                    };
+                    streams?: {
+                        name: string;
+                        /** @enum {string} */
+                        sync_mode?: "incremental" | "full_refresh";
+                        backfill_limit?: number;
+                    }[];
+                };
+            };
+        };
+        responses: {
+            /** @description Created pipeline */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        source: {
+                            /** @description Stripe API key (sk_test_... or sk_live_...) */
+                            api_key: string;
+                            /** @description Stripe account ID (resolved from API if omitted) */
+                            account_id?: string;
+                            /** @description Whether this is a live mode sync */
+                            livemode?: boolean;
+                            /** @description Stripe API version (e.g. 2025-04-30.basil) */
+                            api_version?: string;
+                            /**
+                             * Format: uri
+                             * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
+                             */
+                            base_url?: string;
+                            /**
+                             * Format: uri
+                             * @description URL for managed webhook endpoint registration
+                             */
+                            webhook_url?: string;
+                            /** @description Webhook signing secret (whsec_...) for signature verification */
+                            webhook_secret?: string;
+                            /** @description Enable WebSocket streaming for live events */
+                            websocket?: boolean;
+                            /** @description Enable events API polling for incremental sync after backfill */
+                            poll_events?: boolean;
+                            /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
+                            webhook_port?: number;
+                            /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
+                            revalidate_objects?: string[];
+                            /** @description Max objects to backfill per stream (useful for testing) */
+                            backfill_limit?: number;
+                            /** @description Max Stripe API requests per second (default: 25) */
+                            rate_limit?: number;
+                            /** @description Number of time-range segments for parallel backfill (default: 200) */
+                            backfill_concurrency?: number;
+                            /** @constant */
+                            type: "stripe";
+                        };
+                        destination: {
+                            /** @description Postgres connection string (alias for connection_string) */
+                            url?: string;
+                            /** @description Postgres connection string */
+                            connection_string?: string;
+                            /** @description Postgres host (required for AWS IAM) */
+                            host?: string;
+                            /**
+                             * @description Postgres port
+                             * @default 5432
+                             */
+                            port: number;
+                            /** @description Database name (required for AWS IAM) */
+                            database?: string;
+                            /** @description Database user (required for AWS IAM) */
+                            user?: string;
+                            /** @description Target schema name (e.g. "stripe_sync") */
+                            schema: string;
+                            /**
+                             * @description Records to buffer before flushing
+                             * @default 100
+                             */
+                            batch_size: number;
+                            /** @description AWS RDS IAM authentication config */
+                            aws?: {
+                                /** @description AWS region for RDS instance */
+                                region: string;
+                                /** @description IAM role ARN to assume (cross-account) */
+                                role_arn?: string;
+                                /** @description External ID for STS AssumeRole */
+                                external_id?: string;
+                            };
+                            /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
+                            ssl_ca_pem?: string;
+                            /** @constant */
+                            type: "postgres";
+                        } | {
+                            /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
+                            client_id?: string;
+                            /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
+                            client_secret?: string;
+                            /** @description OAuth2 access token */
+                            access_token: string;
+                            /** @description OAuth2 refresh token */
+                            refresh_token: string;
+                            /** @description Target spreadsheet ID (created if omitted) */
+                            spreadsheet_id?: string;
+                            /**
+                             * @description Title when creating a new spreadsheet
+                             * @default Stripe Sync
+                             */
+                            spreadsheet_title: string;
+                            /**
+                             * @description Rows per Sheets API append call
+                             * @default 50
+                             */
+                            batch_size: number;
+                            /** @constant */
+                            type: "google-sheets";
+                        };
+                        streams?: {
+                            name: string;
+                            /** @enum {string} */
+                            sync_mode?: "incremental" | "full_refresh";
+                            backfill_limit?: number;
+                        }[];
+                    };
+                };
+            };
+            /** @description Invalid input */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: unknown;
+                    };
+                };
+            };
+        };
+    };
+    "pipelines.get": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Retrieved pipeline with status */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        source: {
+                            /** @description Stripe API key (sk_test_... or sk_live_...) */
+                            api_key: string;
+                            /** @description Stripe account ID (resolved from API if omitted) */
+                            account_id?: string;
+                            /** @description Whether this is a live mode sync */
+                            livemode?: boolean;
+                            /** @description Stripe API version (e.g. 2025-04-30.basil) */
+                            api_version?: string;
+                            /**
+                             * Format: uri
+                             * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
+                             */
+                            base_url?: string;
+                            /**
+                             * Format: uri
+                             * @description URL for managed webhook endpoint registration
+                             */
+                            webhook_url?: string;
+                            /** @description Webhook signing secret (whsec_...) for signature verification */
+                            webhook_secret?: string;
+                            /** @description Enable WebSocket streaming for live events */
+                            websocket?: boolean;
+                            /** @description Enable events API polling for incremental sync after backfill */
+                            poll_events?: boolean;
+                            /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
+                            webhook_port?: number;
+                            /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
+                            revalidate_objects?: string[];
+                            /** @description Max objects to backfill per stream (useful for testing) */
+                            backfill_limit?: number;
+                            /** @description Max Stripe API requests per second (default: 25) */
+                            rate_limit?: number;
+                            /** @description Number of time-range segments for parallel backfill (default: 200) */
+                            backfill_concurrency?: number;
+                            /** @constant */
+                            type: "stripe";
+                        };
+                        destination: {
+                            /** @description Postgres connection string (alias for connection_string) */
+                            url?: string;
+                            /** @description Postgres connection string */
+                            connection_string?: string;
+                            /** @description Postgres host (required for AWS IAM) */
+                            host?: string;
+                            /**
+                             * @description Postgres port
+                             * @default 5432
+                             */
+                            port: number;
+                            /** @description Database name (required for AWS IAM) */
+                            database?: string;
+                            /** @description Database user (required for AWS IAM) */
+                            user?: string;
+                            /** @description Target schema name (e.g. "stripe_sync") */
+                            schema: string;
+                            /**
+                             * @description Records to buffer before flushing
+                             * @default 100
+                             */
+                            batch_size: number;
+                            /** @description AWS RDS IAM authentication config */
+                            aws?: {
+                                /** @description AWS region for RDS instance */
+                                region: string;
+                                /** @description IAM role ARN to assume (cross-account) */
+                                role_arn?: string;
+                                /** @description External ID for STS AssumeRole */
+                                external_id?: string;
+                            };
+                            /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
+                            ssl_ca_pem?: string;
+                            /** @constant */
+                            type: "postgres";
+                        } | {
+                            /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
+                            client_id?: string;
+                            /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
+                            client_secret?: string;
+                            /** @description OAuth2 access token */
+                            access_token: string;
+                            /** @description OAuth2 refresh token */
+                            refresh_token: string;
+                            /** @description Target spreadsheet ID (created if omitted) */
+                            spreadsheet_id?: string;
+                            /**
+                             * @description Title when creating a new spreadsheet
+                             * @default Stripe Sync
+                             */
+                            spreadsheet_title: string;
+                            /**
+                             * @description Rows per Sheets API append call
+                             * @default 50
+                             */
+                            batch_size: number;
+                            /** @constant */
+                            type: "google-sheets";
+                        };
+                        streams?: {
+                            name: string;
+                            /** @enum {string} */
+                            sync_mode?: "incremental" | "full_refresh";
+                            backfill_limit?: number;
+                        }[];
+                        status?: {
+                            phase: string;
+                            paused: boolean;
+                            iteration: number;
+                        };
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: unknown;
+                    };
+                };
+            };
+        };
+    };
+    "pipelines.delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted pipeline */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        /** @constant */
+                        deleted: true;
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: unknown;
+                    };
+                };
+            };
+            /** @description Teardown or deletion failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: unknown;
+                    };
+                };
+            };
+        };
+    };
+    "pipelines.update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    source?: {
+                        /** @description Stripe API key (sk_test_... or sk_live_...) */
+                        api_key: string;
+                        /** @description Stripe account ID (resolved from API if omitted) */
+                        account_id?: string;
+                        /** @description Whether this is a live mode sync */
+                        livemode?: boolean;
+                        /** @description Stripe API version (e.g. 2025-04-30.basil) */
+                        api_version?: string;
+                        /**
+                         * Format: uri
+                         * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
+                         */
+                        base_url?: string;
+                        /**
+                         * Format: uri
+                         * @description URL for managed webhook endpoint registration
+                         */
+                        webhook_url?: string;
+                        /** @description Webhook signing secret (whsec_...) for signature verification */
+                        webhook_secret?: string;
+                        /** @description Enable WebSocket streaming for live events */
+                        websocket?: boolean;
+                        /** @description Enable events API polling for incremental sync after backfill */
+                        poll_events?: boolean;
+                        /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
+                        webhook_port?: number;
+                        /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
+                        revalidate_objects?: string[];
+                        /** @description Max objects to backfill per stream (useful for testing) */
+                        backfill_limit?: number;
+                        /** @description Max Stripe API requests per second (default: 25) */
+                        rate_limit?: number;
+                        /** @description Number of time-range segments for parallel backfill (default: 200) */
+                        backfill_concurrency?: number;
+                        /** @constant */
+                        type: "stripe";
+                    };
+                    destination?: {
+                        /** @description Postgres connection string (alias for connection_string) */
+                        url?: string;
+                        /** @description Postgres connection string */
+                        connection_string?: string;
+                        /** @description Postgres host (required for AWS IAM) */
+                        host?: string;
+                        /**
+                         * @description Postgres port
+                         * @default 5432
+                         */
+                        port?: number;
+                        /** @description Database name (required for AWS IAM) */
+                        database?: string;
+                        /** @description Database user (required for AWS IAM) */
+                        user?: string;
+                        /** @description Target schema name (e.g. "stripe_sync") */
+                        schema: string;
+                        /**
+                         * @description Records to buffer before flushing
+                         * @default 100
+                         */
+                        batch_size?: number;
+                        /** @description AWS RDS IAM authentication config */
+                        aws?: {
+                            /** @description AWS region for RDS instance */
+                            region: string;
+                            /** @description IAM role ARN to assume (cross-account) */
+                            role_arn?: string;
+                            /** @description External ID for STS AssumeRole */
+                            external_id?: string;
+                        };
+                        /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
+                        ssl_ca_pem?: string;
+                        /** @constant */
+                        type: "postgres";
+                    } | {
+                        /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
+                        client_id?: string;
+                        /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
+                        client_secret?: string;
+                        /** @description OAuth2 access token */
+                        access_token: string;
+                        /** @description OAuth2 refresh token */
+                        refresh_token: string;
+                        /** @description Target spreadsheet ID (created if omitted) */
+                        spreadsheet_id?: string;
+                        /**
+                         * @description Title when creating a new spreadsheet
+                         * @default Stripe Sync
+                         */
+                        spreadsheet_title?: string;
+                        /**
+                         * @description Rows per Sheets API append call
+                         * @default 50
+                         */
+                        batch_size?: number;
+                        /** @constant */
+                        type: "google-sheets";
+                    };
+                    streams?: {
+                        name: string;
+                        /** @enum {string} */
+                        sync_mode?: "incremental" | "full_refresh";
+                        backfill_limit?: number;
+                    }[];
+                };
+            };
+        };
+        responses: {
+            /** @description Updated pipeline */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        source: {
+                            /** @description Stripe API key (sk_test_... or sk_live_...) */
+                            api_key: string;
+                            /** @description Stripe account ID (resolved from API if omitted) */
+                            account_id?: string;
+                            /** @description Whether this is a live mode sync */
+                            livemode?: boolean;
+                            /** @description Stripe API version (e.g. 2025-04-30.basil) */
+                            api_version?: string;
+                            /**
+                             * Format: uri
+                             * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
+                             */
+                            base_url?: string;
+                            /**
+                             * Format: uri
+                             * @description URL for managed webhook endpoint registration
+                             */
+                            webhook_url?: string;
+                            /** @description Webhook signing secret (whsec_...) for signature verification */
+                            webhook_secret?: string;
+                            /** @description Enable WebSocket streaming for live events */
+                            websocket?: boolean;
+                            /** @description Enable events API polling for incremental sync after backfill */
+                            poll_events?: boolean;
+                            /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
+                            webhook_port?: number;
+                            /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
+                            revalidate_objects?: string[];
+                            /** @description Max objects to backfill per stream (useful for testing) */
+                            backfill_limit?: number;
+                            /** @description Max Stripe API requests per second (default: 25) */
+                            rate_limit?: number;
+                            /** @description Number of time-range segments for parallel backfill (default: 200) */
+                            backfill_concurrency?: number;
+                            /** @constant */
+                            type: "stripe";
+                        };
+                        destination: {
+                            /** @description Postgres connection string (alias for connection_string) */
+                            url?: string;
+                            /** @description Postgres connection string */
+                            connection_string?: string;
+                            /** @description Postgres host (required for AWS IAM) */
+                            host?: string;
+                            /**
+                             * @description Postgres port
+                             * @default 5432
+                             */
+                            port: number;
+                            /** @description Database name (required for AWS IAM) */
+                            database?: string;
+                            /** @description Database user (required for AWS IAM) */
+                            user?: string;
+                            /** @description Target schema name (e.g. "stripe_sync") */
+                            schema: string;
+                            /**
+                             * @description Records to buffer before flushing
+                             * @default 100
+                             */
+                            batch_size: number;
+                            /** @description AWS RDS IAM authentication config */
+                            aws?: {
+                                /** @description AWS region for RDS instance */
+                                region: string;
+                                /** @description IAM role ARN to assume (cross-account) */
+                                role_arn?: string;
+                                /** @description External ID for STS AssumeRole */
+                                external_id?: string;
+                            };
+                            /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
+                            ssl_ca_pem?: string;
+                            /** @constant */
+                            type: "postgres";
+                        } | {
+                            /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
+                            client_id?: string;
+                            /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
+                            client_secret?: string;
+                            /** @description OAuth2 access token */
+                            access_token: string;
+                            /** @description OAuth2 refresh token */
+                            refresh_token: string;
+                            /** @description Target spreadsheet ID (created if omitted) */
+                            spreadsheet_id?: string;
+                            /**
+                             * @description Title when creating a new spreadsheet
+                             * @default Stripe Sync
+                             */
+                            spreadsheet_title: string;
+                            /**
+                             * @description Rows per Sheets API append call
+                             * @default 50
+                             */
+                            batch_size: number;
+                            /** @constant */
+                            type: "google-sheets";
+                        };
+                        streams?: {
+                            name: string;
+                            /** @enum {string} */
+                            sync_mode?: "incremental" | "full_refresh";
+                            backfill_limit?: number;
+                        }[];
+                        status?: {
+                            phase: string;
+                            paused: boolean;
+                            iteration: number;
+                        };
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: unknown;
+                    };
+                };
+            };
+        };
+    };
+    "pipelines.pause": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paused pipeline */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        source: {
+                            /** @description Stripe API key (sk_test_... or sk_live_...) */
+                            api_key: string;
+                            /** @description Stripe account ID (resolved from API if omitted) */
+                            account_id?: string;
+                            /** @description Whether this is a live mode sync */
+                            livemode?: boolean;
+                            /** @description Stripe API version (e.g. 2025-04-30.basil) */
+                            api_version?: string;
+                            /**
+                             * Format: uri
+                             * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
+                             */
+                            base_url?: string;
+                            /**
+                             * Format: uri
+                             * @description URL for managed webhook endpoint registration
+                             */
+                            webhook_url?: string;
+                            /** @description Webhook signing secret (whsec_...) for signature verification */
+                            webhook_secret?: string;
+                            /** @description Enable WebSocket streaming for live events */
+                            websocket?: boolean;
+                            /** @description Enable events API polling for incremental sync after backfill */
+                            poll_events?: boolean;
+                            /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
+                            webhook_port?: number;
+                            /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
+                            revalidate_objects?: string[];
+                            /** @description Max objects to backfill per stream (useful for testing) */
+                            backfill_limit?: number;
+                            /** @description Max Stripe API requests per second (default: 25) */
+                            rate_limit?: number;
+                            /** @description Number of time-range segments for parallel backfill (default: 200) */
+                            backfill_concurrency?: number;
+                            /** @constant */
+                            type: "stripe";
+                        };
+                        destination: {
+                            /** @description Postgres connection string (alias for connection_string) */
+                            url?: string;
+                            /** @description Postgres connection string */
+                            connection_string?: string;
+                            /** @description Postgres host (required for AWS IAM) */
+                            host?: string;
+                            /**
+                             * @description Postgres port
+                             * @default 5432
+                             */
+                            port: number;
+                            /** @description Database name (required for AWS IAM) */
+                            database?: string;
+                            /** @description Database user (required for AWS IAM) */
+                            user?: string;
+                            /** @description Target schema name (e.g. "stripe_sync") */
+                            schema: string;
+                            /**
+                             * @description Records to buffer before flushing
+                             * @default 100
+                             */
+                            batch_size: number;
+                            /** @description AWS RDS IAM authentication config */
+                            aws?: {
+                                /** @description AWS region for RDS instance */
+                                region: string;
+                                /** @description IAM role ARN to assume (cross-account) */
+                                role_arn?: string;
+                                /** @description External ID for STS AssumeRole */
+                                external_id?: string;
+                            };
+                            /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
+                            ssl_ca_pem?: string;
+                            /** @constant */
+                            type: "postgres";
+                        } | {
+                            /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
+                            client_id?: string;
+                            /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
+                            client_secret?: string;
+                            /** @description OAuth2 access token */
+                            access_token: string;
+                            /** @description OAuth2 refresh token */
+                            refresh_token: string;
+                            /** @description Target spreadsheet ID (created if omitted) */
+                            spreadsheet_id?: string;
+                            /**
+                             * @description Title when creating a new spreadsheet
+                             * @default Stripe Sync
+                             */
+                            spreadsheet_title: string;
+                            /**
+                             * @description Rows per Sheets API append call
+                             * @default 50
+                             */
+                            batch_size: number;
+                            /** @constant */
+                            type: "google-sheets";
+                        };
+                        streams?: {
+                            name: string;
+                            /** @enum {string} */
+                            sync_mode?: "incremental" | "full_refresh";
+                            backfill_limit?: number;
+                        }[];
+                        status?: {
+                            phase: string;
+                            paused: boolean;
+                            iteration: number;
+                        };
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: unknown;
+                    };
+                };
+            };
+        };
+    };
+    "pipelines.resume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Resumed pipeline */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        source: {
+                            /** @description Stripe API key (sk_test_... or sk_live_...) */
+                            api_key: string;
+                            /** @description Stripe account ID (resolved from API if omitted) */
+                            account_id?: string;
+                            /** @description Whether this is a live mode sync */
+                            livemode?: boolean;
+                            /** @description Stripe API version (e.g. 2025-04-30.basil) */
+                            api_version?: string;
+                            /**
+                             * Format: uri
+                             * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
+                             */
+                            base_url?: string;
+                            /**
+                             * Format: uri
+                             * @description URL for managed webhook endpoint registration
+                             */
+                            webhook_url?: string;
+                            /** @description Webhook signing secret (whsec_...) for signature verification */
+                            webhook_secret?: string;
+                            /** @description Enable WebSocket streaming for live events */
+                            websocket?: boolean;
+                            /** @description Enable events API polling for incremental sync after backfill */
+                            poll_events?: boolean;
+                            /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
+                            webhook_port?: number;
+                            /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
+                            revalidate_objects?: string[];
+                            /** @description Max objects to backfill per stream (useful for testing) */
+                            backfill_limit?: number;
+                            /** @description Max Stripe API requests per second (default: 25) */
+                            rate_limit?: number;
+                            /** @description Number of time-range segments for parallel backfill (default: 200) */
+                            backfill_concurrency?: number;
+                            /** @constant */
+                            type: "stripe";
+                        };
+                        destination: {
+                            /** @description Postgres connection string (alias for connection_string) */
+                            url?: string;
+                            /** @description Postgres connection string */
+                            connection_string?: string;
+                            /** @description Postgres host (required for AWS IAM) */
+                            host?: string;
+                            /**
+                             * @description Postgres port
+                             * @default 5432
+                             */
+                            port: number;
+                            /** @description Database name (required for AWS IAM) */
+                            database?: string;
+                            /** @description Database user (required for AWS IAM) */
+                            user?: string;
+                            /** @description Target schema name (e.g. "stripe_sync") */
+                            schema: string;
+                            /**
+                             * @description Records to buffer before flushing
+                             * @default 100
+                             */
+                            batch_size: number;
+                            /** @description AWS RDS IAM authentication config */
+                            aws?: {
+                                /** @description AWS region for RDS instance */
+                                region: string;
+                                /** @description IAM role ARN to assume (cross-account) */
+                                role_arn?: string;
+                                /** @description External ID for STS AssumeRole */
+                                external_id?: string;
+                            };
+                            /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
+                            ssl_ca_pem?: string;
+                            /** @constant */
+                            type: "postgres";
+                        } | {
+                            /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
+                            client_id?: string;
+                            /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
+                            client_secret?: string;
+                            /** @description OAuth2 access token */
+                            access_token: string;
+                            /** @description OAuth2 refresh token */
+                            refresh_token: string;
+                            /** @description Target spreadsheet ID (created if omitted) */
+                            spreadsheet_id?: string;
+                            /**
+                             * @description Title when creating a new spreadsheet
+                             * @default Stripe Sync
+                             */
+                            spreadsheet_title: string;
+                            /**
+                             * @description Rows per Sheets API append call
+                             * @default 50
+                             */
+                            batch_size: number;
+                            /** @constant */
+                            type: "google-sheets";
+                        };
+                        streams?: {
+                            name: string;
+                            /** @enum {string} */
+                            sync_mode?: "incremental" | "full_refresh";
+                            backfill_limit?: number;
+                        }[];
+                        status?: {
+                            phase: string;
+                            paused: boolean;
+                            iteration: number;
+                        };
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: unknown;
+                    };
+                };
+            };
+        };
+    };
+    "webhooks.push": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                pipeline_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Event accepted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": "ok";
+                };
+            };
+        };
+    };
 }

--- a/apps/service/src/__generated__/openapi.d.ts
+++ b/apps/service/src/__generated__/openapi.d.ts
@@ -140,7 +140,7 @@ export interface operations {
         }
         content: {
           'application/json': {
-            /** @enum {boolean} */
+            /** @constant */
             ok: true
           }
         }
@@ -200,7 +200,7 @@ export interface operations {
                 rate_limit?: number
                 /** @description Number of time-range segments for parallel backfill (default: 200) */
                 backfill_concurrency?: number
-                /** @enum {string} */
+                /** @constant */
                 type: 'stripe'
               }
               destination:
@@ -220,10 +220,7 @@ export interface operations {
                     database?: string
                     /** @description Database user (required for AWS IAM) */
                     user?: string
-                    /**
-                     * @description Target schema name
-                     * @default public
-                     */
+                    /** @description Target schema name (e.g. "stripe_sync") */
                     schema: string
                     /**
                      * @description Records to buffer before flushing
@@ -241,7 +238,7 @@ export interface operations {
                     }
                     /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
                     ssl_ca_pem?: string
-                    /** @enum {string} */
+                    /** @constant */
                     type: 'postgres'
                   }
                 | {
@@ -265,7 +262,7 @@ export interface operations {
                      * @default 50
                      */
                     batch_size: number
-                    /** @enum {string} */
+                    /** @constant */
                     type: 'google-sheets'
                   }
               streams?: {
@@ -274,6 +271,11 @@ export interface operations {
                 sync_mode?: 'incremental' | 'full_refresh'
                 backfill_limit?: number
               }[]
+              status?: {
+                phase: string
+                paused: boolean
+                iteration: number
+              }
             }[]
             has_more: boolean
           }
@@ -326,7 +328,7 @@ export interface operations {
             rate_limit?: number
             /** @description Number of time-range segments for parallel backfill (default: 200) */
             backfill_concurrency?: number
-            /** @enum {string} */
+            /** @constant */
             type: 'stripe'
           }
           destination:
@@ -346,11 +348,8 @@ export interface operations {
                 database?: string
                 /** @description Database user (required for AWS IAM) */
                 user?: string
-                /**
-                 * @description Target schema name
-                 * @default public
-                 */
-                schema?: string
+                /** @description Target schema name (e.g. "stripe_sync") */
+                schema: string
                 /**
                  * @description Records to buffer before flushing
                  * @default 100
@@ -367,7 +366,7 @@ export interface operations {
                 }
                 /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
                 ssl_ca_pem?: string
-                /** @enum {string} */
+                /** @constant */
                 type: 'postgres'
               }
             | {
@@ -391,7 +390,7 @@ export interface operations {
                  * @default 50
                  */
                 batch_size?: number
-                /** @enum {string} */
+                /** @constant */
                 type: 'google-sheets'
               }
           streams?: {
@@ -447,7 +446,7 @@ export interface operations {
               rate_limit?: number
               /** @description Number of time-range segments for parallel backfill (default: 200) */
               backfill_concurrency?: number
-              /** @enum {string} */
+              /** @constant */
               type: 'stripe'
             }
             destination:
@@ -467,10 +466,7 @@ export interface operations {
                   database?: string
                   /** @description Database user (required for AWS IAM) */
                   user?: string
-                  /**
-                   * @description Target schema name
-                   * @default public
-                   */
+                  /** @description Target schema name (e.g. "stripe_sync") */
                   schema: string
                   /**
                    * @description Records to buffer before flushing
@@ -488,7 +484,7 @@ export interface operations {
                   }
                   /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
                   ssl_ca_pem?: string
-                  /** @enum {string} */
+                  /** @constant */
                   type: 'postgres'
                 }
               | {
@@ -512,7 +508,7 @@ export interface operations {
                    * @default 50
                    */
                   batch_size: number
-                  /** @enum {string} */
+                  /** @constant */
                   type: 'google-sheets'
                 }
             streams?: {
@@ -531,7 +527,7 @@ export interface operations {
         }
         content: {
           'application/json': {
-            error?: unknown
+            error: unknown
           }
         }
       }
@@ -591,7 +587,7 @@ export interface operations {
               rate_limit?: number
               /** @description Number of time-range segments for parallel backfill (default: 200) */
               backfill_concurrency?: number
-              /** @enum {string} */
+              /** @constant */
               type: 'stripe'
             }
             destination:
@@ -611,10 +607,7 @@ export interface operations {
                   database?: string
                   /** @description Database user (required for AWS IAM) */
                   user?: string
-                  /**
-                   * @description Target schema name
-                   * @default public
-                   */
+                  /** @description Target schema name (e.g. "stripe_sync") */
                   schema: string
                   /**
                    * @description Records to buffer before flushing
@@ -632,7 +625,7 @@ export interface operations {
                   }
                   /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
                   ssl_ca_pem?: string
-                  /** @enum {string} */
+                  /** @constant */
                   type: 'postgres'
                 }
               | {
@@ -656,7 +649,7 @@ export interface operations {
                    * @default 50
                    */
                   batch_size: number
-                  /** @enum {string} */
+                  /** @constant */
                   type: 'google-sheets'
                 }
             streams?: {
@@ -680,7 +673,7 @@ export interface operations {
         }
         content: {
           'application/json': {
-            error?: unknown
+            error: unknown
           }
         }
       }
@@ -705,7 +698,7 @@ export interface operations {
         content: {
           'application/json': {
             id: string
-            /** @enum {boolean} */
+            /** @constant */
             deleted: true
           }
         }
@@ -717,7 +710,18 @@ export interface operations {
         }
         content: {
           'application/json': {
-            error?: unknown
+            error: unknown
+          }
+        }
+      }
+      /** @description Teardown or deletion failed */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            error: unknown
           }
         }
       }
@@ -770,7 +774,7 @@ export interface operations {
             rate_limit?: number
             /** @description Number of time-range segments for parallel backfill (default: 200) */
             backfill_concurrency?: number
-            /** @enum {string} */
+            /** @constant */
             type: 'stripe'
           }
           destination?:
@@ -790,11 +794,8 @@ export interface operations {
                 database?: string
                 /** @description Database user (required for AWS IAM) */
                 user?: string
-                /**
-                 * @description Target schema name
-                 * @default public
-                 */
-                schema?: string
+                /** @description Target schema name (e.g. "stripe_sync") */
+                schema: string
                 /**
                  * @description Records to buffer before flushing
                  * @default 100
@@ -811,7 +812,7 @@ export interface operations {
                 }
                 /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
                 ssl_ca_pem?: string
-                /** @enum {string} */
+                /** @constant */
                 type: 'postgres'
               }
             | {
@@ -835,7 +836,7 @@ export interface operations {
                  * @default 50
                  */
                 batch_size?: number
-                /** @enum {string} */
+                /** @constant */
                 type: 'google-sheets'
               }
           streams?: {
@@ -891,7 +892,7 @@ export interface operations {
               rate_limit?: number
               /** @description Number of time-range segments for parallel backfill (default: 200) */
               backfill_concurrency?: number
-              /** @enum {string} */
+              /** @constant */
               type: 'stripe'
             }
             destination:
@@ -911,10 +912,7 @@ export interface operations {
                   database?: string
                   /** @description Database user (required for AWS IAM) */
                   user?: string
-                  /**
-                   * @description Target schema name
-                   * @default public
-                   */
+                  /** @description Target schema name (e.g. "stripe_sync") */
                   schema: string
                   /**
                    * @description Records to buffer before flushing
@@ -932,7 +930,7 @@ export interface operations {
                   }
                   /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
                   ssl_ca_pem?: string
-                  /** @enum {string} */
+                  /** @constant */
                   type: 'postgres'
                 }
               | {
@@ -956,7 +954,7 @@ export interface operations {
                    * @default 50
                    */
                   batch_size: number
-                  /** @enum {string} */
+                  /** @constant */
                   type: 'google-sheets'
                 }
             streams?: {
@@ -980,7 +978,7 @@ export interface operations {
         }
         content: {
           'application/json': {
-            error?: unknown
+            error: unknown
           }
         }
       }
@@ -1040,7 +1038,7 @@ export interface operations {
               rate_limit?: number
               /** @description Number of time-range segments for parallel backfill (default: 200) */
               backfill_concurrency?: number
-              /** @enum {string} */
+              /** @constant */
               type: 'stripe'
             }
             destination:
@@ -1060,10 +1058,7 @@ export interface operations {
                   database?: string
                   /** @description Database user (required for AWS IAM) */
                   user?: string
-                  /**
-                   * @description Target schema name
-                   * @default public
-                   */
+                  /** @description Target schema name (e.g. "stripe_sync") */
                   schema: string
                   /**
                    * @description Records to buffer before flushing
@@ -1081,7 +1076,7 @@ export interface operations {
                   }
                   /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
                   ssl_ca_pem?: string
-                  /** @enum {string} */
+                  /** @constant */
                   type: 'postgres'
                 }
               | {
@@ -1105,7 +1100,7 @@ export interface operations {
                    * @default 50
                    */
                   batch_size: number
-                  /** @enum {string} */
+                  /** @constant */
                   type: 'google-sheets'
                 }
             streams?: {
@@ -1129,7 +1124,7 @@ export interface operations {
         }
         content: {
           'application/json': {
-            error?: unknown
+            error: unknown
           }
         }
       }
@@ -1189,7 +1184,7 @@ export interface operations {
               rate_limit?: number
               /** @description Number of time-range segments for parallel backfill (default: 200) */
               backfill_concurrency?: number
-              /** @enum {string} */
+              /** @constant */
               type: 'stripe'
             }
             destination:
@@ -1209,10 +1204,7 @@ export interface operations {
                   database?: string
                   /** @description Database user (required for AWS IAM) */
                   user?: string
-                  /**
-                   * @description Target schema name
-                   * @default public
-                   */
+                  /** @description Target schema name (e.g. "stripe_sync") */
                   schema: string
                   /**
                    * @description Records to buffer before flushing
@@ -1230,7 +1222,7 @@ export interface operations {
                   }
                   /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
                   ssl_ca_pem?: string
-                  /** @enum {string} */
+                  /** @constant */
                   type: 'postgres'
                 }
               | {
@@ -1254,7 +1246,7 @@ export interface operations {
                    * @default 50
                    */
                   batch_size: number
-                  /** @enum {string} */
+                  /** @constant */
                   type: 'google-sheets'
                 }
             streams?: {
@@ -1278,7 +1270,7 @@ export interface operations {
         }
         content: {
           'application/json': {
-            error?: unknown
+            error: unknown
           }
         }
       }

--- a/apps/service/src/temporal/activities.ts
+++ b/apps/service/src/temporal/activities.ts
@@ -90,13 +90,13 @@ export function createActivities(opts: { engineUrl: string; kafkaBroker?: string
         input?: unknown[]
         state?: Record<string, unknown>
         stateLimit?: number
-        timeLimitSeconds?: number
+        timeLimit?: number
       }
     ): Promise<RunResult & { eof?: { reason: string } }> {
       const engine = createRemoteEngine(engineUrl, config, {
         state: opts?.state,
         stateLimit: opts?.stateLimit,
-        timeLimitSeconds: opts?.timeLimitSeconds,
+        timeLimit: opts?.timeLimit,
       })
       const input = opts?.input?.length ? asIterable(opts.input) : undefined
       const { errors, state, eof } = await drainMessages(
@@ -112,13 +112,13 @@ export function createActivities(opts: { engineUrl: string; kafkaBroker?: string
         input?: unknown[]
         state?: Record<string, unknown>
         stateLimit?: number
-        timeLimitSeconds?: number
+        timeLimit?: number
       }
     ): Promise<{ count: number; state: Record<string, unknown>; eof?: { reason: string } }> {
       const engine = createRemoteEngine(engineUrl, config, {
         state: opts?.state,
         stateLimit: opts?.stateLimit,
-        timeLimitSeconds: opts?.timeLimitSeconds,
+        timeLimit: opts?.timeLimit,
       })
       const input = opts?.input?.length ? asIterable(opts.input) : undefined
       const { records, state, eof } = await drainMessages(

--- a/apps/service/src/temporal/activities.ts
+++ b/apps/service/src/temporal/activities.ts
@@ -13,20 +13,24 @@ async function* asIterable<T>(items: T[]): AsyncIterable<T> {
   for (const item of items) yield item
 }
 
-/** Iterate a message stream, collecting errors/state/records and heartbeating. */
+/** Iterate a message stream, collecting errors/state/records/eof and heartbeating. */
 async function drainMessages(stream: AsyncIterable<Record<string, unknown>>): Promise<{
   errors: RunResult['errors']
   state: Record<string, unknown>
   records: unknown[]
+  eof?: { reason: string }
 }> {
   const errors: RunResult['errors'] = []
   const state: Record<string, unknown> = {}
   const records: unknown[] = []
+  let eof: { reason: string } | undefined
   let count = 0
 
   for await (const m of stream) {
     count++
-    if (m.type === 'error') {
+    if (m.type === 'eof') {
+      eof = { reason: m.reason as string }
+    } else if (m.type === 'error') {
       errors.push({
         message:
           (m.message as string) ||
@@ -44,7 +48,7 @@ async function drainMessages(stream: AsyncIterable<Record<string, unknown>>): Pr
   }
   if (count % 50 !== 0) heartbeat({ messages: count })
 
-  return { errors, state, records }
+  return { errors, state, records, eof }
 }
 
 export function createActivities(opts: { engineUrl: string; kafkaBroker?: string }) {
@@ -82,30 +86,42 @@ export function createActivities(opts: { engineUrl: string; kafkaBroker?: string
 
     async syncImmediate(
       config: PipelineConfig,
-      opts?: { input?: unknown[]; state?: Record<string, unknown>; stateLimit?: number }
-    ): Promise<RunResult> {
+      opts?: {
+        input?: unknown[]
+        state?: Record<string, unknown>
+        stateLimit?: number
+        timeLimitSeconds?: number
+      }
+    ): Promise<RunResult & { eof?: { reason: string } }> {
       const engine = createRemoteEngine(engineUrl, config, {
         state: opts?.state,
         stateLimit: opts?.stateLimit,
+        timeLimitSeconds: opts?.timeLimitSeconds,
       })
       const input = opts?.input?.length ? asIterable(opts.input) : undefined
-      const { errors, state } = await drainMessages(
+      const { errors, state, eof } = await drainMessages(
         engine.sync(input) as AsyncIterable<Record<string, unknown>>
       )
-      return { errors, state }
+      return { errors, state, eof }
     },
 
     async readIntoQueue(
       config: PipelineConfig,
       pipelineId: string,
-      opts?: { input?: unknown[]; state?: Record<string, unknown>; stateLimit?: number }
-    ): Promise<{ count: number; state: Record<string, unknown> }> {
+      opts?: {
+        input?: unknown[]
+        state?: Record<string, unknown>
+        stateLimit?: number
+        timeLimitSeconds?: number
+      }
+    ): Promise<{ count: number; state: Record<string, unknown>; eof?: { reason: string } }> {
       const engine = createRemoteEngine(engineUrl, config, {
         state: opts?.state,
         stateLimit: opts?.stateLimit,
+        timeLimitSeconds: opts?.timeLimitSeconds,
       })
       const input = opts?.input?.length ? asIterable(opts.input) : undefined
-      const { records, state } = await drainMessages(
+      const { records, state, eof } = await drainMessages(
         engine.read(input) as AsyncIterable<Record<string, unknown>>
       )
 
@@ -118,7 +134,7 @@ export function createActivities(opts: { engineUrl: string; kafkaBroker?: string
         })
       }
 
-      return { count: records.length, state }
+      return { count: records.length, state, eof }
     },
 
     async writeFromQueue(

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -22,7 +22,7 @@ Short records of key architectural choices and why they were made.
 
 **Decision:** State is a message type in the protocol, not a separate storage API.
 
-**Rationale:** Keeps connectors stateless and testable. State messages flow through the same async iterable pipeline as data, making them composable with `takeStateCheckpoints()` and other stream utilities.
+**Rationale:** Keeps connectors stateless and testable. State messages flow through the same async iterable pipeline as data, making them composable with `takeLimits()` and other stream utilities.
 
 **Consequence:** Connectors yield `StateMessage` when they want to checkpoint. They receive state via `cursor_in` parameter, never by querying a store.
 

--- a/docs/plans/stream-limits-and-eof.md
+++ b/docs/plans/stream-limits-and-eof.md
@@ -1,0 +1,42 @@
+# Stream Limits and EOF Terminal Message
+
+## Problem
+
+The sync workflow is slow because `stateLimit: 1` means one page per Temporal activity invocation — massive overhead per page (activity scheduling, HTTP connection, connector instantiation). The `X-State-Checkpoint-Limit` header is awkwardly named and only supports count-based limits.
+
+## Solution
+
+Replace `X-State-Checkpoint-Limit` header with two query parameters and add an `eof` terminal message:
+
+- `?state_limit=N` — stop after N state messages (count-based)
+- `?time_limit=N` — stop after N seconds (time-based, any message boundary)
+- `eof` message — last line of every NDJSON response, tells client why stream ended
+
+### EOF message
+
+Every NDJSON streaming response (`/read`, `/sync`) ends with an `eof` message:
+
+```jsonl
+{"type":"record","stream":"customers","data":{"id":"cus_1"},"emitted_at":"..."}
+{"type":"state","stream":"customers","data":{"cursor":"cus_1"}}
+{"type":"eof","reason":"state_limit"}
+```
+
+Reasons:
+
+- `complete` — source exhausted, all data read/written
+- `state_limit` — hit `?state_limit=N`
+- `time_limit` — hit `?time_limit=N`
+- `error` — fatal error stopped the stream
+
+### Why server-side limits (not client-side cancellation)
+
+HTTP streaming is server-push — the server drives the pipeline and writes NDJSON to the socket. TCP backpressure is byte-level, not message-level. Client-side cancellation means the server could be several pages ahead, doing wasted Stripe API calls and Postgres writes whose state the client won't capture. Server-side limits stop cleanly at the right boundary with no wasted work.
+
+### Why `eof` instead of just closing the stream
+
+Every mature streaming protocol needs an explicit terminal signal because transport-level EOF is ambiguous (success vs error vs truncation). Comparable prior art: gRPC trailing metadata with status, OpenAI's `data: [DONE]`, GraphQL subscriptions' `complete` message, JS Iterator's `{ done: true }`.
+
+## Future
+
+Unify all connector operations (spec, discover, check) to use NDJSON streaming — currently these are simple request/response methods, but a unified NDJSON protocol (like Airbyte's) simplifies middleware and tooling.

--- a/packages/protocol/src/protocol.ts
+++ b/packages/protocol/src/protocol.ts
@@ -179,6 +179,18 @@ export const StreamStatusMessage = z
   .meta({ id: 'StreamStatusMessage' })
 export type StreamStatusMessage = z.infer<typeof StreamStatusMessage>
 
+/**
+ * Terminal message — always the last line in an NDJSON streaming response.
+ * Tells the client why the stream ended so it can decide whether to call again.
+ */
+export const EofMessage = z
+  .object({
+    type: z.literal('eof'),
+    reason: z.enum(['complete', 'state_limit', 'time_limit', 'error']),
+  })
+  .meta({ id: 'EofMessage' })
+export type EofMessage = z.infer<typeof EofMessage>
+
 // MARK: - Pipeline params
 
 /** Parameters for a sync pipeline — source/destination config and optional stream selection. */
@@ -203,11 +215,12 @@ export const SyncEngineParams = PipelineConfig
 /** @deprecated Use PipelineConfig */
 export type SyncEngineParams = PipelineConfig
 
-/** The full set of parsed sync request params: pipeline config + cursor state + pagination. */
+/** The full set of parsed sync request params: pipeline config + cursor state + stream limits. */
 export interface SyncParams {
   pipeline: PipelineConfig
   state?: Record<string, unknown>
-  stateCheckpointLimit?: number
+  stateLimit?: number
+  timeLimitMs?: number
 }
 
 // MARK: - Message unions
@@ -218,7 +231,7 @@ export type DestinationInput = z.infer<typeof DestinationInput>
 
 /** Messages the destination yields back to the orchestrator (one per NDJSON line). */
 export const DestinationOutput = z
-  .discriminatedUnion('type', [StateMessage, ErrorMessage, LogMessage])
+  .discriminatedUnion('type', [StateMessage, ErrorMessage, LogMessage, EofMessage])
   .meta({ id: 'DestinationOutput' })
 export type DestinationOutput = z.infer<typeof DestinationOutput>
 
@@ -231,6 +244,7 @@ export const Message = z
     LogMessage,
     ErrorMessage,
     StreamStatusMessage,
+    EofMessage,
   ])
   .meta({ id: 'Message' })
 export type Message = z.infer<typeof Message>

--- a/scripts/generate-openapi.sh
+++ b/scripts/generate-openapi.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
-# Generate OpenAPI specs from engine and service apps.
-# Output: apps/{engine,service}/src/__generated__/openapi.json
+# Generate OpenAPI specs and TypeScript types from engine and service apps.
+# Output: apps/{engine,service}/src/__generated__/{openapi.json,openapi.d.ts}
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
 engine_out=apps/engine/src/__generated__/openapi.json
 service_out=apps/service/src/__generated__/openapi.json
+engine_dts=apps/engine/src/__generated__/openapi.d.ts
+service_dts=apps/service/src/__generated__/openapi.d.ts
 
 check_mode=false
 if [[ "${1:-}" == "--check" ]]; then
@@ -15,6 +17,8 @@ if [[ "${1:-}" == "--check" ]]; then
   trap 'rm -rf "$tmpdir"' EXIT
   engine_out="$tmpdir/engine.json"
   service_out="$tmpdir/service.json"
+  engine_dts="$tmpdir/engine.d.ts"
+  service_dts="$tmpdir/service.d.ts"
 fi
 
 echo "Generating engine OpenAPI spec..."
@@ -57,24 +61,37 @@ pnpm exec prettier --config .prettierrc --log-level warn --write \
   "$engine_out" \
   "$service_out"
 
+echo "Generating TypeScript types..."
+# Resolve to absolute paths (needed because pnpm --filter changes cwd)
+abs_engine_out="$(cd "$(dirname "$engine_out")" && pwd)/$(basename "$engine_out")"
+abs_engine_dts="$(cd "$(dirname "$engine_dts")" && pwd)/$(basename "$engine_dts")"
+abs_service_out="$(cd "$(dirname "$service_out")" && pwd)/$(basename "$service_out")"
+abs_service_dts="$(cd "$(dirname "$service_dts")" && pwd)/$(basename "$service_dts")"
+pnpm --filter @stripe/sync-engine exec openapi-typescript "$abs_engine_out" -o "$abs_engine_dts"
+pnpm --filter @stripe/sync-service exec openapi-typescript "$abs_service_out" -o "$abs_service_dts"
+
 if $check_mode; then
   drift=false
-  for pair in "engine:apps/engine/src/__generated__/openapi.json" "service:apps/service/src/__generated__/openapi.json"; do
-    name="${pair%%:*}"
+  for pair in \
+    "engine.json:apps/engine/src/__generated__/openapi.json" \
+    "service.json:apps/service/src/__generated__/openapi.json" \
+    "engine.d.ts:apps/engine/src/__generated__/openapi.d.ts" \
+    "service.d.ts:apps/service/src/__generated__/openapi.d.ts"; do
+    file="${pair%%:*}"
     checked_in="${pair#*:}"
-    generated="$tmpdir/$name.json"
+    generated="$tmpdir/$file"
     if ! diff -q "$generated" "$checked_in" > /dev/null 2>&1; then
       echo "DRIFT: $checked_in is out of date"
-      diff --unified "$generated" "$checked_in" || true
+      diff --unified "$generated" "$checked_in" | head -40 || true
       drift=true
     fi
   done
   if $drift; then
     echo ""
-    echo "OpenAPI specs are out of date. Run: ./scripts/generate-openapi.sh"
+    echo "Generated OpenAPI files are out of date. Run: ./scripts/generate-openapi.sh"
     exit 1
   fi
-  echo "OpenAPI specs are up to date."
+  echo "Generated OpenAPI files are up to date."
 else
   # Copy to docs/openapi/ for publishing (CDN/static site)
   mkdir -p docs/openapi
@@ -84,5 +101,7 @@ else
   echo "Done:"
   echo "  $engine_out  ($(wc -l < "$engine_out") lines)"
   echo "  $service_out ($(wc -l < "$service_out") lines)"
+  echo "  $engine_dts"
+  echo "  $service_dts"
   echo "  docs/openapi/ (publishing copy)"
 fi


### PR DESCRIPTION
## Summary

- Add `EofMessage` to the protocol — always the last NDJSON line in `/read` and `/sync` responses, telling the client why the stream ended (`complete`, `state_limit`, `time_limit`, or `error`)
- Replace `X-State-Checkpoint-Limit` header with `?state_limit=N` and `?time_limit=N` query params
- `takeLimits()` replaces `takeStateCheckpoints()` with combined state count + time deadline support
- Activities capture `eof` from the NDJSON stream so the workflow knows whether to call again

## Motivation

The sync workflow is slow because `stateLimit: 1` means one page per Temporal activity invocation. These changes let callers control how much work a single response does via query params, and the `eof` message tells the client why streaming stopped — removing ambiguity between "source exhausted" and "limit hit."

See `docs/plans/stream-limits-and-eof.md` for the full design rationale.

## Test plan

- [x] All 531 unit tests pass (147 engine, 87 source-stripe, etc.)
- [x] Pipeline tests cover: state_limit, time_limit, combined limits, eof reasons, empty streams
- [x] API tests verify query params on /read and /sync with eof terminal messages
- [x] OpenAPI spec regenerated — `state_limit` and `time_limit` as query params, `EofMessage` in schemas, no `x-state-checkpoint-limit` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)