### PR TITLE
refactor(service): reduce duplicated pipeline response handling

### DIFF
--- a/apps/service/src/api/app.test.ts
+++ b/apps/service/src/api/app.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeAll, afterAll, vi } from 'vitest'
+import { describe, expect, it, beforeAll, afterAll, afterEach, vi } from 'vitest'
 import type { WorkflowClient } from '@temporalio/client'
 import { TestWorkflowEnvironment } from '@temporalio/testing'
 import { Worker } from '@temporalio/worker'
@@ -81,6 +81,57 @@ describe('GET /health', () => {
   })
 })
 
+describe('pipeline query fallbacks', () => {
+  it('GET /pipelines returns stored pipelines when status queries fail', async () => {
+    const pipeline = {
+      id: 'pipe_failed',
+      source: { type: 'test' },
+      destination: { type: 'test' },
+    }
+    const store = memoryPipelineStore()
+    await store.set(pipeline.id, pipeline)
+
+    const getHandle = vi.fn(() => ({
+      query: vi.fn().mockRejectedValue(new Error('query unavailable')),
+    }))
+
+    const res = await createApp({
+      temporal: { client: { getHandle } as unknown as WorkflowClient, taskQueue: 'unused' },
+      resolver,
+      pipelines: store,
+    }).request('/pipelines')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      data: [pipeline],
+      has_more: false,
+    })
+  })
+
+  it('GET /pipelines/:id returns the stored pipeline when status queries fail', async () => {
+    const pipeline = {
+      id: 'pipe_failed',
+      source: { type: 'test' },
+      destination: { type: 'test' },
+    }
+    const store = memoryPipelineStore()
+    await store.set(pipeline.id, pipeline)
+
+    const getHandle = vi.fn(() => ({
+      query: vi.fn().mockRejectedValue(new Error('query unavailable')),
+    }))
+
+    const res = await createApp({
+      temporal: { client: { getHandle } as unknown as WorkflowClient, taskQueue: 'unused' },
+      resolver,
+      pipelines: store,
+    }).request(`/pipelines/${pipeline.id}`)
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual(pipeline)
+  })
+})
+
 describe('POST /pipelines workflow dispatch', () => {
   it('starts google-sheets pipelines on the dedicated workflow', async () => {
     const start = vi.fn(async () => ({}))
@@ -114,6 +165,91 @@ describe('POST /pipelines workflow dispatch', () => {
         args: [expect.stringMatching(/^pipe_/)],
       })
     )
+  })
+})
+
+describe('pipeline mutation responses', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('PATCH /pipelines returns the stored update plus queried status', async () => {
+    const currentPipeline = {
+      id: 'pipe_123',
+      source: { type: 'test' },
+      destination: { type: 'test' },
+      streams: [{ name: 'customers' }],
+    }
+    const updatedPipeline = {
+      ...currentPipeline,
+      streams: [{ name: 'products' }],
+    }
+    const store = memoryPipelineStore()
+    await store.set(currentPipeline.id, currentPipeline)
+
+    const handle = {
+      query: vi.fn().mockResolvedValue({ phase: 'live', paused: false, iteration: 1 }),
+      signal: vi.fn(async () => undefined),
+    }
+
+    const res = await createApp({
+      temporal: {
+        client: { getHandle: vi.fn(() => handle) } as unknown as WorkflowClient,
+        taskQueue: 'unused',
+      },
+      resolver,
+      pipelines: store,
+    }).request('/pipelines/pipe_123', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ streams: [{ name: 'products' }] }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      ...updatedPipeline,
+      status: { phase: 'live', paused: false, iteration: 1 },
+    })
+    expect(handle.signal).toHaveBeenCalledWith('update', {})
+  })
+
+  it.each([
+    { path: '/pause', patch: { paused: true }, paused: true },
+    { path: '/resume', patch: { paused: false }, paused: false },
+  ])('POST $path returns the pipeline plus refreshed status', async ({ path, patch, paused }) => {
+    vi.useFakeTimers()
+
+    const pipeline = {
+      id: 'pipe_123',
+      source: { type: 'test' },
+      destination: { type: 'test' },
+    }
+    const store = memoryPipelineStore()
+    await store.set(pipeline.id, pipeline)
+
+    const handle = {
+      query: vi.fn().mockResolvedValue({ phase: 'live', paused, iteration: 1 }),
+      signal: vi.fn(async () => undefined),
+    }
+
+    const responsePromise = createApp({
+      temporal: {
+        client: { getHandle: vi.fn(() => handle) } as unknown as WorkflowClient,
+        taskQueue: 'unused',
+      },
+      resolver,
+      pipelines: store,
+    }).request(`/pipelines/${pipeline.id}${path}`, { method: 'POST' })
+
+    await vi.advanceTimersByTimeAsync(200)
+
+    const res = await responsePromise
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      ...pipeline,
+      status: { phase: 'live', paused, iteration: 1 },
+    })
+    expect(handle.signal).toHaveBeenCalledWith('update', patch)
   })
 })
 

--- a/apps/service/src/api/app.ts
+++ b/apps/service/src/api/app.ts
@@ -11,6 +11,11 @@ import type { WorkflowStatus } from '../temporal/workflows/_shared.js'
 
 const DEFAULT_PIPELINE_WORKFLOW = 'pipelineWorkflow'
 const GOOGLE_SHEETS_PIPELINE_WORKFLOW = 'googleSheetPipelineWorkflow'
+const SIGNAL_RESPONSE_DELAY_MS = 200
+
+type PipelineHandle = ReturnType<WorkflowClient['getHandle']>
+type PipelineWithStatus = Pipeline & { status?: WorkflowStatus }
+type PipelineListResponse = { data: PipelineWithStatus[]; has_more: boolean }
 
 function workflowTypeForPipeline(pipeline: Pipeline): string {
   return pipeline.destination.type === 'google-sheets'
@@ -25,6 +30,10 @@ function genId(prefix: string): string {
   return `${prefix}_${(_idCounter++).toString(36)}`
 }
 
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 async function queryStatus(
   temporal: WorkflowClient,
   id: string
@@ -33,6 +42,28 @@ async function queryStatus(
     return await temporal.getHandle(id).query<WorkflowStatus>('status')
   } catch {
     return undefined
+  }
+}
+
+function pipelineWithStatus(pipeline: Pipeline, status?: WorkflowStatus): PipelineWithStatus {
+  return status ? { ...pipeline, status } : pipeline
+}
+
+async function queryPipelineWithStatus(
+  temporal: WorkflowClient,
+  pipeline: Pipeline
+): Promise<PipelineWithStatus> {
+  return pipelineWithStatus(pipeline, await queryStatus(temporal, pipeline.id))
+}
+
+async function signalPipelineUpdate(
+  handle: PipelineHandle,
+  patch: Record<string, unknown>,
+  settleMs = 0
+): Promise<void> {
+  await handle.signal('update', patch)
+  if (settleMs > 0) {
+    await sleep(settleMs)
   }
 }
 
@@ -79,6 +110,12 @@ export function createApp(options: AppOptions) {
       .optional()
       .describe('Live workflow status. Absent if no workflow is running for this pipeline.'),
   })
+
+  const jsonResponse = <T>(
+    c: { json: (body: T, status: number) => Response },
+    body: T,
+    status: number
+  ) => c.json(body, status)
 
   const app = new OpenAPIHono({
     defaultHook: (result, c) => {
@@ -136,12 +173,9 @@ export function createApp(options: AppOptions) {
     async (c) => {
       const stored = await pipelines.list()
       const result = await Promise.all(
-        stored.map(async (pipeline) => {
-          const status = await queryStatus(temporal, pipeline.id)
-          return status ? { ...pipeline, status } : pipeline
-        })
+        stored.map((pipeline) => queryPipelineWithStatus(temporal, pipeline))
       )
-      return c.json({ data: result, has_more: false } as any, 200)
+      return jsonResponse(c, { data: result, has_more: false } satisfies PipelineListResponse, 200)
     }
   )
 
@@ -176,7 +210,7 @@ export function createApp(options: AppOptions) {
         taskQueue,
         args: [id],
       })
-      return c.json(pipeline as any, 201)
+      return jsonResponse(c, pipeline, 201)
     }
   )
 
@@ -207,8 +241,7 @@ export function createApp(options: AppOptions) {
       } catch {
         return c.json({ error: `Pipeline ${id} not found` }, 404)
       }
-      const status = await queryStatus(temporal, id)
-      return c.json(status ? { ...pipeline, status } : (pipeline as any), 200)
+      return jsonResponse(c, await queryPipelineWithStatus(temporal, pipeline), 200)
     }
   )
 
@@ -287,13 +320,12 @@ export function createApp(options: AppOptions) {
 
       // Best-effort: notify the workflow that config changed
       try {
-        await temporal.getHandle(id).signal('update', {})
+        await signalPipelineUpdate(temporal.getHandle(id), {})
       } catch {
         // Workflow may not be running — config is persisted, that's fine
       }
 
-      const status = await queryStatus(temporal, id)
-      return c.json(status ? { ...updated, status } : (updated as any), 200)
+      return jsonResponse(c, await queryPipelineWithStatus(temporal, updated), 200)
     }
   )
 
@@ -325,13 +357,15 @@ export function createApp(options: AppOptions) {
         return c.json({ error: `Pipeline ${id} not found` }, 404)
       }
       try {
-        await temporal.getHandle(id).signal('update', { paused: true })
-        await new Promise((r) => setTimeout(r, 200))
+        await signalPipelineUpdate(
+          temporal.getHandle(id),
+          { paused: true },
+          SIGNAL_RESPONSE_DELAY_MS
+        )
       } catch {
         return c.json({ error: `Pipeline ${id} workflow not found` }, 404)
       }
-      const status = await queryStatus(temporal, id)
-      return c.json(status ? { ...pipeline, status } : (pipeline as any), 200)
+      return jsonResponse(c, await queryPipelineWithStatus(temporal, pipeline), 200)
     }
   )
 
@@ -363,13 +397,15 @@ export function createApp(options: AppOptions) {
         return c.json({ error: `Pipeline ${id} not found` }, 404)
       }
       try {
-        await temporal.getHandle(id).signal('update', { paused: false })
-        await new Promise((r) => setTimeout(r, 200))
+        await signalPipelineUpdate(
+          temporal.getHandle(id),
+          { paused: false },
+          SIGNAL_RESPONSE_DELAY_MS
+        )
       } catch {
         return c.json({ error: `Pipeline ${id} workflow not found` }, 404)
       }
-      const status = await queryStatus(temporal, id)
-      return c.json(status ? { ...pipeline, status } : (pipeline as any), 200)
+      return jsonResponse(c, await queryPipelineWithStatus(temporal, pipeline), 200)
     }
   )
 


### PR DESCRIPTION
## Summary
- dedupe service API pipeline query and update-response handling into shared helpers
- remove repeated response cast noise in the touched handlers
- add focused regression coverage for memo-backed query fallbacks and mutation response rereads

## Testing
- pnpm --filter @stripe/sync-service exec vitest run src/api/app.test.ts
- pnpm exec eslint apps/service/src/api/app.ts apps/service/src/api/app.test.ts
- pnpm --filter @stripe/sync-service exec tsc --noEmit
- pnpm --filter @stripe/sync-service build
