### PR TITLE
feat(protocol): Zod .describe() for OpenAPI field descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ for the full dependency graph.
 
 ## Key Rules
 
+0. **This file is an index, not a rulebook** — before adding anything here, check if it belongs in [docs/architecture/principles.md](docs/architecture/principles.md), [docs/architecture/decisions.md](docs/architecture/decisions.md), or another doc first. Only add to AGENTS.md if no better home exists.
 1. **Connector isolation** — sources never import destinations, both depend only on `protocol`. Enforced by `e2e/layers.test.ts`.
 2. **State is a message** — connectors never access state storage directly. State in = `cursor_in`; state out = `StateMessage`.
 3. **Snake_case on the wire** — all Zod schemas and JSON wire format use snake_case.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,6 @@ See [docs/architecture/principles.md](docs/architecture/principles.md) for the c
 - All serializable inputs/outputs (Zod schemas, JSON wire format) must use **snake_case** field names.
 - Source connectors must use `console.error` for logging (stdout is the NDJSON stream).
 - Generated OpenAPI specs live in each package's `src/__generated__/openapi.json` — regenerate after route/schema changes.
-- Zod schema fields must use `.describe()` for descriptions — JSDoc comments on Zod fields are stripped by TypeScript and never reach the generated OpenAPI spec.
 - Non-trivial PRs should be accompanied by a plan artifact in `docs/plans/YYYY-MM-DD-<slug>.md`. Save it before or alongside the first implementation commit.
 
 ## Key Gotchas

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,8 @@ See [docs/architecture/principles.md](docs/architecture/principles.md) for the c
 - All serializable inputs/outputs (Zod schemas, JSON wire format) must use **snake_case** field names.
 - Source connectors must use `console.error` for logging (stdout is the NDJSON stream).
 - Generated OpenAPI specs live in each package's `src/__generated__/openapi.json` — regenerate after route/schema changes.
+- Zod schema fields must use `.describe()` for descriptions — JSDoc comments on Zod fields are stripped by TypeScript and never reach the generated OpenAPI spec.
+- Non-trivial PRs should be accompanied by a plan artifact in `docs/plans/YYYY-MM-DD-<slug>.md`. Save it before or alongside the first implementation commit.
 
 ## Key Gotchas
 

--- a/apps/engine/src/__generated__/openapi.d.ts
+++ b/apps/engine/src/__generated__/openapi.d.ts
@@ -183,75 +183,107 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         Message: components["schemas"]["RecordMessage"] | components["schemas"]["StateMessage"] | components["schemas"]["CatalogMessage"] | components["schemas"]["LogMessage"] | components["schemas"]["ErrorMessage"] | components["schemas"]["StreamStatusMessage"] | components["schemas"]["EofMessage"];
+        /** @description One record for one stream. */
         RecordMessage: {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
             type: "record";
+            /** @description Stream (table) name this record belongs to. */
             stream: string;
+            /** @description The record payload as a key-value map. */
             data: {
                 [key: string]: unknown;
             };
-            /** Format: date-time */
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp when the record was emitted by the source.
+             */
             emitted_at: string;
         };
+        /** @description Per-stream checkpoint for resumable syncs. Emitted by the source after each page/batch so the orchestrator can persist progress. */
         StateMessage: {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
             type: "state";
+            /** @description Stream being checkpointed. */
             stream: string;
+            /** @description Opaque checkpoint data — only the source understands its contents. The orchestrator persists it keyed by stream and passes it back on resume. */
             data: unknown;
         };
+        /** @description Catalog of available streams. Emitted by a source during discover(). */
         CatalogMessage: {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
             type: "catalog";
+            /** @description All streams available from this source. */
             streams: {
+                /** @description Collection name (e.g. "customers", "invoices", "pg_public.users"). */
                 name: string;
+                /** @description Paths to fields that uniquely identify a record within this stream. Supports composite keys and nested paths. e.g. [["id"]] or [["account_id"], ["created"]] */
                 primary_key: string[][];
+                /** @description JSON Schema describing the record shape. Discovered at runtime or provided by config. */
                 json_schema?: {
                     [key: string]: unknown;
                 };
+                /** @description Source-specific metadata that applies to every record in this stream. The destination can use these for schema naming, partitioning, etc. Examples: Stripe: { api_version, account_id, live_mode }. */
                 metadata?: {
                     [key: string]: unknown;
                 };
             }[];
         };
+        /** @description Structured log output from a source or destination. */
         LogMessage: {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
             type: "log";
-            /** @enum {string} */
+            /**
+             * @description Log severity level.
+             * @enum {string}
+             */
             level: "debug" | "info" | "warn" | "error";
+            /** @description Human-readable log message. */
             message: string;
         };
+        /** @description Structured error from a source or destination. */
         ErrorMessage: {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
             type: "error";
-            /** @enum {string} */
+            /**
+             * @description Error category — lets the orchestrator decide whether to retry, alert, or abort.
+             * @enum {string}
+             */
             failure_type: "config_error" | "system_error" | "transient_error" | "auth_error";
+            /** @description Human-readable error description. */
             message: string;
+            /** @description Stream that triggered the error, if applicable. */
             stream?: string;
+            /** @description Full stack trace for debugging. */
             stack_trace?: string;
         };
+        /** @description Per-stream status update from a source. Enables progress reporting in CLI / dashboard. */
         StreamStatusMessage: {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
             type: "stream_status";
+            /** @description Stream being reported on. */
             stream: string;
-            /** @enum {string} */
+            /**
+             * @description Current phase of the stream within this sync run.
+             * @enum {string}
+             */
             status: "started" | "running" | "complete" | "incomplete";
         };
         EofMessage: {
@@ -264,76 +296,108 @@ export interface components {
             reason: "complete" | "state_limit" | "time_limit" | "error";
         };
         DestinationOutput: components["schemas"]["StateMessageOutput"] | components["schemas"]["ErrorMessageOutput"] | components["schemas"]["LogMessageOutput"] | components["schemas"]["EofMessageOutput"];
+        /** @description Catalog of available streams. Emitted by a source during discover(). */
         CatalogMessageOutput: {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
             type: "catalog";
+            /** @description All streams available from this source. */
             streams: {
+                /** @description Collection name (e.g. "customers", "invoices", "pg_public.users"). */
                 name: string;
+                /** @description Paths to fields that uniquely identify a record within this stream. Supports composite keys and nested paths. e.g. [["id"]] or [["account_id"], ["created"]] */
                 primary_key: string[][];
+                /** @description JSON Schema describing the record shape. Discovered at runtime or provided by config. */
                 json_schema?: {
                     [key: string]: unknown;
                 };
+                /** @description Source-specific metadata that applies to every record in this stream. The destination can use these for schema naming, partitioning, etc. Examples: Stripe: { api_version, account_id, live_mode }. */
                 metadata?: {
                     [key: string]: unknown;
                 };
             }[];
         };
         MessageOutput: components["schemas"]["RecordMessageOutput"] | components["schemas"]["StateMessageOutput"] | components["schemas"]["CatalogMessageOutput"] | components["schemas"]["LogMessageOutput"] | components["schemas"]["ErrorMessageOutput"] | components["schemas"]["StreamStatusMessageOutput"] | components["schemas"]["EofMessageOutput"];
+        /** @description One record for one stream. */
         RecordMessageOutput: {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
             type: "record";
+            /** @description Stream (table) name this record belongs to. */
             stream: string;
+            /** @description The record payload as a key-value map. */
             data: {
                 [key: string]: unknown;
             };
-            /** Format: date-time */
+            /**
+             * Format: date-time
+             * @description ISO 8601 timestamp when the record was emitted by the source.
+             */
             emitted_at: string;
         };
+        /** @description Per-stream checkpoint for resumable syncs. Emitted by the source after each page/batch so the orchestrator can persist progress. */
         StateMessageOutput: {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
             type: "state";
+            /** @description Stream being checkpointed. */
             stream: string;
+            /** @description Opaque checkpoint data — only the source understands its contents. The orchestrator persists it keyed by stream and passes it back on resume. */
             data: unknown;
         };
+        /** @description Structured log output from a source or destination. */
         LogMessageOutput: {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
             type: "log";
-            /** @enum {string} */
+            /**
+             * @description Log severity level.
+             * @enum {string}
+             */
             level: "debug" | "info" | "warn" | "error";
+            /** @description Human-readable log message. */
             message: string;
         };
+        /** @description Structured error from a source or destination. */
         ErrorMessageOutput: {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
             type: "error";
-            /** @enum {string} */
+            /**
+             * @description Error category — lets the orchestrator decide whether to retry, alert, or abort.
+             * @enum {string}
+             */
             failure_type: "config_error" | "system_error" | "transient_error" | "auth_error";
+            /** @description Human-readable error description. */
             message: string;
+            /** @description Stream that triggered the error, if applicable. */
             stream?: string;
+            /** @description Full stack trace for debugging. */
             stack_trace?: string;
         };
+        /** @description Per-stream status update from a source. Enables progress reporting in CLI / dashboard. */
         StreamStatusMessageOutput: {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
             type: "stream_status";
+            /** @description Stream being reported on. */
             stream: string;
-            /** @enum {string} */
+            /**
+             * @description Current phase of the stream within this sync run.
+             * @enum {string}
+             */
             status: "started" | "running" | "complete" | "incomplete";
         };
         EofMessageOutput: {

--- a/apps/engine/src/__generated__/openapi.json
+++ b/apps/engine/src/__generated__/openapi.json
@@ -243,27 +243,16 @@
             }
           },
           {
-            "in": "query",
-            "name": "state_limit",
+            "in": "header",
+            "name": "x-state-checkpoint-limit",
             "schema": {
-              "description": "Stop streaming after N state messages.",
-              "example": "100",
+              "description": "When set, stops streaming after N state checkpoint messages. Enables page-at-a-time sync.",
+              "example": "1",
               "type": "integer",
               "exclusiveMinimum": 0,
               "maximum": 9007199254740991
             },
-            "description": "Stop streaming after N state messages."
-          },
-          {
-            "in": "query",
-            "name": "time_limit",
-            "schema": {
-              "description": "Stop streaming after N seconds.",
-              "example": "10",
-              "type": "number",
-              "exclusiveMinimum": 0
-            },
-            "description": "Stop streaming after N seconds."
+            "description": "When set, stops streaming after N state checkpoint messages. Enables page-at-a-time sync."
           }
         ],
         "responses": {
@@ -366,27 +355,16 @@
             }
           },
           {
-            "in": "query",
-            "name": "state_limit",
+            "in": "header",
+            "name": "x-state-checkpoint-limit",
             "schema": {
-              "description": "Stop streaming after N state messages.",
-              "example": "100",
+              "description": "When set, stops streaming after N state checkpoint messages. Enables page-at-a-time sync.",
+              "example": "1",
               "type": "integer",
               "exclusiveMinimum": 0,
               "maximum": 9007199254740991
             },
-            "description": "Stop streaming after N state messages."
-          },
-          {
-            "in": "query",
-            "name": "time_limit",
-            "schema": {
-              "description": "Stop streaming after N seconds.",
-              "example": "10",
-              "type": "number",
-              "exclusiveMinimum": 0
-            },
-            "description": "Stop streaming after N seconds."
+            "description": "When set, stops streaming after N state checkpoint messages. Enables page-at-a-time sync."
           }
         ],
         "responses": {
@@ -479,8 +457,7 @@
           { "$ref": "#/components/schemas/CatalogMessage" },
           { "$ref": "#/components/schemas/LogMessage" },
           { "$ref": "#/components/schemas/ErrorMessage" },
-          { "$ref": "#/components/schemas/StreamStatusMessage" },
-          { "$ref": "#/components/schemas/EofMessage" }
+          { "$ref": "#/components/schemas/StreamStatusMessage" }
         ],
         "type": "object",
         "discriminator": {
@@ -491,8 +468,7 @@
             "catalog": "#/components/schemas/CatalogMessage",
             "log": "#/components/schemas/LogMessage",
             "error": "#/components/schemas/ErrorMessage",
-            "stream_status": "#/components/schemas/StreamStatusMessage",
-            "eof": "#/components/schemas/EofMessage"
+            "stream_status": "#/components/schemas/StreamStatusMessage"
           }
         }
       },
@@ -500,28 +476,37 @@
         "type": "object",
         "properties": {
           "type": { "type": "string", "const": "record" },
-          "stream": { "type": "string" },
+          "stream": {
+            "type": "string",
+            "description": "Stream (table) name this record belongs to."
+          },
           "data": {
             "type": "object",
             "propertyNames": { "type": "string" },
-            "additionalProperties": {}
+            "additionalProperties": {},
+            "description": "The record payload as a key-value map."
           },
           "emitted_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+            "description": "ISO 8601 timestamp when the record was emitted by the source."
           }
         },
-        "required": ["type", "stream", "data", "emitted_at"]
+        "required": ["type", "stream", "data", "emitted_at"],
+        "description": "One record for one stream."
       },
       "StateMessage": {
         "type": "object",
         "properties": {
           "type": { "type": "string", "const": "state" },
-          "stream": { "type": "string" },
-          "data": {}
+          "stream": { "type": "string", "description": "Stream being checkpointed." },
+          "data": {
+            "description": "Opaque checkpoint data — only the source understands its contents. The orchestrator persists it keyed by stream and passes it back on resume."
+          }
         },
-        "required": ["type", "stream", "data"]
+        "required": ["type", "stream", "data"],
+        "description": "Per-stream checkpoint for resumable syncs. Emitted by the source after each page/batch so the orchestrator can persist progress."
       },
       "CatalogMessage": {
         "type": "object",
@@ -532,36 +517,50 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": { "type": "string" },
+                "name": {
+                  "type": "string",
+                  "description": "Collection name (e.g. \"customers\", \"invoices\", \"pg_public.users\")."
+                },
                 "primary_key": {
                   "type": "array",
-                  "items": { "type": "array", "items": { "type": "string" } }
+                  "items": { "type": "array", "items": { "type": "string" } },
+                  "description": "Paths to fields that uniquely identify a record within this stream. Supports composite keys and nested paths. e.g. [[\"id\"]] or [[\"account_id\"], [\"created\"]]"
                 },
                 "json_schema": {
+                  "description": "JSON Schema describing the record shape. Discovered at runtime or provided by config.",
                   "type": "object",
                   "propertyNames": { "type": "string" },
                   "additionalProperties": {}
                 },
                 "metadata": {
+                  "description": "Source-specific metadata that applies to every record in this stream. The destination can use these for schema naming, partitioning, etc. Examples: Stripe: { api_version, account_id, live_mode }.",
                   "type": "object",
                   "propertyNames": { "type": "string" },
                   "additionalProperties": {}
                 }
               },
-              "required": ["name", "primary_key"]
-            }
+              "required": ["name", "primary_key"],
+              "description": "A named collection of records — analogous to a table or API resource."
+            },
+            "description": "All streams available from this source."
           }
         },
-        "required": ["type", "streams"]
+        "required": ["type", "streams"],
+        "description": "Catalog of available streams. Emitted by a source during discover()."
       },
       "LogMessage": {
         "type": "object",
         "properties": {
           "type": { "type": "string", "const": "log" },
-          "level": { "type": "string", "enum": ["debug", "info", "warn", "error"] },
-          "message": { "type": "string" }
+          "level": {
+            "type": "string",
+            "enum": ["debug", "info", "warn", "error"],
+            "description": "Log severity level."
+          },
+          "message": { "type": "string", "description": "Human-readable log message." }
         },
-        "required": ["type", "level", "message"]
+        "required": ["type", "level", "message"],
+        "description": "Structured log output from a source or destination."
       },
       "ErrorMessage": {
         "type": "object",
@@ -569,37 +568,38 @@
           "type": { "type": "string", "const": "error" },
           "failure_type": {
             "type": "string",
-            "enum": ["config_error", "system_error", "transient_error", "auth_error"]
+            "enum": ["config_error", "system_error", "transient_error", "auth_error"],
+            "description": "Error category — lets the orchestrator decide whether to retry, alert, or abort."
           },
-          "message": { "type": "string" },
-          "stream": { "type": "string" },
-          "stack_trace": { "type": "string" }
+          "message": { "type": "string", "description": "Human-readable error description." },
+          "stream": {
+            "description": "Stream that triggered the error, if applicable.",
+            "type": "string"
+          },
+          "stack_trace": { "description": "Full stack trace for debugging.", "type": "string" }
         },
-        "required": ["type", "failure_type", "message"]
+        "required": ["type", "failure_type", "message"],
+        "description": "Structured error from a source or destination."
       },
       "StreamStatusMessage": {
         "type": "object",
         "properties": {
           "type": { "type": "string", "const": "stream_status" },
-          "stream": { "type": "string" },
-          "status": { "type": "string", "enum": ["started", "running", "complete", "incomplete"] }
+          "stream": { "type": "string", "description": "Stream being reported on." },
+          "status": {
+            "type": "string",
+            "enum": ["started", "running", "complete", "incomplete"],
+            "description": "Current phase of the stream within this sync run."
+          }
         },
-        "required": ["type", "stream", "status"]
-      },
-      "EofMessage": {
-        "type": "object",
-        "properties": {
-          "type": { "type": "string", "const": "eof" },
-          "reason": { "type": "string", "enum": ["complete", "state_limit", "time_limit", "error"] }
-        },
-        "required": ["type", "reason"]
+        "required": ["type", "stream", "status"],
+        "description": "Per-stream status update from a source. Enables progress reporting in CLI / dashboard."
       },
       "DestinationOutput": {
         "oneOf": [
           { "$ref": "#/components/schemas/StateMessageOutput" },
           { "$ref": "#/components/schemas/ErrorMessageOutput" },
-          { "$ref": "#/components/schemas/LogMessageOutput" },
-          { "$ref": "#/components/schemas/EofMessageOutput" }
+          { "$ref": "#/components/schemas/LogMessageOutput" }
         ],
         "type": "object",
         "discriminator": {
@@ -607,8 +607,7 @@
           "mapping": {
             "state": "#/components/schemas/StateMessageOutput",
             "error": "#/components/schemas/ErrorMessageOutput",
-            "log": "#/components/schemas/LogMessageOutput",
-            "eof": "#/components/schemas/EofMessageOutput"
+            "log": "#/components/schemas/LogMessageOutput"
           }
         }
       },
@@ -621,29 +620,38 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": { "type": "string" },
+                "name": {
+                  "type": "string",
+                  "description": "Collection name (e.g. \"customers\", \"invoices\", \"pg_public.users\")."
+                },
                 "primary_key": {
                   "type": "array",
-                  "items": { "type": "array", "items": { "type": "string" } }
+                  "items": { "type": "array", "items": { "type": "string" } },
+                  "description": "Paths to fields that uniquely identify a record within this stream. Supports composite keys and nested paths. e.g. [[\"id\"]] or [[\"account_id\"], [\"created\"]]"
                 },
                 "json_schema": {
+                  "description": "JSON Schema describing the record shape. Discovered at runtime or provided by config.",
                   "type": "object",
                   "propertyNames": { "type": "string" },
                   "additionalProperties": {}
                 },
                 "metadata": {
+                  "description": "Source-specific metadata that applies to every record in this stream. The destination can use these for schema naming, partitioning, etc. Examples: Stripe: { api_version, account_id, live_mode }.",
                   "type": "object",
                   "propertyNames": { "type": "string" },
                   "additionalProperties": {}
                 }
               },
               "required": ["name", "primary_key"],
-              "additionalProperties": false
-            }
+              "additionalProperties": false,
+              "description": "A named collection of records — analogous to a table or API resource."
+            },
+            "description": "All streams available from this source."
           }
         },
         "required": ["type", "streams"],
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "Catalog of available streams. Emitted by a source during discover()."
       },
       "MessageOutput": {
         "oneOf": [
@@ -652,8 +660,7 @@
           { "$ref": "#/components/schemas/CatalogMessageOutput" },
           { "$ref": "#/components/schemas/LogMessageOutput" },
           { "$ref": "#/components/schemas/ErrorMessageOutput" },
-          { "$ref": "#/components/schemas/StreamStatusMessageOutput" },
-          { "$ref": "#/components/schemas/EofMessageOutput" }
+          { "$ref": "#/components/schemas/StreamStatusMessageOutput" }
         ],
         "type": "object",
         "discriminator": {
@@ -664,8 +671,7 @@
             "catalog": "#/components/schemas/CatalogMessageOutput",
             "log": "#/components/schemas/LogMessageOutput",
             "error": "#/components/schemas/ErrorMessageOutput",
-            "stream_status": "#/components/schemas/StreamStatusMessageOutput",
-            "eof": "#/components/schemas/EofMessageOutput"
+            "stream_status": "#/components/schemas/StreamStatusMessageOutput"
           }
         }
       },
@@ -673,40 +679,54 @@
         "type": "object",
         "properties": {
           "type": { "type": "string", "const": "record" },
-          "stream": { "type": "string" },
+          "stream": {
+            "type": "string",
+            "description": "Stream (table) name this record belongs to."
+          },
           "data": {
             "type": "object",
             "propertyNames": { "type": "string" },
-            "additionalProperties": {}
+            "additionalProperties": {},
+            "description": "The record payload as a key-value map."
           },
           "emitted_at": {
             "type": "string",
             "format": "date-time",
-            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+            "description": "ISO 8601 timestamp when the record was emitted by the source."
           }
         },
         "required": ["type", "stream", "data", "emitted_at"],
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "One record for one stream."
       },
       "StateMessageOutput": {
         "type": "object",
         "properties": {
           "type": { "type": "string", "const": "state" },
-          "stream": { "type": "string" },
-          "data": {}
+          "stream": { "type": "string", "description": "Stream being checkpointed." },
+          "data": {
+            "description": "Opaque checkpoint data — only the source understands its contents. The orchestrator persists it keyed by stream and passes it back on resume."
+          }
         },
         "required": ["type", "stream", "data"],
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "Per-stream checkpoint for resumable syncs. Emitted by the source after each page/batch so the orchestrator can persist progress."
       },
       "LogMessageOutput": {
         "type": "object",
         "properties": {
           "type": { "type": "string", "const": "log" },
-          "level": { "type": "string", "enum": ["debug", "info", "warn", "error"] },
-          "message": { "type": "string" }
+          "level": {
+            "type": "string",
+            "enum": ["debug", "info", "warn", "error"],
+            "description": "Log severity level."
+          },
+          "message": { "type": "string", "description": "Human-readable log message." }
         },
         "required": ["type", "level", "message"],
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "Structured log output from a source or destination."
       },
       "ErrorMessageOutput": {
         "type": "object",
@@ -714,33 +734,34 @@
           "type": { "type": "string", "const": "error" },
           "failure_type": {
             "type": "string",
-            "enum": ["config_error", "system_error", "transient_error", "auth_error"]
+            "enum": ["config_error", "system_error", "transient_error", "auth_error"],
+            "description": "Error category — lets the orchestrator decide whether to retry, alert, or abort."
           },
-          "message": { "type": "string" },
-          "stream": { "type": "string" },
-          "stack_trace": { "type": "string" }
+          "message": { "type": "string", "description": "Human-readable error description." },
+          "stream": {
+            "description": "Stream that triggered the error, if applicable.",
+            "type": "string"
+          },
+          "stack_trace": { "description": "Full stack trace for debugging.", "type": "string" }
         },
         "required": ["type", "failure_type", "message"],
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "Structured error from a source or destination."
       },
       "StreamStatusMessageOutput": {
         "type": "object",
         "properties": {
           "type": { "type": "string", "const": "stream_status" },
-          "stream": { "type": "string" },
-          "status": { "type": "string", "enum": ["started", "running", "complete", "incomplete"] }
+          "stream": { "type": "string", "description": "Stream being reported on." },
+          "status": {
+            "type": "string",
+            "enum": ["started", "running", "complete", "incomplete"],
+            "description": "Current phase of the stream within this sync run."
+          }
         },
         "required": ["type", "stream", "status"],
-        "additionalProperties": false
-      },
-      "EofMessageOutput": {
-        "type": "object",
-        "properties": {
-          "type": { "type": "string", "const": "eof" },
-          "reason": { "type": "string", "enum": ["complete", "state_limit", "time_limit", "error"] }
-        },
-        "required": ["type", "reason"],
-        "additionalProperties": false
+        "additionalProperties": false,
+        "description": "Per-stream status update from a source. Enables progress reporting in CLI / dashboard."
       },
       "StripeSourceConfig": {
         "type": "object",

--- a/apps/engine/src/__generated__/openapi.json
+++ b/apps/engine/src/__generated__/openapi.json
@@ -243,16 +243,27 @@
             }
           },
           {
-            "in": "header",
-            "name": "x-state-checkpoint-limit",
+            "in": "query",
+            "name": "state_limit",
             "schema": {
-              "description": "When set, stops streaming after N state checkpoint messages. Enables page-at-a-time sync.",
-              "example": "1",
+              "description": "Stop streaming after N state messages.",
+              "example": "100",
               "type": "integer",
               "exclusiveMinimum": 0,
               "maximum": 9007199254740991
             },
-            "description": "When set, stops streaming after N state checkpoint messages. Enables page-at-a-time sync."
+            "description": "Stop streaming after N state messages."
+          },
+          {
+            "in": "query",
+            "name": "time_limit",
+            "schema": {
+              "description": "Stop streaming after N seconds.",
+              "example": "10",
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "description": "Stop streaming after N seconds."
           }
         ],
         "responses": {
@@ -355,16 +366,27 @@
             }
           },
           {
-            "in": "header",
-            "name": "x-state-checkpoint-limit",
+            "in": "query",
+            "name": "state_limit",
             "schema": {
-              "description": "When set, stops streaming after N state checkpoint messages. Enables page-at-a-time sync.",
-              "example": "1",
+              "description": "Stop streaming after N state messages.",
+              "example": "100",
               "type": "integer",
               "exclusiveMinimum": 0,
               "maximum": 9007199254740991
             },
-            "description": "When set, stops streaming after N state checkpoint messages. Enables page-at-a-time sync."
+            "description": "Stop streaming after N state messages."
+          },
+          {
+            "in": "query",
+            "name": "time_limit",
+            "schema": {
+              "description": "Stop streaming after N seconds.",
+              "example": "10",
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "description": "Stop streaming after N seconds."
           }
         ],
         "responses": {
@@ -457,7 +479,8 @@
           { "$ref": "#/components/schemas/CatalogMessage" },
           { "$ref": "#/components/schemas/LogMessage" },
           { "$ref": "#/components/schemas/ErrorMessage" },
-          { "$ref": "#/components/schemas/StreamStatusMessage" }
+          { "$ref": "#/components/schemas/StreamStatusMessage" },
+          { "$ref": "#/components/schemas/EofMessage" }
         ],
         "type": "object",
         "discriminator": {
@@ -468,7 +491,8 @@
             "catalog": "#/components/schemas/CatalogMessage",
             "log": "#/components/schemas/LogMessage",
             "error": "#/components/schemas/ErrorMessage",
-            "stream_status": "#/components/schemas/StreamStatusMessage"
+            "stream_status": "#/components/schemas/StreamStatusMessage",
+            "eof": "#/components/schemas/EofMessage"
           }
         }
       },
@@ -595,11 +619,20 @@
         "required": ["type", "stream", "status"],
         "description": "Per-stream status update from a source. Enables progress reporting in CLI / dashboard."
       },
+      "EofMessage": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "const": "eof" },
+          "reason": { "type": "string", "enum": ["complete", "state_limit", "time_limit", "error"] }
+        },
+        "required": ["type", "reason"]
+      },
       "DestinationOutput": {
         "oneOf": [
           { "$ref": "#/components/schemas/StateMessageOutput" },
           { "$ref": "#/components/schemas/ErrorMessageOutput" },
-          { "$ref": "#/components/schemas/LogMessageOutput" }
+          { "$ref": "#/components/schemas/LogMessageOutput" },
+          { "$ref": "#/components/schemas/EofMessageOutput" }
         ],
         "type": "object",
         "discriminator": {
@@ -607,7 +640,8 @@
           "mapping": {
             "state": "#/components/schemas/StateMessageOutput",
             "error": "#/components/schemas/ErrorMessageOutput",
-            "log": "#/components/schemas/LogMessageOutput"
+            "log": "#/components/schemas/LogMessageOutput",
+            "eof": "#/components/schemas/EofMessageOutput"
           }
         }
       },
@@ -660,7 +694,8 @@
           { "$ref": "#/components/schemas/CatalogMessageOutput" },
           { "$ref": "#/components/schemas/LogMessageOutput" },
           { "$ref": "#/components/schemas/ErrorMessageOutput" },
-          { "$ref": "#/components/schemas/StreamStatusMessageOutput" }
+          { "$ref": "#/components/schemas/StreamStatusMessageOutput" },
+          { "$ref": "#/components/schemas/EofMessageOutput" }
         ],
         "type": "object",
         "discriminator": {
@@ -671,7 +706,8 @@
             "catalog": "#/components/schemas/CatalogMessageOutput",
             "log": "#/components/schemas/LogMessageOutput",
             "error": "#/components/schemas/ErrorMessageOutput",
-            "stream_status": "#/components/schemas/StreamStatusMessageOutput"
+            "stream_status": "#/components/schemas/StreamStatusMessageOutput",
+            "eof": "#/components/schemas/EofMessageOutput"
           }
         }
       },
@@ -762,6 +798,15 @@
         "required": ["type", "stream", "status"],
         "additionalProperties": false,
         "description": "Per-stream status update from a source. Enables progress reporting in CLI / dashboard."
+      },
+      "EofMessageOutput": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "const": "eof" },
+          "reason": { "type": "string", "enum": ["complete", "state_limit", "time_limit", "error"] }
+        },
+        "required": ["type", "reason"],
+        "additionalProperties": false
       },
       "StripeSourceConfig": {
         "type": "object",

--- a/apps/service/src/__generated__/openapi.d.ts
+++ b/apps/service/src/__generated__/openapi.d.ts
@@ -164,6 +164,7 @@ export interface operations {
                 content: {
                     "application/json": {
                         data: {
+                            /** @description Unique pipeline identifier (e.g. pipe_abc123). */
                             id: string;
                             source: {
                                 /** @description Stripe API key (sk_test_... or sk_live_...) */
@@ -263,15 +264,25 @@ export interface operations {
                                 /** @constant */
                                 type: "google-sheets";
                             };
+                            /** @description Selected streams to sync. All streams synced if omitted. */
                             streams?: {
+                                /** @description Stream (table) name to sync. */
                                 name: string;
-                                /** @enum {string} */
+                                /**
+                                 * @description How the source reads this stream. Defaults to full_refresh.
+                                 * @enum {string}
+                                 */
                                 sync_mode?: "incremental" | "full_refresh";
+                                /** @description Cap backfill to this many records, then mark the stream complete. */
                                 backfill_limit?: number;
                             }[];
+                            /** @description Live workflow status. Absent if no workflow is running for this pipeline. */
                             status?: {
+                                /** @description Current workflow phase (e.g. "backfill", "live", "idle"). */
                                 phase: string;
+                                /** @description Whether the pipeline is currently paused. */
                                 paused: boolean;
+                                /** @description Number of times this workflow has continued-as-new. */
                                 iteration: number;
                             };
                         }[];
@@ -389,10 +400,16 @@ export interface operations {
                         /** @constant */
                         type: "google-sheets";
                     };
+                    /** @description Selected streams to sync. All streams synced if omitted. */
                     streams?: {
+                        /** @description Stream (table) name to sync. */
                         name: string;
-                        /** @enum {string} */
+                        /**
+                         * @description How the source reads this stream. Defaults to full_refresh.
+                         * @enum {string}
+                         */
                         sync_mode?: "incremental" | "full_refresh";
+                        /** @description Cap backfill to this many records, then mark the stream complete. */
                         backfill_limit?: number;
                     }[];
                 };
@@ -406,6 +423,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
+                        /** @description Unique pipeline identifier (e.g. pipe_abc123). */
                         id: string;
                         source: {
                             /** @description Stripe API key (sk_test_... or sk_live_...) */
@@ -505,10 +523,16 @@ export interface operations {
                             /** @constant */
                             type: "google-sheets";
                         };
+                        /** @description Selected streams to sync. All streams synced if omitted. */
                         streams?: {
+                            /** @description Stream (table) name to sync. */
                             name: string;
-                            /** @enum {string} */
+                            /**
+                             * @description How the source reads this stream. Defaults to full_refresh.
+                             * @enum {string}
+                             */
                             sync_mode?: "incremental" | "full_refresh";
+                            /** @description Cap backfill to this many records, then mark the stream complete. */
                             backfill_limit?: number;
                         }[];
                     };
@@ -545,6 +569,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
+                        /** @description Unique pipeline identifier (e.g. pipe_abc123). */
                         id: string;
                         source: {
                             /** @description Stripe API key (sk_test_... or sk_live_...) */
@@ -644,15 +669,25 @@ export interface operations {
                             /** @constant */
                             type: "google-sheets";
                         };
+                        /** @description Selected streams to sync. All streams synced if omitted. */
                         streams?: {
+                            /** @description Stream (table) name to sync. */
                             name: string;
-                            /** @enum {string} */
+                            /**
+                             * @description How the source reads this stream. Defaults to full_refresh.
+                             * @enum {string}
+                             */
                             sync_mode?: "incremental" | "full_refresh";
+                            /** @description Cap backfill to this many records, then mark the stream complete. */
                             backfill_limit?: number;
                         }[];
+                        /** @description Live workflow status. Absent if no workflow is running for this pipeline. */
                         status?: {
+                            /** @description Current workflow phase (e.g. "backfill", "live", "idle"). */
                             phase: string;
+                            /** @description Whether the pipeline is currently paused. */
                             paused: boolean;
+                            /** @description Number of times this workflow has continued-as-new. */
                             iteration: number;
                         };
                     };
@@ -829,10 +864,16 @@ export interface operations {
                         /** @constant */
                         type: "google-sheets";
                     };
+                    /** @description Selected streams to sync. All streams synced if omitted. */
                     streams?: {
+                        /** @description Stream (table) name to sync. */
                         name: string;
-                        /** @enum {string} */
+                        /**
+                         * @description How the source reads this stream. Defaults to full_refresh.
+                         * @enum {string}
+                         */
                         sync_mode?: "incremental" | "full_refresh";
+                        /** @description Cap backfill to this many records, then mark the stream complete. */
                         backfill_limit?: number;
                     }[];
                 };
@@ -846,6 +887,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
+                        /** @description Unique pipeline identifier (e.g. pipe_abc123). */
                         id: string;
                         source: {
                             /** @description Stripe API key (sk_test_... or sk_live_...) */
@@ -945,15 +987,25 @@ export interface operations {
                             /** @constant */
                             type: "google-sheets";
                         };
+                        /** @description Selected streams to sync. All streams synced if omitted. */
                         streams?: {
+                            /** @description Stream (table) name to sync. */
                             name: string;
-                            /** @enum {string} */
+                            /**
+                             * @description How the source reads this stream. Defaults to full_refresh.
+                             * @enum {string}
+                             */
                             sync_mode?: "incremental" | "full_refresh";
+                            /** @description Cap backfill to this many records, then mark the stream complete. */
                             backfill_limit?: number;
                         }[];
+                        /** @description Live workflow status. Absent if no workflow is running for this pipeline. */
                         status?: {
+                            /** @description Current workflow phase (e.g. "backfill", "live", "idle"). */
                             phase: string;
+                            /** @description Whether the pipeline is currently paused. */
                             paused: boolean;
+                            /** @description Number of times this workflow has continued-as-new. */
                             iteration: number;
                         };
                     };
@@ -990,6 +1042,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
+                        /** @description Unique pipeline identifier (e.g. pipe_abc123). */
                         id: string;
                         source: {
                             /** @description Stripe API key (sk_test_... or sk_live_...) */
@@ -1089,15 +1142,25 @@ export interface operations {
                             /** @constant */
                             type: "google-sheets";
                         };
+                        /** @description Selected streams to sync. All streams synced if omitted. */
                         streams?: {
+                            /** @description Stream (table) name to sync. */
                             name: string;
-                            /** @enum {string} */
+                            /**
+                             * @description How the source reads this stream. Defaults to full_refresh.
+                             * @enum {string}
+                             */
                             sync_mode?: "incremental" | "full_refresh";
+                            /** @description Cap backfill to this many records, then mark the stream complete. */
                             backfill_limit?: number;
                         }[];
+                        /** @description Live workflow status. Absent if no workflow is running for this pipeline. */
                         status?: {
+                            /** @description Current workflow phase (e.g. "backfill", "live", "idle"). */
                             phase: string;
+                            /** @description Whether the pipeline is currently paused. */
                             paused: boolean;
+                            /** @description Number of times this workflow has continued-as-new. */
                             iteration: number;
                         };
                     };
@@ -1134,6 +1197,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
+                        /** @description Unique pipeline identifier (e.g. pipe_abc123). */
                         id: string;
                         source: {
                             /** @description Stripe API key (sk_test_... or sk_live_...) */
@@ -1233,15 +1297,25 @@ export interface operations {
                             /** @constant */
                             type: "google-sheets";
                         };
+                        /** @description Selected streams to sync. All streams synced if omitted. */
                         streams?: {
+                            /** @description Stream (table) name to sync. */
                             name: string;
-                            /** @enum {string} */
+                            /**
+                             * @description How the source reads this stream. Defaults to full_refresh.
+                             * @enum {string}
+                             */
                             sync_mode?: "incremental" | "full_refresh";
+                            /** @description Cap backfill to this many records, then mark the stream complete. */
                             backfill_limit?: number;
                         }[];
+                        /** @description Live workflow status. Absent if no workflow is running for this pipeline. */
                         status?: {
+                            /** @description Current workflow phase (e.g. "backfill", "live", "idle"). */
                             phase: string;
+                            /** @description Whether the pipeline is currently paused. */
                             paused: boolean;
+                            /** @description Number of times this workflow has continued-as-new. */
                             iteration: number;
                         };
                     };

--- a/apps/service/src/__generated__/openapi.json
+++ b/apps/service/src/__generated__/openapi.json
@@ -52,7 +52,8 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Unique pipeline identifier (e.g. pipe_abc123)."
                           },
                           "source": {
                             "oneOf": [
@@ -267,18 +268,22 @@
                             }
                           },
                           "streams": {
+                            "description": "Selected streams to sync. All streams synced if omitted.",
                             "type": "array",
                             "items": {
                               "type": "object",
                               "properties": {
                                 "name": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "description": "Stream (table) name to sync."
                                 },
                                 "sync_mode": {
+                                  "description": "How the source reads this stream. Defaults to full_refresh.",
                                   "type": "string",
                                   "enum": ["incremental", "full_refresh"]
                                 },
                                 "backfill_limit": {
+                                  "description": "Cap backfill to this many records, then mark the stream complete.",
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 9007199254740991
@@ -289,16 +294,20 @@
                             }
                           },
                           "status": {
+                            "description": "Live workflow status. Absent if no workflow is running for this pipeline.",
                             "type": "object",
                             "properties": {
                               "phase": {
-                                "type": "string"
+                                "type": "string",
+                                "description": "Current workflow phase (e.g. \"backfill\", \"live\", \"idle\")."
                               },
                               "paused": {
-                                "type": "boolean"
+                                "type": "boolean",
+                                "description": "Whether the pipeline is currently paused."
                               },
                               "iteration": {
-                                "type": "number"
+                                "type": "number",
+                                "description": "Number of times this workflow has continued-as-new."
                               }
                             },
                             "required": ["phase", "paused", "iteration"],
@@ -538,18 +547,22 @@
                     }
                   },
                   "streams": {
+                    "description": "Selected streams to sync. All streams synced if omitted.",
                     "type": "array",
                     "items": {
                       "type": "object",
                       "properties": {
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "Stream (table) name to sync."
                         },
                         "sync_mode": {
+                          "description": "How the source reads this stream. Defaults to full_refresh.",
                           "type": "string",
                           "enum": ["incremental", "full_refresh"]
                         },
                         "backfill_limit": {
+                          "description": "Cap backfill to this many records, then mark the stream complete.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
                           "maximum": 9007199254740991
@@ -573,7 +586,8 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Unique pipeline identifier (e.g. pipe_abc123)."
                     },
                     "source": {
                       "oneOf": [
@@ -788,18 +802,22 @@
                       }
                     },
                     "streams": {
+                      "description": "Selected streams to sync. All streams synced if omitted.",
                       "type": "array",
                       "items": {
                         "type": "object",
                         "properties": {
                           "name": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Stream (table) name to sync."
                           },
                           "sync_mode": {
+                            "description": "How the source reads this stream. Defaults to full_refresh.",
                             "type": "string",
                             "enum": ["incremental", "full_refresh"]
                           },
                           "backfill_limit": {
+                            "description": "Cap backfill to this many records, then mark the stream complete.",
                             "type": "integer",
                             "exclusiveMinimum": 0,
                             "maximum": 9007199254740991
@@ -859,7 +877,8 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Unique pipeline identifier (e.g. pipe_abc123)."
                     },
                     "source": {
                       "oneOf": [
@@ -1074,18 +1093,22 @@
                       }
                     },
                     "streams": {
+                      "description": "Selected streams to sync. All streams synced if omitted.",
                       "type": "array",
                       "items": {
                         "type": "object",
                         "properties": {
                           "name": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Stream (table) name to sync."
                           },
                           "sync_mode": {
+                            "description": "How the source reads this stream. Defaults to full_refresh.",
                             "type": "string",
                             "enum": ["incremental", "full_refresh"]
                           },
                           "backfill_limit": {
+                            "description": "Cap backfill to this many records, then mark the stream complete.",
                             "type": "integer",
                             "exclusiveMinimum": 0,
                             "maximum": 9007199254740991
@@ -1096,16 +1119,20 @@
                       }
                     },
                     "status": {
+                      "description": "Live workflow status. Absent if no workflow is running for this pipeline.",
                       "type": "object",
                       "properties": {
                         "phase": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "Current workflow phase (e.g. \"backfill\", \"live\", \"idle\")."
                         },
                         "paused": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether the pipeline is currently paused."
                         },
                         "iteration": {
-                          "type": "number"
+                          "type": "number",
+                          "description": "Number of times this workflow has continued-as-new."
                         }
                       },
                       "required": ["phase", "paused", "iteration"],
@@ -1363,18 +1390,22 @@
                     }
                   },
                   "streams": {
+                    "description": "Selected streams to sync. All streams synced if omitted.",
                     "type": "array",
                     "items": {
                       "type": "object",
                       "properties": {
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "Stream (table) name to sync."
                         },
                         "sync_mode": {
+                          "description": "How the source reads this stream. Defaults to full_refresh.",
                           "type": "string",
                           "enum": ["incremental", "full_refresh"]
                         },
                         "backfill_limit": {
+                          "description": "Cap backfill to this many records, then mark the stream complete.",
                           "type": "integer",
                           "exclusiveMinimum": 0,
                           "maximum": 9007199254740991
@@ -1397,7 +1428,8 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Unique pipeline identifier (e.g. pipe_abc123)."
                     },
                     "source": {
                       "oneOf": [
@@ -1612,18 +1644,22 @@
                       }
                     },
                     "streams": {
+                      "description": "Selected streams to sync. All streams synced if omitted.",
                       "type": "array",
                       "items": {
                         "type": "object",
                         "properties": {
                           "name": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Stream (table) name to sync."
                           },
                           "sync_mode": {
+                            "description": "How the source reads this stream. Defaults to full_refresh.",
                             "type": "string",
                             "enum": ["incremental", "full_refresh"]
                           },
                           "backfill_limit": {
+                            "description": "Cap backfill to this many records, then mark the stream complete.",
                             "type": "integer",
                             "exclusiveMinimum": 0,
                             "maximum": 9007199254740991
@@ -1634,16 +1670,20 @@
                       }
                     },
                     "status": {
+                      "description": "Live workflow status. Absent if no workflow is running for this pipeline.",
                       "type": "object",
                       "properties": {
                         "phase": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "Current workflow phase (e.g. \"backfill\", \"live\", \"idle\")."
                         },
                         "paused": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether the pipeline is currently paused."
                         },
                         "iteration": {
-                          "type": "number"
+                          "type": "number",
+                          "description": "Number of times this workflow has continued-as-new."
                         }
                       },
                       "required": ["phase", "paused", "iteration"],
@@ -1768,7 +1808,8 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Unique pipeline identifier (e.g. pipe_abc123)."
                     },
                     "source": {
                       "oneOf": [
@@ -1983,18 +2024,22 @@
                       }
                     },
                     "streams": {
+                      "description": "Selected streams to sync. All streams synced if omitted.",
                       "type": "array",
                       "items": {
                         "type": "object",
                         "properties": {
                           "name": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Stream (table) name to sync."
                           },
                           "sync_mode": {
+                            "description": "How the source reads this stream. Defaults to full_refresh.",
                             "type": "string",
                             "enum": ["incremental", "full_refresh"]
                           },
                           "backfill_limit": {
+                            "description": "Cap backfill to this many records, then mark the stream complete.",
                             "type": "integer",
                             "exclusiveMinimum": 0,
                             "maximum": 9007199254740991
@@ -2005,16 +2050,20 @@
                       }
                     },
                     "status": {
+                      "description": "Live workflow status. Absent if no workflow is running for this pipeline.",
                       "type": "object",
                       "properties": {
                         "phase": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "Current workflow phase (e.g. \"backfill\", \"live\", \"idle\")."
                         },
                         "paused": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether the pipeline is currently paused."
                         },
                         "iteration": {
-                          "type": "number"
+                          "type": "number",
+                          "description": "Number of times this workflow has continued-as-new."
                         }
                       },
                       "required": ["phase", "paused", "iteration"],
@@ -2070,7 +2119,8 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Unique pipeline identifier (e.g. pipe_abc123)."
                     },
                     "source": {
                       "oneOf": [
@@ -2285,18 +2335,22 @@
                       }
                     },
                     "streams": {
+                      "description": "Selected streams to sync. All streams synced if omitted.",
                       "type": "array",
                       "items": {
                         "type": "object",
                         "properties": {
                           "name": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Stream (table) name to sync."
                           },
                           "sync_mode": {
+                            "description": "How the source reads this stream. Defaults to full_refresh.",
                             "type": "string",
                             "enum": ["incremental", "full_refresh"]
                           },
                           "backfill_limit": {
+                            "description": "Cap backfill to this many records, then mark the stream complete.",
                             "type": "integer",
                             "exclusiveMinimum": 0,
                             "maximum": 9007199254740991
@@ -2307,16 +2361,20 @@
                       }
                     },
                     "status": {
+                      "description": "Live workflow status. Absent if no workflow is running for this pipeline.",
                       "type": "object",
                       "properties": {
                         "phase": {
-                          "type": "string"
+                          "type": "string",
+                          "description": "Current workflow phase (e.g. \"backfill\", \"live\", \"idle\")."
                         },
                         "paused": {
-                          "type": "boolean"
+                          "type": "boolean",
+                          "description": "Whether the pipeline is currently paused."
                         },
                         "iteration": {
-                          "type": "number"
+                          "type": "number",
+                          "description": "Number of times this workflow has continued-as-new."
                         }
                       },
                       "required": ["phase", "paused", "iteration"],

--- a/apps/service/src/api/app.ts
+++ b/apps/service/src/api/app.ts
@@ -49,11 +49,12 @@ export function createApp(options: AppOptions) {
   const PipelineWithStatusSchema = PipelineSchema.extend({
     status: z
       .object({
-        phase: z.string(),
-        paused: z.boolean(),
-        iteration: z.number(),
+        phase: z.string().describe('Current workflow phase (e.g. "backfill", "live", "idle").'),
+        paused: z.boolean().describe('Whether the pipeline is currently paused.'),
+        iteration: z.number().describe('Number of times this workflow has continued-as-new.'),
       })
-      .optional(),
+      .optional()
+      .describe('Live workflow status. Absent if no workflow is running for this pipeline.'),
   })
 
   const app = new OpenAPIHono({

--- a/apps/service/src/lib/createSchemas.ts
+++ b/apps/service/src/lib/createSchemas.ts
@@ -4,16 +4,24 @@ import type { ConnectorResolver } from '@stripe/sync-engine'
 // MARK: - Static schemas (independent of connector set)
 
 export const StreamConfig = z.object({
-  name: z.string(),
-  sync_mode: z.enum(['incremental', 'full_refresh']).optional(),
-  backfill_limit: z.number().int().positive().optional(),
+  name: z.string().describe('Stream (table) name to sync.'),
+  sync_mode: z
+    .enum(['incremental', 'full_refresh'])
+    .optional()
+    .describe('How the source reads this stream. Defaults to full_refresh.'),
+  backfill_limit: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Cap backfill to this many records, then mark the stream complete.'),
 })
 
 export const LogEntry = z.object({
-  level: z.enum(['debug', 'info', 'warn', 'error']),
-  message: z.string(),
-  stream: z.string().optional(),
-  timestamp: z.string(),
+  level: z.enum(['debug', 'info', 'warn', 'error']).describe('Log severity level.'),
+  message: z.string().describe('Human-readable log message.'),
+  stream: z.string().optional().describe('Stream that produced this log entry, if applicable.'),
+  timestamp: z.string().describe('ISO 8601 timestamp when the log entry was produced.'),
 })
 
 // MARK: - Dynamic schema factory (depends on registered connectors)
@@ -57,16 +65,22 @@ export function createSchemas(resolver: ConnectorResolver) {
 
   // Composed schemas
   const Pipeline = z.object({
-    id: z.string(),
+    id: z.string().describe('Unique pipeline identifier (e.g. pipe_abc123).'),
     source: SourceConfig,
     destination: DestinationConfig,
-    streams: z.array(StreamConfig).optional(),
+    streams: z
+      .array(StreamConfig)
+      .optional()
+      .describe('Selected streams to sync. All streams synced if omitted.'),
   })
 
   const CreatePipeline = z.object({
     source: SourceConfig,
     destination: DestinationConfig,
-    streams: z.array(StreamConfig).optional(),
+    streams: z
+      .array(StreamConfig)
+      .optional()
+      .describe('Selected streams to sync. All streams synced if omitted.'),
   })
 
   const UpdatePipeline = CreatePipeline.partial()

--- a/docs/architecture/principles.md
+++ b/docs/architecture/principles.md
@@ -33,3 +33,7 @@ No silent skips when dependencies (stripe-mock, Docker Postgres) are unavailable
 ## 8. Schema is discovered, not hardcoded
 
 Sources advertise available streams via `CatalogMessage`. Destinations create tables from the catalog. No hardcoded table definitions.
+
+## 9. Use `.describe()` for Zod field descriptions
+
+JSDoc comments on Zod fields (`/** ... */`) are stripped by TypeScript and never reach the OpenAPI generator. Always use `.describe('...')` on Zod schema fields so descriptions appear in the generated spec.

--- a/docs/plans/2026-04-03-engine-interface-refactor.md
+++ b/docs/plans/2026-04-03-engine-interface-refactor.md
@@ -1,0 +1,68 @@
+# Engine Interface Refactor: Per-call PipelineConfig
+
+**PR:** #233
+**Branch:** `tx/engine-interface-refactor`
+
+## Context
+
+`createEngine` and `createRemoteEngine` were binding `PipelineConfig` at **construction time**, making one engine instance equal one pipeline. This was the wrong granularity:
+
+1. `/health` needs no source or destination at all
+2. `/discover` needs only a source config
+3. `check()` already checks source and destination independently
+4. `createRemoteEngine` is just an HTTP client — forcing pipeline config at construction required callers to create a new instance per pipeline
+
+## What Changed
+
+### `Engine` interface
+
+Methods now take `PipelineConfig` as the first argument. `discover()` was added, taking only source config.
+
+```typescript
+export interface Engine {
+  setup(pipeline: PipelineConfig): Promise<SetupResult>
+  teardown(pipeline: PipelineConfig): Promise<void>
+  check(pipeline: PipelineConfig): Promise<{ source: CheckResult; destination: CheckResult }>
+  discover(source: PipelineConfig['source']): Promise<CatalogMessage>
+  read(
+    pipeline: PipelineConfig,
+    opts?: ReadOpts,
+    input?: AsyncIterable<unknown>
+  ): AsyncIterable<Message>
+  write(
+    pipeline: PipelineConfig,
+    messages: AsyncIterable<Message>
+  ): AsyncIterable<DestinationOutput>
+  sync(
+    pipeline: PipelineConfig,
+    opts?: SyncOpts,
+    input?: AsyncIterable<unknown>
+  ): AsyncIterable<DestinationOutput>
+}
+```
+
+`input` stream is always the last positional argument. `state` and `stateLimit` moved into `ReadOpts`/`SyncOpts`.
+
+### `createEngine(resolver)` — resolver only
+
+Config validation and catalog discovery happen per-call. `createEngineFromParams` removed.
+
+### `createRemoteEngine(url)` — URL only
+
+State/stateLimit moved into per-call opts.
+
+### `activities.ts`
+
+One `Engine` created at `createActivities()` time, reused across all activity invocations.
+
+### `app.ts`
+
+One `Engine` created at app startup via `createEngine(resolver)`. Each route calls `engine.method(pipeline, opts, input)`.
+
+## Files Modified
+
+- `apps/engine/src/lib/engine.ts`
+- `apps/engine/src/lib/remote-engine.ts`
+- `apps/engine/src/lib/index.ts`
+- `apps/engine/src/api/app.ts`
+- `apps/service/src/temporal/activities.ts`

--- a/packages/protocol/src/protocol.ts
+++ b/packages/protocol/src/protocol.ts
@@ -8,174 +8,190 @@ import { z } from 'zod'
 
 // MARK: - Data model
 
-/** A named collection of records — analogous to a table or API resource. */
-export const Stream = z.object({
-  /** Collection name (e.g. "customers", "invoices", "pg_public.users"). */
-  name: z.string(),
+export const Stream = z
+  .object({
+    name: z.string().describe('Collection name (e.g. "customers", "invoices", "pg_public.users").'),
 
-  /**
-   * Paths to fields that uniquely identify a record within this stream.
-   * Supports composite keys and nested paths.
-   * e.g. [["id"]] or [["account_id"], ["created"]]
-   */
-  primary_key: z.array(z.array(z.string())),
+    primary_key: z
+      .array(z.array(z.string()))
+      .describe(
+        'Paths to fields that uniquely identify a record within this stream. Supports composite keys and nested paths. e.g. [["id"]] or [["account_id"], ["created"]]'
+      ),
 
-  /** JSON Schema describing the record shape. Discovered at runtime or provided by config. */
-  json_schema: z.record(z.string(), z.unknown()).optional(),
+    json_schema: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe(
+        'JSON Schema describing the record shape. Discovered at runtime or provided by config.'
+      ),
 
-  /**
-   * Source-specific metadata that applies to every record in this stream.
-   * The destination can use these for schema naming, partitioning, etc.
-   *
-   * Examples:
-   *   Stripe source:    { api_version: "2025-04-30.basil", account_id: "acct_123", live_mode: true }
-   *   Metronome source: { account_id: "met_456" }
-   *   Postgres source:  { schema: "public", database: "mydb" }
-   */
-  metadata: z.record(z.string(), z.unknown()).optional(),
-})
+    metadata: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe(
+        'Source-specific metadata that applies to every record in this stream. The destination can use these for schema naming, partitioning, etc. Examples: Stripe: { api_version, account_id, live_mode }.'
+      ),
+  })
+  .describe('A named collection of records — analogous to a table or API resource.')
 export type Stream = z.infer<typeof Stream>
 
 // MARK: - Configured catalog
 
-/** A stream selected by the user with sync settings applied. */
-export const ConfiguredStream = z.object({
-  stream: Stream,
+export const ConfiguredStream = z
+  .object({
+    stream: Stream,
 
-  /** How the source reads this stream. */
-  sync_mode: z.enum(['full_refresh', 'incremental']),
+    sync_mode: z
+      .enum(['full_refresh', 'incremental'])
+      .describe('How the source reads this stream.'),
 
-  /** How the destination writes this stream. */
-  destination_sync_mode: z.enum(['append', 'overwrite', 'append_dedup']),
+    destination_sync_mode: z
+      .enum(['append', 'overwrite', 'append_dedup'])
+      .describe('How the destination writes this stream.'),
 
-  /** Field path used as the cursor for incremental syncs. */
-  cursor_field: z.array(z.string()).optional(),
+    cursor_field: z
+      .array(z.string())
+      .optional()
+      .describe('Field path used as the cursor for incremental syncs.'),
 
-  /** Extra system columns the destination should add to this stream's table. */
-  system_columns: z
-    .array(
-      z.object({
-        /** Column name, e.g. "_account_id". */
-        name: z.string(),
-        /** Postgres type, e.g. "text". */
-        type: z.string().default('text'),
-        /** Whether to create an index on this column. */
-        index: z.boolean().default(false),
-      })
-    )
-    .optional(),
+    system_columns: z
+      .array(
+        z.object({
+          name: z.string().describe('Column name, e.g. "_account_id".'),
+          type: z.string().default('text').describe('Postgres type, e.g. "text".'),
+          index: z.boolean().default(false).describe('Whether to create an index on this column.'),
+        })
+      )
+      .optional()
+      .describe("Extra system columns the destination should add to this stream's table."),
 
-  /** If set, only these field names are included in records for this stream. */
-  fields: z.array(z.string()).optional(),
+    fields: z
+      .array(z.string())
+      .optional()
+      .describe('If set, only these field names are included in records for this stream.'),
 
-  /** Cap backfill to this many records, then mark the stream complete. */
-  backfill_limit: z.number().int().positive().optional(),
-})
+    backfill_limit: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe('Cap backfill to this many records, then mark the stream complete.'),
+  })
+  .describe('A stream selected by the user with sync settings applied.')
 export type ConfiguredStream = z.infer<typeof ConfiguredStream>
 
-/**
- * The user's selected and configured streams.
- * Persisted on the Sync resource. Passed to read() and write().
- */
-export const ConfiguredCatalog = z.object({
-  streams: z.array(ConfiguredStream),
-})
+export const ConfiguredCatalog = z
+  .object({
+    streams: z.array(ConfiguredStream),
+  })
+  .describe(
+    "The user's selected and configured streams. Persisted on the Sync resource. Passed to read() and write()."
+  )
 export type ConfiguredCatalog = z.infer<typeof ConfiguredCatalog>
 
 // MARK: - Connector specification
 
-/** JSON Schema describing the configuration a connector requires. */
-export const ConnectorSpecification = z.object({
-  /** JSON Schema for the connector's configuration object. */
-  config: z.record(z.string(), z.unknown()),
-  /** JSON Schema for per-stream state (cursor/checkpoint shape). */
-  stream_state: z.record(z.string(), z.unknown()).optional(),
-  /** JSON Schema for the read() input parameter (e.g. a webhook event). */
-  input: z.record(z.string(), z.unknown()).optional(),
-})
+export const ConnectorSpecification = z
+  .object({
+    config: z
+      .record(z.string(), z.unknown())
+      .describe("JSON Schema for the connector's configuration object."),
+    stream_state: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe('JSON Schema for per-stream state (cursor/checkpoint shape).'),
+    input: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe('JSON Schema for the read() input parameter (e.g. a webhook event).'),
+  })
+  .describe('JSON Schema describing the configuration a connector requires.')
 export type ConnectorSpecification = z.infer<typeof ConnectorSpecification>
 
-/** Result of a connection check. */
-export const CheckResult = z.object({
-  status: z.enum(['succeeded', 'failed']),
-  message: z.string().optional(),
-})
+export const CheckResult = z
+  .object({
+    status: z.enum(['succeeded', 'failed']),
+    message: z.string().optional().describe('Human-readable explanation of the check result.'),
+  })
+  .describe('Result of a connection check.')
 export type CheckResult = z.infer<typeof CheckResult>
 
 // MARK: - Messages
 
-/** One record for one stream. */
 export const RecordMessage = z
   .object({
     type: z.literal('record'),
-    stream: z.string(),
-    data: z.record(z.string(), z.unknown()),
-    emitted_at: z.string().datetime(),
+    stream: z.string().describe('Stream (table) name this record belongs to.'),
+    data: z.record(z.string(), z.unknown()).describe('The record payload as a key-value map.'),
+    emitted_at: z
+      .string()
+      .datetime()
+      .describe('ISO 8601 timestamp when the record was emitted by the source.'),
   })
+  .describe('One record for one stream.')
   .meta({ id: 'RecordMessage' })
 export type RecordMessage = z.infer<typeof RecordMessage>
 
-/**
- * Per-stream checkpoint for resumable syncs.
- *
- * The `stream` field tells the orchestrator which stream is being checkpointed.
- * The `data` field is opaque — only the source understands its contents.
- * The orchestrator persists state keyed by (sync_id, stream) and passes the
- * full map back to the source on resume.
- */
 export const StateMessage = z
   .object({
     type: z.literal('state'),
-    stream: z.string(),
-    data: z.unknown(),
+    stream: z.string().describe('Stream being checkpointed.'),
+    data: z
+      .unknown()
+      .describe(
+        'Opaque checkpoint data — only the source understands its contents. The orchestrator persists it keyed by stream and passes it back on resume.'
+      ),
   })
+  .describe(
+    'Per-stream checkpoint for resumable syncs. Emitted by the source after each page/batch so the orchestrator can persist progress.'
+  )
   .meta({ id: 'StateMessage' })
 export type StateMessage = z.infer<typeof StateMessage>
 
-/** Catalog of available streams. Emitted by a source during discover(). */
 export const CatalogMessage = z
   .object({
     type: z.literal('catalog'),
-    streams: z.array(Stream),
+    streams: z.array(Stream).describe('All streams available from this source.'),
   })
+  .describe('Catalog of available streams. Emitted by a source during discover().')
   .meta({ id: 'CatalogMessage' })
 export type CatalogMessage = z.infer<typeof CatalogMessage>
 
-/** Structured log output from a source or destination. */
 export const LogMessage = z
   .object({
     type: z.literal('log'),
-    level: z.enum(['debug', 'info', 'warn', 'error']),
-    message: z.string(),
+    level: z.enum(['debug', 'info', 'warn', 'error']).describe('Log severity level.'),
+    message: z.string().describe('Human-readable log message.'),
   })
+  .describe('Structured log output from a source or destination.')
   .meta({ id: 'LogMessage' })
 export type LogMessage = z.infer<typeof LogMessage>
 
-/**
- * Structured error from a source or destination.
- * failure_type lets the orchestrator decide whether to retry, alert, or abort.
- */
 export const ErrorMessage = z
   .object({
     type: z.literal('error'),
-    failure_type: z.enum(['config_error', 'system_error', 'transient_error', 'auth_error']),
-    message: z.string(),
-    stream: z.string().optional(),
-    stack_trace: z.string().optional(),
+    failure_type: z
+      .enum(['config_error', 'system_error', 'transient_error', 'auth_error'])
+      .describe('Error category — lets the orchestrator decide whether to retry, alert, or abort.'),
+    message: z.string().describe('Human-readable error description.'),
+    stream: z.string().optional().describe('Stream that triggered the error, if applicable.'),
+    stack_trace: z.string().optional().describe('Full stack trace for debugging.'),
   })
+  .describe('Structured error from a source or destination.')
   .meta({ id: 'ErrorMessage' })
 export type ErrorMessage = z.infer<typeof ErrorMessage>
 
-/**
- * Per-stream status update from a source.
- * Enables progress reporting in CLI / dashboard.
- */
 export const StreamStatusMessage = z
   .object({
     type: z.literal('stream_status'),
-    stream: z.string(),
-    status: z.enum(['started', 'running', 'complete', 'incomplete']),
+    stream: z.string().describe('Stream being reported on.'),
+    status: z
+      .enum(['started', 'running', 'complete', 'incomplete'])
+      .describe('Current phase of the stream within this sync run.'),
   })
+  .describe(
+    'Per-stream status update from a source. Enables progress reporting in CLI / dashboard.'
+  )
   .meta({ id: 'StreamStatusMessage' })
 export type StreamStatusMessage = z.infer<typeof StreamStatusMessage>
 


### PR DESCRIPTION
## Summary

- **`packages/protocol/src/protocol.ts`**: Convert all JSDoc comments on Zod fields to `.describe()` calls so they appear in the generated OpenAPI spec. Covers all 9 schema types: `Stream`, `ConfiguredStream`, `ConfiguredCatalog`, `ConnectorSpecification`, `CheckResult`, `RecordMessage`, `StateMessage`, `CatalogMessage`, `LogMessage`, `ErrorMessage`, `StreamStatusMessage`.
- **`apps/service/src/lib/createSchemas.ts`** and **`apps/service/src/api/app.ts`**: Add `.describe()` to `StreamConfig`, `LogEntry`, `Pipeline`, and `PipelineWithStatusSchema.status` fields.
- **Regenerated OpenAPI specs**: engine 73 → 123 `description` fields; service 290 → 348.
- **`AGENTS.md`**: Add convention that Zod fields must use `.describe()` (not JSDoc), and non-trivial PRs should have a plan artifact in `docs/plans/`.
- **`docs/plans/2026-04-03-engine-interface-refactor.md`**: Archive of the engine interface refactor plan (PR #233).

## Root cause

JSDoc comments (`/** ... */`) on Zod schema fields are stripped by TypeScript at compile time and never reach the OpenAPI generator. The description on `StreamStatusMessage` ("Per-stream status update from a source. Enables progress reporting in CLI / dashboard.") was a concrete example — it appeared in source but was absent from the generated spec.

## Test plan

- [x] `pnpm build` exits 0
- [x] `pnpm test` — 53 tests pass
- [x] `grep -c '"description"' apps/engine/src/__generated__/openapi.json` → 123 (was 73)
- [x] `grep -c '"description"' apps/service/src/__generated__/openapi.json` → 348 (was 290)

🤖 Generated with [Claude Code](https://claude.com/claude-code)