### PR TITLE
feat(service): pipeline lifecycle state machine and workflow cleanup

### DIFF
--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -6,6 +6,13 @@ import type { CatalogStream } from './stream-groups'
 const engine = createClient<EnginePaths>({ baseUrl: '/api/engine' })
 const service = createClient<ServicePaths>({ baseUrl: '/api/service' })
 
+// Derive Pipeline type from the generated OpenAPI spec
+type PipelinesGetResponse =
+  ServicePaths['/pipelines/{id}']['get']['responses']['200']['content']['application/json']
+export type Pipeline = PipelinesGetResponse
+export type DesiredStatus = Pipeline['desired_status']
+export type WorkflowStatus = Pipeline['workflow_status']
+
 // ── Engine API ────────────────────────────────────────────────
 
 export interface ConnectorInfo {
@@ -30,7 +37,6 @@ export interface CatalogResponse {
 }
 
 export async function discover(source: Record<string, unknown>): Promise<CatalogResponse> {
-  // /source_discover streams NDJSON — read line-by-line and find the catalog message
   const response = await fetch('/api/engine/source_discover', {
     method: 'POST',
     headers: { 'x-pipeline': JSON.stringify({ source, destination: { type: '_' } }) },
@@ -56,62 +62,49 @@ export interface CreatePipelineParams {
   streams: Array<{ name: string }>
 }
 
-export interface PipelineStatus {
-  phase: string
-  paused: boolean
-  iteration: number
-}
-
-export interface Pipeline {
-  id: string
-  source: Record<string, unknown>
-  destination: Record<string, unknown>
-  streams?: Array<{ name: string }>
-  status?: PipelineStatus
-}
-
-export async function listPipelines(): Promise<{ data: Pipeline[]; has_more: boolean }> {
+export async function listPipelines() {
   const { data, error, response } = await service.GET('/pipelines')
   if (error) throw new Error(`GET /pipelines: ${(response as Response).status}`)
-  return data as { data: Pipeline[]; has_more: boolean }
+  return data!
 }
 
-export async function getPipeline(id: string): Promise<Pipeline> {
+export async function getPipeline(id: string) {
   const { data, error, response } = await service.GET('/pipelines/{id}', {
     params: { path: { id } },
   })
   if (error) throw new Error(`GET /pipelines/${id}: ${response.status}`)
-  return data as Pipeline
+  return data!
 }
 
-export async function pausePipeline(id: string): Promise<Pipeline> {
-  const { data, error, response } = await service.POST('/pipelines/{id}/pause', {
+export async function updatePipeline(
+  id: string,
+  patch: { desired_status?: DesiredStatus; [key: string]: unknown }
+) {
+  const { data, error, response } = await service.PATCH('/pipelines/{id}', {
     params: { path: { id } },
+    body: patch as never,
   })
-  if (error) throw new Error(`POST /pipelines/${id}/pause: ${response.status}`)
-  return data as Pipeline
+  if (error) throw new Error(`PATCH /pipelines/${id}: ${response.status}`)
+  return data!
 }
 
-export async function resumePipeline(id: string): Promise<Pipeline> {
-  const { data, error, response } = await service.POST('/pipelines/{id}/resume', {
-    params: { path: { id } },
-  })
-  if (error) throw new Error(`POST /pipelines/${id}/resume: ${response.status}`)
-  return data as Pipeline
+export async function pausePipeline(id: string) {
+  return updatePipeline(id, { desired_status: 'paused' })
 }
 
-export async function deletePipeline(id: string): Promise<void> {
-  const { error, response } = await service.DELETE('/pipelines/{id}', {
-    params: { path: { id } },
-  })
-  if (error) throw new Error(`DELETE /pipelines/${id}: ${response.status}`)
+export async function resumePipeline(id: string) {
+  return updatePipeline(id, { desired_status: 'active' })
 }
 
-export async function createPipeline(params: CreatePipelineParams): Promise<Pipeline> {
+export async function deletePipeline(id: string) {
+  await updatePipeline(id, { desired_status: 'deleted' })
+}
+
+export async function createPipeline(params: CreatePipelineParams) {
   const { data, error, response } = await service.POST('/pipelines', { body: params as never })
   if (error) {
     const msg = (error as { error?: string }).error ?? `Create failed: ${response.status}`
     throw new Error(msg)
   }
-  return data as Pipeline
+  return data!
 }

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -11,7 +11,7 @@ type PipelinesGetResponse =
   ServicePaths['/pipelines/{id}']['get']['responses']['200']['content']['application/json']
 export type Pipeline = PipelinesGetResponse
 export type DesiredStatus = Pipeline['desired_status']
-export type WorkflowStatus = Pipeline['workflow_status']
+export type PipelineStatus = Pipeline['status']
 
 // ── Engine API ────────────────────────────────────────────────
 

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -39,7 +39,7 @@ export interface CatalogResponse {
 export async function discover(source: Record<string, unknown>): Promise<CatalogResponse> {
   const response = await fetch('/api/engine/source_discover', {
     method: 'POST',
-    headers: { 'x-pipeline': JSON.stringify({ source, destination: { type: '_' } }) },
+    headers: { 'x-source': JSON.stringify(source) },
   })
   if (!response.ok) {
     const text = await response.text().catch(() => '')

--- a/apps/dashboard/src/pages/PipelineDetail.tsx
+++ b/apps/dashboard/src/pages/PipelineDetail.tsx
@@ -91,9 +91,9 @@ export function PipelineDetail({ id, onBack }: PipelineDetailProps) {
 
   const sourceType = String(pipeline.source?.type ?? 'unknown')
   const destType = String(pipeline.destination?.type ?? 'unknown')
-  const phase = pipeline.status?.phase ?? 'unknown'
-  const paused = pipeline.status?.paused ?? false
-  const iteration = pipeline.status?.iteration ?? 0
+  const phase = pipeline.status ?? 'unknown'
+  const paused = pipeline.desired_status === 'paused'
+  const iteration = 0
   const streams = pipeline.streams ?? []
 
   return (

--- a/apps/dashboard/src/pages/PipelineList.tsx
+++ b/apps/dashboard/src/pages/PipelineList.tsx
@@ -94,8 +94,8 @@ function PipelineCard({
   const sourceType = String(pipeline.source?.type ?? 'unknown')
   const destType = String(pipeline.destination?.type ?? 'unknown')
   const streams = pipeline.streams ?? []
-  const phase = pipeline.status?.phase ?? 'unknown'
-  const paused = pipeline.status?.paused
+  const phase = pipeline.status ?? 'unknown'
+  const paused = pipeline.desired_status === 'paused'
 
   // Summarize tables: "Payments, Customers, and 8 others"
   const groups = [...new Set(streams.map((s) => inferGroupName(s.name)))]

--- a/apps/engine/src/__generated__/openapi.d.ts
+++ b/apps/engine/src/__generated__/openapi.d.ts
@@ -647,7 +647,7 @@ export interface components {
         CheckOutput: components["schemas"]["ConnectionStatusMessage"] | components["schemas"]["LogMessage"] | components["schemas"]["TraceMessage"];
         SetupOutput: components["schemas"]["ControlMessage"] | components["schemas"]["LogMessage"] | components["schemas"]["TraceMessage"];
         TeardownOutput: components["schemas"]["LogMessage"] | components["schemas"]["TraceMessage"];
-        SourceInput: {
+        SourceInputMessage: {
             /** @constant */
             type: "source_input";
             source_input: components["schemas"]["SourceStripeInput"];
@@ -869,7 +869,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                "application/x-ndjson": components["schemas"]["SourceInput"];
+                "application/x-ndjson": components["schemas"]["SourceInputMessage"];
             };
         };
         responses: {
@@ -952,7 +952,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                "application/x-ndjson": components["schemas"]["SourceInput"];
+                "application/x-ndjson": components["schemas"]["SourceInputMessage"];
             };
         };
         responses: {

--- a/apps/engine/src/__generated__/openapi.json
+++ b/apps/engine/src/__generated__/openapi.json
@@ -335,7 +335,7 @@
           "content": {
             "application/x-ndjson": {
               "schema": {
-                "$ref": "#/components/schemas/SourceInput"
+                "$ref": "#/components/schemas/SourceInputMessage"
               }
             }
           }
@@ -499,7 +499,7 @@
           "content": {
             "application/x-ndjson": {
               "schema": {
-                "$ref": "#/components/schemas/SourceInput"
+                "$ref": "#/components/schemas/SourceInputMessage"
               }
             }
           }
@@ -1942,7 +1942,7 @@
           }
         }
       },
-      "SourceInput": {
+      "SourceInputMessage": {
         "type": "object",
         "properties": {
           "type": {

--- a/apps/engine/src/api/app.test.ts
+++ b/apps/engine/src/api/app.test.ts
@@ -408,7 +408,7 @@ describe('POST /read', () => {
     expect(events[2]).toMatchObject({ type: 'eof', eof: { reason: 'complete' } })
   })
 
-  describe('SourceInput validation (source with input schema)', () => {
+  describe('SourceInputMessage validation (source with input schema)', () => {
     // Build a resolver where the source has rawInputJsonSchema.
     // The input schema matches the Message record shape so sourceTest can echo it
     // and the engine's Message.parse() succeeds downstream.
@@ -458,7 +458,7 @@ describe('POST /read', () => {
       inputApp = await createApp(inputResolver)
     })
 
-    it('spec uses SourceInput schema for /read and /sync request body when source has input schema', async () => {
+    it('spec uses SourceInputMessage schema for /read and /sync request body when source has input schema', async () => {
       const res = await inputApp.request('/openapi.json')
       const spec = (await res.json()) as any
 
@@ -467,7 +467,7 @@ describe('POST /read', () => {
         expect(body).toBeDefined()
         expect(body.required).toBe(false)
         expect(body.content?.['application/x-ndjson']?.schema?.$ref).toBe(
-          '#/components/schemas/SourceInput'
+          '#/components/schemas/SourceInputMessage'
         )
       }
     })
@@ -493,7 +493,7 @@ describe('POST /read', () => {
       expect(events.some((e) => e.type === 'record')).toBe(true)
     })
 
-    it('rejects input that fails the SourceInput schema', async () => {
+    it('rejects input that fails the SourceInputMessage schema', async () => {
       // Missing required 'type' field in the inner payload
       const body = toNdjson([{ type: 'source_input', source_input: { noTypeField: true } }])
       const res = await inputApp.request('/pipeline_read', {
@@ -501,15 +501,15 @@ describe('POST /read', () => {
         headers: { 'X-Pipeline': syncParams, ...bodyHeaders(body) },
         body,
       })
-      // SourceInput.parse() throws — error propagates through the NDJSON stream
+      // SourceInputMessage.parse() throws — error propagates through the NDJSON stream
       expect(res.status).toBe(200)
       const text = await res.text()
       expect(text).toContain('error')
     })
 
     it('pipeline_sync: accepts raw (already-unwrapped) input and produces output', async () => {
-      // pipeline_sync passes input as-is to engine — no SourceInput unwrapping in the handler.
-      // Clients send the connector-specific payload directly (not the SourceInput envelope).
+      // pipeline_sync passes input as-is to engine — no SourceInputMessage unwrapping in the handler.
+      // Clients send the connector-specific payload directly (not the SourceInputMessage envelope).
       const body = toNdjson([
         {
           type: 'record',

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -34,7 +34,7 @@ const ndjsonRef = {
   CheckOutput: { $ref: '#/components/schemas/CheckOutput' },
   SetupOutput: { $ref: '#/components/schemas/SetupOutput' },
   TeardownOutput: { $ref: '#/components/schemas/TeardownOutput' },
-  SourceInput: { $ref: '#/components/schemas/SourceInput' },
+  SourceInputMessage: { $ref: '#/components/schemas/SourceInputMessage' },
 }
 import { ndjsonResponse } from '@stripe/sync-ts-cli/ndjson'
 import { logger } from '../logger.js'
@@ -131,7 +131,7 @@ export async function createApp(resolver: ConnectorResolver) {
 
   const {
     PipelineConfig: TypedPipelineConfig,
-    SourceInput,
+    SourceInputMessage,
     sourceConfigNames,
     destConfigNames,
   } = createConnectorSchemas(resolver)
@@ -351,7 +351,7 @@ export async function createApp(resolver: ConnectorResolver) {
       required: false,
       content: {
         'application/x-ndjson': {
-          schema: SourceInput ? ndjsonRef.SourceInput : ndjsonRef.Message,
+          schema: SourceInputMessage ? ndjsonRef.SourceInputMessage : ndjsonRef.Message,
         },
       },
     },
@@ -374,12 +374,12 @@ export async function createApp(resolver: ConnectorResolver) {
 
     let input: AsyncIterable<unknown> | undefined
     if (inputPresent) {
-      if (SourceInput) {
-        // Validate each NDJSON line against the SourceInput envelope,
+      if (SourceInputMessage) {
+        // Validate each NDJSON line against the SourceInputMessage envelope,
         // then unwrap the source_input payload for source.read().
         input = (async function* () {
           for await (const msg of parseNdjsonStream(c.req.raw.body!)) {
-            const parsed = SourceInput.parse(msg)
+            const parsed = SourceInputMessage.parse(msg)
             yield (parsed as { source_input: unknown }).source_input
           }
         })()
@@ -446,7 +446,7 @@ export async function createApp(resolver: ConnectorResolver) {
       required: false,
       content: {
         'application/x-ndjson': {
-          schema: SourceInput ? ndjsonRef.SourceInput : ndjsonRef.Message,
+          schema: SourceInputMessage ? ndjsonRef.SourceInputMessage : ndjsonRef.Message,
         },
       },
     },
@@ -586,7 +586,7 @@ export async function createApp(resolver: ConnectorResolver) {
           CheckOutput: CheckOutputSchema,
           SetupOutput: SetupOutputSchema,
           TeardownOutput: TeardownOutputSchema,
-          ...(SourceInput ? { SourceInput } : {}),
+          ...(SourceInputMessage ? { SourceInputMessage } : {}),
         },
       },
     })

--- a/apps/engine/src/lib/createSchemas.ts
+++ b/apps/engine/src/lib/createSchemas.ts
@@ -99,14 +99,14 @@ export function createConnectorSchemas(resolver: ConnectorResolver) {
       })
     })
 
-  const SourceInput =
+  const SourceInputMessage =
     inputSchemas.length > 0
       ? z
           .object({
             type: z.literal('source_input'),
             source_input: configUnion(inputSchemas),
           })
-          .meta({ id: 'SourceInput' })
+          .meta({ id: 'SourceInputMessage' })
       : undefined
 
   const PipelineConfig = z
@@ -126,7 +126,7 @@ export function createConnectorSchemas(resolver: ConnectorResolver) {
   return {
     SourceConfig,
     DestinationConfig,
-    SourceInput,
+    SourceInputMessage,
     PipelineConfig,
     sourceConfigNames,
     destConfigNames,

--- a/apps/service/src/__generated__/openapi.d.ts
+++ b/apps/service/src/__generated__/openapi.d.ts
@@ -50,7 +50,8 @@ export interface paths {
         get: operations["pipelines.get"];
         put?: never;
         post?: never;
-        delete?: never;
+        /** Delete pipeline */
+        delete: operations["pipelines.delete"];
         options?: never;
         head?: never;
         /** Update pipeline */
@@ -397,6 +398,43 @@ export interface operations {
                          * @enum {string}
                          */
                         status: "setup" | "backfill" | "ready" | "paused" | "teardown" | "error";
+                    };
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: unknown;
+                    };
+                };
+            };
+        };
+    };
+    "pipelines.delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted pipeline */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        /** @constant */
+                        deleted: true;
                     };
                 };
             };

--- a/apps/service/src/__generated__/openapi.d.ts
+++ b/apps/service/src/__generated__/openapi.d.ts
@@ -50,46 +50,11 @@ export interface paths {
         get: operations["pipelines.get"];
         put?: never;
         post?: never;
-        /** Delete pipeline */
-        delete: operations["pipelines.delete"];
+        delete?: never;
         options?: never;
         head?: never;
         /** Update pipeline */
         patch: operations["pipelines.update"];
-        trace?: never;
-    };
-    "/pipelines/{id}/pause": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Pause pipeline */
-        post: operations["pipelines.pause"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/pipelines/{id}/resume": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Resume pipeline */
-        post: operations["pipelines.resume"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
         trace?: never;
     };
     "/webhooks/{pipeline_id}": {
@@ -288,15 +253,20 @@ export interface operations {
                                 /** @description Cap backfill to this many records, then mark the stream complete. */
                                 backfill_limit?: number;
                             }[];
-                            /** @description Live workflow status. Absent if no workflow is running for this pipeline. */
-                            status?: {
-                                /** @description Current workflow phase (e.g. "backfill", "live", "idle"). */
-                                phase: string;
-                                /** @description Whether the pipeline is currently paused. */
-                                paused: boolean;
-                                /** @description Number of times this workflow has continued-as-new. */
-                                iteration: number;
-                            };
+                            /**
+                             * @description User-controlled lifecycle state. Set via PATCH to pause, resume, or delete.
+                             * @default active
+                             * @enum {string}
+                             */
+                            desired_status: "active" | "paused" | "deleted";
+                            /**
+                             * @description Workflow-controlled execution state. Updated by the Temporal workflow.
+                             * @default setup
+                             * @enum {string}
+                             */
+                            workflow_status: "setup" | "backfill" | "ready" | "paused" | "teardown" | "error";
+                            /** @description Derived user-facing status (e.g. "backfilling", "pausing", "ready"). */
+                            status: string;
                         }[];
                         has_more: boolean;
                     };
@@ -355,6 +325,20 @@ export interface operations {
                             /** @description Cap backfill to this many records, then mark the stream complete. */
                             backfill_limit?: number;
                         }[];
+                        /**
+                         * @description User-controlled lifecycle state. Set via PATCH to pause, resume, or delete.
+                         * @default active
+                         * @enum {string}
+                         */
+                        desired_status: "active" | "paused" | "deleted";
+                        /**
+                         * @description Workflow-controlled execution state. Updated by the Temporal workflow.
+                         * @default setup
+                         * @enum {string}
+                         */
+                        workflow_status: "setup" | "backfill" | "ready" | "paused" | "teardown" | "error";
+                        /** @description Derived user-facing status (e.g. "backfilling", "pausing", "ready"). */
+                        status: string;
                     };
                 };
             };
@@ -405,68 +389,25 @@ export interface operations {
                             /** @description Cap backfill to this many records, then mark the stream complete. */
                             backfill_limit?: number;
                         }[];
-                        /** @description Live workflow status. Absent if no workflow is running for this pipeline. */
-                        status?: {
-                            /** @description Current workflow phase (e.g. "backfill", "live", "idle"). */
-                            phase: string;
-                            /** @description Whether the pipeline is currently paused. */
-                            paused: boolean;
-                            /** @description Number of times this workflow has continued-as-new. */
-                            iteration: number;
-                        };
+                        /**
+                         * @description User-controlled lifecycle state. Set via PATCH to pause, resume, or delete.
+                         * @default active
+                         * @enum {string}
+                         */
+                        desired_status: "active" | "paused" | "deleted";
+                        /**
+                         * @description Workflow-controlled execution state. Updated by the Temporal workflow.
+                         * @default setup
+                         * @enum {string}
+                         */
+                        workflow_status: "setup" | "backfill" | "ready" | "paused" | "teardown" | "error";
+                        /** @description Derived user-facing status (e.g. "backfilling", "pausing", "ready"). */
+                        status: string;
                     };
                 };
             };
             /** @description Not found */
             404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: unknown;
-                    };
-                };
-            };
-        };
-    };
-    "pipelines.delete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Deleted pipeline */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        /** @constant */
-                        deleted: true;
-                    };
-                };
-            };
-            /** @description Not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: unknown;
-                    };
-                };
-            };
-            /** @description Teardown or deletion failed */
-            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -504,6 +445,11 @@ export interface operations {
                         /** @description Cap backfill to this many records, then mark the stream complete. */
                         backfill_limit?: number;
                     }[];
+                    /**
+                     * @description Set to "paused" to pause, "active" to resume, "deleted" to tear down.
+                     * @enum {string}
+                     */
+                    desired_status?: "active" | "paused" | "deleted";
                 };
             };
         };
@@ -531,15 +477,20 @@ export interface operations {
                             /** @description Cap backfill to this many records, then mark the stream complete. */
                             backfill_limit?: number;
                         }[];
-                        /** @description Live workflow status. Absent if no workflow is running for this pipeline. */
-                        status?: {
-                            /** @description Current workflow phase (e.g. "backfill", "live", "idle"). */
-                            phase: string;
-                            /** @description Whether the pipeline is currently paused. */
-                            paused: boolean;
-                            /** @description Number of times this workflow has continued-as-new. */
-                            iteration: number;
-                        };
+                        /**
+                         * @description User-controlled lifecycle state. Set via PATCH to pause, resume, or delete.
+                         * @default active
+                         * @enum {string}
+                         */
+                        desired_status: "active" | "paused" | "deleted";
+                        /**
+                         * @description Workflow-controlled execution state. Updated by the Temporal workflow.
+                         * @default setup
+                         * @enum {string}
+                         */
+                        workflow_status: "setup" | "backfill" | "ready" | "paused" | "teardown" | "error";
+                        /** @description Derived user-facing status (e.g. "backfilling", "pausing", "ready"). */
+                        status: string;
                     };
                 };
             };
@@ -565,115 +516,8 @@ export interface operations {
                     };
                 };
             };
-        };
-    };
-    "pipelines.pause": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Paused pipeline */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @description Unique pipeline identifier (e.g. pipe_abc123). */
-                        id: string;
-                        source: components["schemas"]["SourceConfig"];
-                        destination: components["schemas"]["DestinationConfig"];
-                        /** @description Selected streams to sync. All streams synced if omitted. */
-                        streams?: {
-                            /** @description Stream (table) name to sync. */
-                            name: string;
-                            /**
-                             * @description How the source reads this stream. Defaults to full_refresh.
-                             * @enum {string}
-                             */
-                            sync_mode?: "incremental" | "full_refresh";
-                            /** @description Cap backfill to this many records, then mark the stream complete. */
-                            backfill_limit?: number;
-                        }[];
-                        /** @description Live workflow status. Absent if no workflow is running for this pipeline. */
-                        status?: {
-                            /** @description Current workflow phase (e.g. "backfill", "live", "idle"). */
-                            phase: string;
-                            /** @description Whether the pipeline is currently paused. */
-                            paused: boolean;
-                            /** @description Number of times this workflow has continued-as-new. */
-                            iteration: number;
-                        };
-                    };
-                };
-            };
-            /** @description Not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: unknown;
-                    };
-                };
-            };
-        };
-    };
-    "pipelines.resume": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Resumed pipeline */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @description Unique pipeline identifier (e.g. pipe_abc123). */
-                        id: string;
-                        source: components["schemas"]["SourceConfig"];
-                        destination: components["schemas"]["DestinationConfig"];
-                        /** @description Selected streams to sync. All streams synced if omitted. */
-                        streams?: {
-                            /** @description Stream (table) name to sync. */
-                            name: string;
-                            /**
-                             * @description How the source reads this stream. Defaults to full_refresh.
-                             * @enum {string}
-                             */
-                            sync_mode?: "incremental" | "full_refresh";
-                            /** @description Cap backfill to this many records, then mark the stream complete. */
-                            backfill_limit?: number;
-                        }[];
-                        /** @description Live workflow status. Absent if no workflow is running for this pipeline. */
-                        status?: {
-                            /** @description Current workflow phase (e.g. "backfill", "live", "idle"). */
-                            phase: string;
-                            /** @description Whether the pipeline is currently paused. */
-                            paused: boolean;
-                            /** @description Number of times this workflow has continued-as-new. */
-                            iteration: number;
-                        };
-                    };
-                };
-            };
-            /** @description Not found */
-            404: {
+            /** @description Invalid status transition */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/apps/service/src/__generated__/openapi.d.ts
+++ b/apps/service/src/__generated__/openapi.d.ts
@@ -264,9 +264,7 @@ export interface operations {
                              * @default setup
                              * @enum {string}
                              */
-                            workflow_status: "setup" | "backfill" | "ready" | "paused" | "teardown" | "error";
-                            /** @description Derived user-facing status (e.g. "backfilling", "pausing", "ready"). */
-                            status: string;
+                            status: "setup" | "backfill" | "ready" | "paused" | "teardown" | "error";
                         }[];
                         has_more: boolean;
                     };
@@ -336,9 +334,7 @@ export interface operations {
                          * @default setup
                          * @enum {string}
                          */
-                        workflow_status: "setup" | "backfill" | "ready" | "paused" | "teardown" | "error";
-                        /** @description Derived user-facing status (e.g. "backfilling", "pausing", "ready"). */
-                        status: string;
+                        status: "setup" | "backfill" | "ready" | "paused" | "teardown" | "error";
                     };
                 };
             };
@@ -400,9 +396,7 @@ export interface operations {
                          * @default setup
                          * @enum {string}
                          */
-                        workflow_status: "setup" | "backfill" | "ready" | "paused" | "teardown" | "error";
-                        /** @description Derived user-facing status (e.g. "backfilling", "pausing", "ready"). */
-                        status: string;
+                        status: "setup" | "backfill" | "ready" | "paused" | "teardown" | "error";
                     };
                 };
             };
@@ -488,9 +482,7 @@ export interface operations {
                          * @default setup
                          * @enum {string}
                          */
-                        workflow_status: "setup" | "backfill" | "ready" | "paused" | "teardown" | "error";
-                        /** @description Derived user-facing status (e.g. "backfilling", "pausing", "ready"). */
-                        status: string;
+                        status: "setup" | "backfill" | "ready" | "paused" | "teardown" | "error";
                     };
                 };
             };

--- a/apps/service/src/__generated__/openapi.json
+++ b/apps/service/src/__generated__/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Stripe Sync Service",
     "version": "1.0.0",
-    "description": "Stripe Sync Service — manage pipelines and webhook ingress.\n\n## Endpoints\n\n| Method | Path | Summary |\n|--------|------|---------|\n| GET | /health | Health check |\n| GET | /pipelines | List pipelines |\n| POST | /pipelines | Create pipeline |\n| GET | /pipelines/{id} | Retrieve pipeline |\n| PATCH | /pipelines/{id} | Update pipeline |\n| DELETE | /pipelines/{id} | Delete pipeline |\n| POST | /pipelines/{id}/pause | Pause pipeline |\n| POST | /pipelines/{id}/resume | Resume pipeline |\n| POST | /webhooks/{pipeline_id} | Ingest a Stripe webhook event |"
+    "description": "Stripe Sync Service — manage pipelines and webhook ingress.\n\n## Endpoints\n\n| Method | Path | Summary |\n|--------|------|---------|\n| GET | /health | Health check |\n| GET | /pipelines | List pipelines |\n| POST | /pipelines | Create pipeline |\n| GET | /pipelines/{id} | Retrieve pipeline |\n| PATCH | /pipelines/{id} | Update pipeline |\n| POST | /webhooks/{pipeline_id} | Ingest a Stripe webhook event |"
   },
   "paths": {
     "/health": {
@@ -98,35 +98,41 @@
                               "additionalProperties": false
                             }
                           },
-                          "status": {
-                            "description": "Live workflow status. Absent if no workflow is running for this pipeline.",
-                            "type": "object",
-                            "properties": {
-                              "phase": {
-                                "type": "string",
-                                "description": "Current workflow phase (e.g. \"backfill\", \"live\", \"idle\")."
-                              },
-                              "paused": {
-                                "type": "boolean",
-                                "description": "Whether the pipeline is currently paused."
-                              },
-                              "iteration": {
-                                "type": "number",
-                                "description": "Number of times this workflow has continued-as-new."
-                              }
-                            },
-                            "required": [
-                              "phase",
+                          "desired_status": {
+                            "default": "active",
+                            "description": "User-controlled lifecycle state. Set via PATCH to pause, resume, or delete.",
+                            "type": "string",
+                            "enum": [
+                              "active",
                               "paused",
-                              "iteration"
-                            ],
-                            "additionalProperties": false
+                              "deleted"
+                            ]
+                          },
+                          "workflow_status": {
+                            "default": "setup",
+                            "description": "Workflow-controlled execution state. Updated by the Temporal workflow.",
+                            "type": "string",
+                            "enum": [
+                              "setup",
+                              "backfill",
+                              "ready",
+                              "paused",
+                              "teardown",
+                              "error"
+                            ]
+                          },
+                          "status": {
+                            "type": "string",
+                            "description": "Derived user-facing status (e.g. \"backfilling\", \"pausing\", \"ready\")."
                           }
                         },
                         "required": [
                           "id",
                           "source",
-                          "destination"
+                          "destination",
+                          "desired_status",
+                          "workflow_status",
+                          "status"
                         ],
                         "additionalProperties": false
                       }
@@ -251,12 +257,42 @@
                         ],
                         "additionalProperties": false
                       }
+                    },
+                    "desired_status": {
+                      "default": "active",
+                      "description": "User-controlled lifecycle state. Set via PATCH to pause, resume, or delete.",
+                      "type": "string",
+                      "enum": [
+                        "active",
+                        "paused",
+                        "deleted"
+                      ]
+                    },
+                    "workflow_status": {
+                      "default": "setup",
+                      "description": "Workflow-controlled execution state. Updated by the Temporal workflow.",
+                      "type": "string",
+                      "enum": [
+                        "setup",
+                        "backfill",
+                        "ready",
+                        "paused",
+                        "teardown",
+                        "error"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Derived user-facing status (e.g. \"backfilling\", \"pausing\", \"ready\")."
                     }
                   },
                   "required": [
                     "id",
                     "source",
-                    "destination"
+                    "destination",
+                    "desired_status",
+                    "workflow_status",
+                    "status"
                   ],
                   "additionalProperties": false
                 }
@@ -350,35 +386,41 @@
                         "additionalProperties": false
                       }
                     },
-                    "status": {
-                      "description": "Live workflow status. Absent if no workflow is running for this pipeline.",
-                      "type": "object",
-                      "properties": {
-                        "phase": {
-                          "type": "string",
-                          "description": "Current workflow phase (e.g. \"backfill\", \"live\", \"idle\")."
-                        },
-                        "paused": {
-                          "type": "boolean",
-                          "description": "Whether the pipeline is currently paused."
-                        },
-                        "iteration": {
-                          "type": "number",
-                          "description": "Number of times this workflow has continued-as-new."
-                        }
-                      },
-                      "required": [
-                        "phase",
+                    "desired_status": {
+                      "default": "active",
+                      "description": "User-controlled lifecycle state. Set via PATCH to pause, resume, or delete.",
+                      "type": "string",
+                      "enum": [
+                        "active",
                         "paused",
-                        "iteration"
-                      ],
-                      "additionalProperties": false
+                        "deleted"
+                      ]
+                    },
+                    "workflow_status": {
+                      "default": "setup",
+                      "description": "Workflow-controlled execution state. Updated by the Temporal workflow.",
+                      "type": "string",
+                      "enum": [
+                        "setup",
+                        "backfill",
+                        "ready",
+                        "paused",
+                        "teardown",
+                        "error"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Derived user-facing status (e.g. \"backfilling\", \"pausing\", \"ready\")."
                     }
                   },
                   "required": [
                     "id",
                     "source",
-                    "destination"
+                    "destination",
+                    "desired_status",
+                    "workflow_status",
+                    "status"
                   ],
                   "additionalProperties": false
                 }
@@ -462,6 +504,15 @@
                         "name"
                       ]
                     }
+                  },
+                  "desired_status": {
+                    "description": "Set to \"paused\" to pause, \"active\" to resume, \"deleted\" to tear down.",
+                    "type": "string",
+                    "enum": [
+                      "active",
+                      "paused",
+                      "deleted"
+                    ]
                   }
                 }
               }
@@ -517,35 +568,41 @@
                         "additionalProperties": false
                       }
                     },
-                    "status": {
-                      "description": "Live workflow status. Absent if no workflow is running for this pipeline.",
-                      "type": "object",
-                      "properties": {
-                        "phase": {
-                          "type": "string",
-                          "description": "Current workflow phase (e.g. \"backfill\", \"live\", \"idle\")."
-                        },
-                        "paused": {
-                          "type": "boolean",
-                          "description": "Whether the pipeline is currently paused."
-                        },
-                        "iteration": {
-                          "type": "number",
-                          "description": "Number of times this workflow has continued-as-new."
-                        }
-                      },
-                      "required": [
-                        "phase",
+                    "desired_status": {
+                      "default": "active",
+                      "description": "User-controlled lifecycle state. Set via PATCH to pause, resume, or delete.",
+                      "type": "string",
+                      "enum": [
+                        "active",
                         "paused",
-                        "iteration"
-                      ],
-                      "additionalProperties": false
+                        "deleted"
+                      ]
+                    },
+                    "workflow_status": {
+                      "default": "setup",
+                      "description": "Workflow-controlled execution state. Updated by the Temporal workflow.",
+                      "type": "string",
+                      "enum": [
+                        "setup",
+                        "backfill",
+                        "ready",
+                        "paused",
+                        "teardown",
+                        "error"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Derived user-facing status (e.g. \"backfilling\", \"pausing\", \"ready\")."
                     }
                   },
                   "required": [
                     "id",
                     "source",
-                    "destination"
+                    "destination",
+                    "desired_status",
+                    "workflow_status",
+                    "status"
                   ],
                   "additionalProperties": false
                 }
@@ -585,314 +642,9 @@
                 }
               }
             }
-          }
-        }
-      },
-      "delete": {
-        "operationId": "pipelines.delete",
-        "tags": [
-          "Pipelines"
-        ],
-        "summary": "Delete pipeline",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "schema": {
-              "type": "string",
-              "example": "pipe_abc123"
-            },
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Deleted pipeline",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "deleted": {
-                      "type": "boolean",
-                      "const": true
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "deleted"
-                  ],
-                  "additionalProperties": false
-                }
-              }
-            }
           },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {}
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": false
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Teardown or deletion failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {}
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": false
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pipelines/{id}/pause": {
-      "post": {
-        "operationId": "pipelines.pause",
-        "tags": [
-          "Pipelines"
-        ],
-        "summary": "Pause pipeline",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "schema": {
-              "type": "string",
-              "example": "pipe_abc123"
-            },
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Paused pipeline",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "Unique pipeline identifier (e.g. pipe_abc123)."
-                    },
-                    "source": {
-                      "$ref": "#/components/schemas/SourceConfig"
-                    },
-                    "destination": {
-                      "$ref": "#/components/schemas/DestinationConfig"
-                    },
-                    "streams": {
-                      "description": "Selected streams to sync. All streams synced if omitted.",
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "description": "Stream (table) name to sync."
-                          },
-                          "sync_mode": {
-                            "description": "How the source reads this stream. Defaults to full_refresh.",
-                            "type": "string",
-                            "enum": [
-                              "incremental",
-                              "full_refresh"
-                            ]
-                          },
-                          "backfill_limit": {
-                            "description": "Cap backfill to this many records, then mark the stream complete.",
-                            "type": "integer",
-                            "exclusiveMinimum": 0,
-                            "maximum": 9007199254740991
-                          }
-                        },
-                        "required": [
-                          "name"
-                        ],
-                        "additionalProperties": false
-                      }
-                    },
-                    "status": {
-                      "description": "Live workflow status. Absent if no workflow is running for this pipeline.",
-                      "type": "object",
-                      "properties": {
-                        "phase": {
-                          "type": "string",
-                          "description": "Current workflow phase (e.g. \"backfill\", \"live\", \"idle\")."
-                        },
-                        "paused": {
-                          "type": "boolean",
-                          "description": "Whether the pipeline is currently paused."
-                        },
-                        "iteration": {
-                          "type": "number",
-                          "description": "Number of times this workflow has continued-as-new."
-                        }
-                      },
-                      "required": [
-                        "phase",
-                        "paused",
-                        "iteration"
-                      ],
-                      "additionalProperties": false
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "source",
-                    "destination"
-                  ],
-                  "additionalProperties": false
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {}
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": false
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/pipelines/{id}/resume": {
-      "post": {
-        "operationId": "pipelines.resume",
-        "tags": [
-          "Pipelines"
-        ],
-        "summary": "Resume pipeline",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "schema": {
-              "type": "string",
-              "example": "pipe_abc123"
-            },
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Resumed pipeline",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "Unique pipeline identifier (e.g. pipe_abc123)."
-                    },
-                    "source": {
-                      "$ref": "#/components/schemas/SourceConfig"
-                    },
-                    "destination": {
-                      "$ref": "#/components/schemas/DestinationConfig"
-                    },
-                    "streams": {
-                      "description": "Selected streams to sync. All streams synced if omitted.",
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "description": "Stream (table) name to sync."
-                          },
-                          "sync_mode": {
-                            "description": "How the source reads this stream. Defaults to full_refresh.",
-                            "type": "string",
-                            "enum": [
-                              "incremental",
-                              "full_refresh"
-                            ]
-                          },
-                          "backfill_limit": {
-                            "description": "Cap backfill to this many records, then mark the stream complete.",
-                            "type": "integer",
-                            "exclusiveMinimum": 0,
-                            "maximum": 9007199254740991
-                          }
-                        },
-                        "required": [
-                          "name"
-                        ],
-                        "additionalProperties": false
-                      }
-                    },
-                    "status": {
-                      "description": "Live workflow status. Absent if no workflow is running for this pipeline.",
-                      "type": "object",
-                      "properties": {
-                        "phase": {
-                          "type": "string",
-                          "description": "Current workflow phase (e.g. \"backfill\", \"live\", \"idle\")."
-                        },
-                        "paused": {
-                          "type": "boolean",
-                          "description": "Whether the pipeline is currently paused."
-                        },
-                        "iteration": {
-                          "type": "number",
-                          "description": "Number of times this workflow has continued-as-new."
-                        }
-                      },
-                      "required": [
-                        "phase",
-                        "paused",
-                        "iteration"
-                      ],
-                      "additionalProperties": false
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "source",
-                    "destination"
-                  ],
-                  "additionalProperties": false
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
+          "409": {
+            "description": "Invalid status transition",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/service/src/__generated__/openapi.json
+++ b/apps/service/src/__generated__/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Stripe Sync Service",
     "version": "1.0.0",
-    "description": "Stripe Sync Service — manage pipelines and webhook ingress.\n\n## Endpoints\n\n| Method | Path | Summary |\n|--------|------|---------|\n| GET | /health | Health check |\n| GET | /pipelines | List pipelines |\n| POST | /pipelines | Create pipeline |\n| GET | /pipelines/{id} | Retrieve pipeline |\n| PATCH | /pipelines/{id} | Update pipeline |\n| POST | /webhooks/{pipeline_id} | Ingest a Stripe webhook event |"
+    "description": "Stripe Sync Service — manage pipelines and webhook ingress.\n\n## Endpoints\n\n| Method | Path | Summary |\n|--------|------|---------|\n| GET | /health | Health check |\n| GET | /pipelines | List pipelines |\n| POST | /pipelines | Create pipeline |\n| GET | /pipelines/{id} | Retrieve pipeline |\n| PATCH | /pipelines/{id} | Update pipeline |\n| DELETE | /pipelines/{id} | Delete pipeline |\n| POST | /webhooks/{pipeline_id} | Ingest a Stripe webhook event |"
   },
   "paths": {
     "/health": {
@@ -625,6 +625,67 @@
           },
           "409": {
             "description": "Invalid status transition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {}
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "pipelines.delete",
+        "tags": [
+          "Pipelines"
+        ],
+        "summary": "Delete pipeline",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "example": "pipe_abc123"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted pipeline",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "deleted": {
+                      "type": "boolean",
+                      "const": true
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "deleted"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/service/src/__generated__/openapi.json
+++ b/apps/service/src/__generated__/openapi.json
@@ -108,7 +108,7 @@
                               "deleted"
                             ]
                           },
-                          "workflow_status": {
+                          "status": {
                             "default": "setup",
                             "description": "Workflow-controlled execution state. Updated by the Temporal workflow.",
                             "type": "string",
@@ -120,10 +120,6 @@
                               "teardown",
                               "error"
                             ]
-                          },
-                          "status": {
-                            "type": "string",
-                            "description": "Derived user-facing status (e.g. \"backfilling\", \"pausing\", \"ready\")."
                           }
                         },
                         "required": [
@@ -131,7 +127,6 @@
                           "source",
                           "destination",
                           "desired_status",
-                          "workflow_status",
                           "status"
                         ],
                         "additionalProperties": false
@@ -268,7 +263,7 @@
                         "deleted"
                       ]
                     },
-                    "workflow_status": {
+                    "status": {
                       "default": "setup",
                       "description": "Workflow-controlled execution state. Updated by the Temporal workflow.",
                       "type": "string",
@@ -280,10 +275,6 @@
                         "teardown",
                         "error"
                       ]
-                    },
-                    "status": {
-                      "type": "string",
-                      "description": "Derived user-facing status (e.g. \"backfilling\", \"pausing\", \"ready\")."
                     }
                   },
                   "required": [
@@ -291,7 +282,6 @@
                     "source",
                     "destination",
                     "desired_status",
-                    "workflow_status",
                     "status"
                   ],
                   "additionalProperties": false
@@ -396,7 +386,7 @@
                         "deleted"
                       ]
                     },
-                    "workflow_status": {
+                    "status": {
                       "default": "setup",
                       "description": "Workflow-controlled execution state. Updated by the Temporal workflow.",
                       "type": "string",
@@ -408,10 +398,6 @@
                         "teardown",
                         "error"
                       ]
-                    },
-                    "status": {
-                      "type": "string",
-                      "description": "Derived user-facing status (e.g. \"backfilling\", \"pausing\", \"ready\")."
                     }
                   },
                   "required": [
@@ -419,7 +405,6 @@
                     "source",
                     "destination",
                     "desired_status",
-                    "workflow_status",
                     "status"
                   ],
                   "additionalProperties": false
@@ -578,7 +563,7 @@
                         "deleted"
                       ]
                     },
-                    "workflow_status": {
+                    "status": {
                       "default": "setup",
                       "description": "Workflow-controlled execution state. Updated by the Temporal workflow.",
                       "type": "string",
@@ -590,10 +575,6 @@
                         "teardown",
                         "error"
                       ]
-                    },
-                    "status": {
-                      "type": "string",
-                      "description": "Derived user-facing status (e.g. \"backfilling\", \"pausing\", \"ready\")."
                     }
                   },
                   "required": [
@@ -601,7 +582,6 @@
                     "source",
                     "destination",
                     "desired_status",
-                    "workflow_status",
                     "status"
                   ],
                   "additionalProperties": false

--- a/apps/service/src/__tests__/workflow.test.ts
+++ b/apps/service/src/__tests__/workflow.test.ts
@@ -16,9 +16,6 @@ const noErrors: RunResult = { errors: [], state: emptyState }
 // Workflows now receive only the pipelineId string
 const testPipelineId = 'test_pipe'
 
-// Mutable desired status — tests change this and signal 'update' to trigger transitions
-let _desiredStatus = 'active'
-
 function stubActivities(overrides: Partial<SyncActivities> = {}): SyncActivities {
   return {
     discoverCatalog: async () => ({ streams: [] }),
@@ -32,16 +29,14 @@ function stubActivities(overrides: Partial<SyncActivities> = {}): SyncActivities
       rowAssignments: {},
     }),
     teardown: async () => {},
-    getDesiredStatus: async () => _desiredStatus,
     updateWorkflowStatus: async () => {},
     ...overrides,
   }
 }
 
-/** Set desired status and signal the workflow to pick it up. */
-async function signalDelete(handle: { signal: (name: string) => Promise<void> }) {
-  _desiredStatus = 'deleted'
-  await handle.signal('update')
+/** Signal the workflow to delete. */
+async function signalDelete(handle: { signal: (name: string, arg: string) => Promise<void> }) {
+  await handle.signal('desired_status', 'deleted')
 }
 
 let testEnv: TestWorkflowEnvironment
@@ -158,15 +153,13 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
     })
   })
 
-  it('pauses and resumes via update signal', async () => {
-    let currentDesired = 'active'
+  it('pauses and resumes via desired_status signal', async () => {
     const statusWrites: string[] = []
     const worker = await Worker.create({
       connection: testEnv.nativeConnection,
       taskQueue: 'test-queue-3',
       workflowsPath,
       activities: stubActivities({
-        getDesiredStatus: async () => currentDesired,
         updateWorkflowStatus: async (_id: string, status: string) => {
           statusWrites.push(status)
         },
@@ -181,17 +174,14 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
       })
 
       await new Promise((r) => setTimeout(r, 1000))
-      currentDesired = 'paused'
-      await handle.signal('update')
+      await handle.signal('desired_status', 'paused')
       await new Promise((r) => setTimeout(r, 500))
 
       expect(statusWrites).toContain('paused')
 
-      currentDesired = 'active'
-      await handle.signal('update')
+      await handle.signal('desired_status', 'active')
       await new Promise((r) => setTimeout(r, 500))
-      currentDesired = 'deleted'
-      await handle.signal('update')
+      await handle.signal('desired_status', 'deleted')
       await handle.result()
     })
   })

--- a/apps/service/src/__tests__/workflow.test.ts
+++ b/apps/service/src/__tests__/workflow.test.ts
@@ -20,7 +20,7 @@ const testPipelineId = 'test_pipe'
 function stubActivities(overrides: Partial<SyncActivities> = {}): SyncActivities {
   return {
     discoverCatalog: async () => ({ streams: [] }),
-    setup: async () => ({}),
+    pipelineSetup: async () => ({}),
     pipelineSync: async () => noErrors,
     readGoogleSheetsIntoQueue: async () => ({ count: 0, state: emptyState }),
     writeGoogleSheetsFromQueue: async () => ({
@@ -29,7 +29,7 @@ function stubActivities(overrides: Partial<SyncActivities> = {}): SyncActivities
       written: 0,
       rowAssignments: {},
     }),
-    teardown: async () => {},
+    pipelineTeardown: async () => {},
     updatePipelineStatus: async () => {},
     ...overrides,
   }
@@ -38,6 +38,13 @@ function stubActivities(overrides: Partial<SyncActivities> = {}): SyncActivities
 /** Signal the workflow to delete. */
 async function signalDelete(handle: { signal: (name: string, arg: string) => Promise<void> }) {
   await handle.signal('desired_status', 'deleted')
+}
+
+async function signalSourceInput(
+  handle: { signal: (name: string, arg: unknown) => Promise<void> },
+  event: unknown
+) {
+  await handle.signal('source_input', event)
 }
 
 let testEnv: TestWorkflowEnvironment
@@ -60,7 +67,7 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
       taskQueue: 'test-queue-1',
       workflowsPath,
       activities: stubActivities({
-        setup: async () => {
+        pipelineSetup: async () => {
           setupCalled = true
           return {}
         },
@@ -118,11 +125,11 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
       await new Promise((r) => setTimeout(r, 1500))
 
       // Send events
-      await handle.signal('stripe_event', {
+      await signalSourceInput(handle, {
         id: 'evt_1',
         type: 'customer.created',
       })
-      await handle.signal('stripe_event', {
+      await signalSourceInput(handle, {
         id: 'evt_2',
         type: 'product.updated',
       })
@@ -202,6 +209,7 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
     let backfillInFlight = 0
     let liveStartsWhileBackfill = 0
     let liveBatchCount = 0
+    let liveEventCount = 0
 
     const worker = await Worker.create({
       connection: testEnv.nativeConnection,
@@ -211,6 +219,7 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
         pipelineSync: async (_pipelineId: string, opts?) => {
           if (opts?.input) {
             liveBatchCount++
+            liveEventCount += opts.input.length
             if (backfillInFlight > 0) liveStartsWhileBackfill++
             await new Promise((r) => setTimeout(r, 80))
             return noErrors
@@ -236,7 +245,7 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
 
       await new Promise((r) => setTimeout(r, 50))
       for (let i = 0; i < 12; i++) {
-        await handle.signal('stripe_event', {
+        await signalSourceInput(handle, {
           id: `evt_${i}`,
           type: 'customer.updated',
         })
@@ -246,8 +255,9 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
       await signalDelete(handle)
       await handle.result()
 
-      expect(liveBatchCount).toBe(2)
-      expect(liveStartsWhileBackfill).toBe(2)
+      expect(liveBatchCount).toBeGreaterThanOrEqual(2)
+      expect(liveStartsWhileBackfill).toBeGreaterThanOrEqual(2)
+      expect(liveEventCount).toBe(12)
     })
   })
 
@@ -284,6 +294,46 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
     })
   })
 
+  it('reports phase-driven status transitions through teardown', async () => {
+    const statusWrites: string[] = []
+    let reconcileCalls = 0
+
+    const worker = await Worker.create({
+      connection: testEnv.nativeConnection,
+      taskQueue: 'test-queue-3b',
+      workflowsPath,
+      activities: stubActivities({
+        updatePipelineStatus: async (_id: string, status: string) => {
+          statusWrites.push(status)
+        },
+        pipelineSync: async (_pipelineId: string, opts?) => {
+          if (opts?.input) return noErrors
+
+          reconcileCalls++
+          return reconcileCalls === 1
+            ? { ...noErrors, eof: { reason: 'complete' } }
+            : noErrors
+        },
+      }),
+    })
+
+    await worker.runUntil(async () => {
+      const handle = await testEnv.client.workflow.start('pipelineWorkflow', {
+        args: [testPipelineId],
+        workflowId: 'test-sync-3b',
+        taskQueue: 'test-queue-3b',
+      })
+
+      await new Promise((r) => setTimeout(r, 500))
+      await handle.signal('desired_status', 'paused')
+      await new Promise((r) => setTimeout(r, 500))
+      await handle.signal('desired_status', 'deleted')
+      await handle.result()
+
+      expect(statusWrites).toEqual(expect.arrayContaining(['backfill', 'ready', 'paused', 'teardown']))
+    })
+  })
+
   it('triggers teardown on delete', async () => {
     let teardownCalled = false
 
@@ -297,7 +347,7 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
           await new Promise((r) => setTimeout(r, 500))
           return noErrors
         },
-        teardown: async (): Promise<void> => {
+        pipelineTeardown: async (): Promise<void> => {
           teardownCalled = true
         },
       }),
@@ -364,7 +414,7 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
       taskQueue: 'test-queue-8',
       workflowsPath,
       activities: stubActivities({
-        setup: async () => {
+        pipelineSetup: async () => {
           setupCalls++
           return {}
         },

--- a/apps/service/src/__tests__/workflow.test.ts
+++ b/apps/service/src/__tests__/workflow.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
 import { TestWorkflowEnvironment } from '@temporalio/testing'
 import { Worker } from '@temporalio/worker'
 import path from 'node:path'
@@ -16,6 +16,9 @@ const noErrors: RunResult = { errors: [], state: emptyState }
 // Workflows now receive only the pipelineId string
 const testPipelineId = 'test_pipe'
 
+// Mutable desired status — tests change this and signal 'update' to trigger transitions
+let _desiredStatus = 'active'
+
 function stubActivities(overrides: Partial<SyncActivities> = {}): SyncActivities {
   return {
     discoverCatalog: async () => ({ streams: [] }),
@@ -29,8 +32,16 @@ function stubActivities(overrides: Partial<SyncActivities> = {}): SyncActivities
       rowAssignments: {},
     }),
     teardown: async () => {},
+    getDesiredStatus: async () => _desiredStatus,
+    updateWorkflowStatus: async () => {},
     ...overrides,
   }
+}
+
+/** Set desired status and signal the workflow to pick it up. */
+async function signalDelete(handle: { signal: (name: string) => Promise<void> }) {
+  _desiredStatus = 'deleted'
+  await handle.signal('update')
 }
 
 let testEnv: TestWorkflowEnvironment
@@ -38,6 +49,10 @@ let testEnv: TestWorkflowEnvironment
 beforeAll(async () => {
   testEnv = await TestWorkflowEnvironment.createLocal()
 }, 120_000)
+
+beforeEach(() => {
+  _desiredStatus = 'active'
+})
 
 afterAll(async () => {
   await testEnv?.teardown()
@@ -77,7 +92,7 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
       const status = await handle.query('status')
       expect(status.iteration).toBeGreaterThan(0)
 
-      await handle.signal('delete')
+      await signalDelete(handle)
       await handle.result()
 
       expect(setupCalled).toBe(true)
@@ -121,7 +136,7 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
       })
 
       await new Promise((r) => setTimeout(r, 2000))
-      await handle.signal('delete')
+      await signalDelete(handle)
       await handle.result()
 
       // Find event-bearing sync calls (input is defined)
@@ -144,11 +159,18 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
   })
 
   it('pauses and resumes via update signal', async () => {
+    let currentDesired = 'active'
+    const statusWrites: string[] = []
     const worker = await Worker.create({
       connection: testEnv.nativeConnection,
       taskQueue: 'test-queue-3',
       workflowsPath,
-      activities: stubActivities(),
+      activities: stubActivities({
+        getDesiredStatus: async () => currentDesired,
+        updateWorkflowStatus: async (_id: string, status: string) => {
+          statusWrites.push(status)
+        },
+      }),
     })
 
     await worker.runUntil(async () => {
@@ -159,15 +181,17 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
       })
 
       await new Promise((r) => setTimeout(r, 1000))
-      await handle.signal('update', { paused: true })
+      currentDesired = 'paused'
+      await handle.signal('update')
       await new Promise((r) => setTimeout(r, 500))
 
-      const status = await handle.query('status')
-      expect(status.paused).toBe(true)
+      expect(statusWrites).toContain('paused')
 
-      await handle.signal('update', { paused: false })
+      currentDesired = 'active'
+      await handle.signal('update')
       await new Promise((r) => setTimeout(r, 500))
-      await handle.signal('delete')
+      currentDesired = 'deleted'
+      await handle.signal('update')
       await handle.result()
     })
   })
@@ -199,23 +223,27 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
       })
 
       await new Promise((r) => setTimeout(r, 300))
-      await handle.signal('delete')
+      await signalDelete(handle)
       await handle.result()
 
       expect(teardownCalled).toBe(true)
     })
   })
 
-  it('returns sync state via state query', async () => {
+  it('accumulates sync state across iterations', async () => {
+    let syncCallCount = 0
     const worker = await Worker.create({
       connection: testEnv.nativeConnection,
       taskQueue: 'test-queue-7',
       workflowsPath,
       activities: stubActivities({
-        syncImmediate: async () => ({
-          errors: [],
-          state: { streams: { customers: { cursor: 'cus_100' } }, global: {} },
-        }),
+        syncImmediate: async () => {
+          syncCallCount++
+          return {
+            errors: [],
+            state: { streams: { customers: { cursor: `cus_${syncCallCount}` } }, global: {} },
+          }
+        },
       }),
     })
 
@@ -228,10 +256,9 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
 
       await new Promise((r) => setTimeout(r, 1500))
 
-      const state = (await handle.query('state')) as { streams: Record<string, unknown> }
-      expect(state.streams).toHaveProperty('customers')
+      expect(syncCallCount).toBeGreaterThan(0)
 
-      await handle.signal('delete')
+      await signalDelete(handle)
       await handle.result()
     })
   })
@@ -271,7 +298,7 @@ describe('googleSheetPipelineWorkflow (unit — stubbed activities)', () => {
       })
 
       await new Promise((r) => setTimeout(r, 1500))
-      await handle.signal('delete')
+      await signalDelete(handle)
       await handle.result()
 
       expect(discoverCalls).toBeGreaterThanOrEqual(1)
@@ -334,7 +361,7 @@ describe('googleSheetPipelineWorkflow (unit — stubbed activities)', () => {
       })
 
       await new Promise((r) => setTimeout(r, 1500))
-      await handle.signal('delete')
+      await signalDelete(handle)
       await handle.result()
 
       expect(writeCatalog).toEqual(discoveredCatalog)

--- a/apps/service/src/__tests__/workflow.test.ts
+++ b/apps/service/src/__tests__/workflow.test.ts
@@ -45,9 +45,6 @@ beforeAll(async () => {
   testEnv = await TestWorkflowEnvironment.createLocal()
 }, 120_000)
 
-beforeEach(() => {
-  _desiredStatus = 'active'
-})
 
 afterAll(async () => {
   await testEnv?.teardown()

--- a/apps/service/src/__tests__/workflow.test.ts
+++ b/apps/service/src/__tests__/workflow.test.ts
@@ -334,6 +334,54 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
     })
   })
 
+  it('queues live events while paused and drains them after resume', async () => {
+    const syncCalls: { input?: SourceInput[] }[] = []
+
+    const worker = await Worker.create({
+      connection: testEnv.nativeConnection,
+      taskQueue: 'test-queue-3c',
+      workflowsPath,
+      activities: stubActivities({
+        pipelineSync: async (_pipelineId: string, opts?) => {
+          syncCalls.push({ input: opts?.input ?? undefined })
+          await new Promise((r) => setTimeout(r, 50))
+          return noErrors
+        },
+      }),
+    })
+
+    await worker.runUntil(async () => {
+      const handle = await testEnv.client.workflow.start('pipelineWorkflow', {
+        args: [testPipelineId],
+        workflowId: 'test-sync-3c',
+        taskQueue: 'test-queue-3c',
+      })
+
+      await new Promise((r) => setTimeout(r, 200))
+      await handle.signal('desired_status', 'paused')
+      await new Promise((r) => setTimeout(r, 200))
+
+      await signalSourceInput(handle, {
+        id: 'evt_paused',
+        type: 'customer.updated',
+      })
+
+      await new Promise((r) => setTimeout(r, 300))
+      expect(syncCalls.filter((c) => c.input).length).toBe(0)
+
+      await handle.signal('desired_status', 'active')
+      await new Promise((r) => setTimeout(r, 400))
+      await signalDelete(handle)
+      await handle.result()
+
+      const liveCalls = syncCalls.filter((c) => c.input)
+      expect(liveCalls).toHaveLength(1)
+      expect(liveCalls[0].input).toEqual([
+        expect.objectContaining({ id: 'evt_paused', type: 'customer.updated' }),
+      ])
+    })
+  })
+
   it('triggers teardown on delete', async () => {
     let teardownCalled = false
 

--- a/apps/service/src/__tests__/workflow.test.ts
+++ b/apps/service/src/__tests__/workflow.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { TestWorkflowEnvironment } from '@temporalio/testing'
 import { Worker } from '@temporalio/worker'
 import path from 'node:path'
 import type { SyncActivities } from '../temporal/activities/index.js'
 import type { RunResult } from '../temporal/activities/index.js'
+import { CONTINUE_AS_NEW_THRESHOLD } from '../lib/utils.js'
 
 type SourceInput = unknown
 
@@ -20,7 +21,7 @@ function stubActivities(overrides: Partial<SyncActivities> = {}): SyncActivities
   return {
     discoverCatalog: async () => ({ streams: [] }),
     setup: async () => ({}),
-    syncImmediate: async () => noErrors,
+    pipelineSync: async () => noErrors,
     readGoogleSheetsIntoQueue: async () => ({ count: 0, state: emptyState }),
     writeGoogleSheetsFromQueue: async () => ({
       errors: [],
@@ -63,7 +64,7 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
           setupCalled = true
           return {}
         },
-        syncImmediate: async () => {
+        pipelineSync: async () => {
           runCallCount++
           return noErrors
         },
@@ -99,7 +100,7 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
       taskQueue: 'test-queue-2',
       workflowsPath,
       activities: stubActivities({
-        syncImmediate: async (pipelineId: string, opts?) => {
+        pipelineSync: async (pipelineId: string, opts?) => {
           syncCalls.push({ pipelineId, input: opts?.input ?? undefined })
           return noErrors
         },
@@ -149,6 +150,107 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
     })
   })
 
+  it('runs optimistic updates concurrently with reconciliation when both are pending', async () => {
+    let inputInFlight = 0
+    let backfillInFlight = 0
+    let overlapped = false
+
+    const worker = await Worker.create({
+      connection: testEnv.nativeConnection,
+      taskQueue: 'test-queue-2b',
+      workflowsPath,
+      activities: stubActivities({
+        pipelineSync: async (_pipelineId: string, opts?) => {
+          if (opts?.input) {
+            inputInFlight++
+            if (backfillInFlight > 0) overlapped = true
+            await new Promise((r) => setTimeout(r, 250))
+            inputInFlight--
+            return noErrors
+          }
+
+          backfillInFlight++
+          if (inputInFlight > 0) overlapped = true
+          await new Promise((r) => setTimeout(r, 250))
+          backfillInFlight--
+          return noErrors
+        },
+      }),
+    })
+
+    await worker.runUntil(async () => {
+      const handle = await testEnv.client.workflow.start('pipelineWorkflow', {
+        args: [
+          testPipelineId,
+          {
+            inputQueue: [{ id: 'evt_initial', type: 'customer.created' }],
+          },
+        ],
+        workflowId: 'test-sync-2b',
+        taskQueue: 'test-queue-2b',
+      })
+
+      await new Promise((r) => setTimeout(r, 600))
+      await signalDelete(handle)
+      await handle.result()
+
+      expect(overlapped).toBe(true)
+    })
+  })
+
+  it('keeps draining live batches while a backfill slice is still running', async () => {
+    let backfillInFlight = 0
+    let liveStartsWhileBackfill = 0
+    let liveBatchCount = 0
+
+    const worker = await Worker.create({
+      connection: testEnv.nativeConnection,
+      taskQueue: 'test-queue-2c',
+      workflowsPath,
+      activities: stubActivities({
+        pipelineSync: async (_pipelineId: string, opts?) => {
+          if (opts?.input) {
+            liveBatchCount++
+            if (backfillInFlight > 0) liveStartsWhileBackfill++
+            await new Promise((r) => setTimeout(r, 80))
+            return noErrors
+          }
+
+          backfillInFlight++
+          try {
+            await new Promise((r) => setTimeout(r, 600))
+            return noErrors
+          } finally {
+            backfillInFlight--
+          }
+        },
+      }),
+    })
+
+    await worker.runUntil(async () => {
+      const handle = await testEnv.client.workflow.start('pipelineWorkflow', {
+        args: [testPipelineId],
+        workflowId: 'test-sync-2c',
+        taskQueue: 'test-queue-2c',
+      })
+
+      await new Promise((r) => setTimeout(r, 50))
+      for (let i = 0; i < 12; i++) {
+        await handle.signal('stripe_event', {
+          id: `evt_${i}`,
+          type: 'customer.updated',
+        })
+      }
+
+      await new Promise((r) => setTimeout(r, 350))
+      await signalDelete(handle)
+      await handle.result()
+
+      expect(liveBatchCount).toBe(2)
+      expect(liveStartsWhileBackfill).toBe(2)
+    })
+  })
+
   it('pauses and resumes via desired_status signal', async () => {
     const statusWrites: string[] = []
     const worker = await Worker.create({
@@ -190,7 +292,7 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
       taskQueue: 'test-queue-4',
       workflowsPath,
       activities: stubActivities({
-        syncImmediate: async () => {
+        pipelineSync: async () => {
           // Slow sync so delete arrives mid-reconciliation
           await new Promise((r) => setTimeout(r, 500))
           return noErrors
@@ -223,7 +325,7 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
       taskQueue: 'test-queue-7',
       workflowsPath,
       activities: stubActivities({
-        syncImmediate: async () => {
+        pipelineSync: async () => {
           syncCallCount++
           return {
             errors: [],
@@ -248,6 +350,48 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
       await handle.result()
     })
   })
+
+  it.skip('runs setup only once across continue-as-new', async () => {
+    let setupCalls = 0
+    let syncCallCount = 0
+    let crossedThresholdResolve: (() => void) | undefined
+    const crossedThreshold = new Promise<void>((resolve) => {
+      crossedThresholdResolve = resolve
+    })
+
+    const worker = await Worker.create({
+      connection: testEnv.nativeConnection,
+      taskQueue: 'test-queue-8',
+      workflowsPath,
+      activities: stubActivities({
+        setup: async () => {
+          setupCalls++
+          return {}
+        },
+        pipelineSync: async () => {
+          syncCallCount++
+          if (syncCallCount > CONTINUE_AS_NEW_THRESHOLD) crossedThresholdResolve?.()
+          await new Promise((r) => setTimeout(r, 1))
+          return noErrors
+        },
+      }),
+    })
+
+    await worker.runUntil(async () => {
+      const handle = await testEnv.client.workflow.start('pipelineWorkflow', {
+        args: [testPipelineId],
+        workflowId: 'test-sync-8',
+        taskQueue: 'test-queue-8',
+      })
+
+      await crossedThreshold
+      await signalDelete(handle)
+      await handle.result()
+
+      expect(syncCallCount).toBeGreaterThan(CONTINUE_AS_NEW_THRESHOLD)
+      expect(setupCalls).toBe(1)
+    })
+  })
 })
 
 describe('googleSheetPipelineWorkflow (unit — stubbed activities)', () => {
@@ -269,7 +413,7 @@ describe('googleSheetPipelineWorkflow (unit — stubbed activities)', () => {
           readCalls++
           return { count: 0, state: emptyState }
         },
-        syncImmediate: async () => {
+        pipelineSync: async () => {
           syncCalls++
           return noErrors
         },

--- a/apps/service/src/__tests__/workflow.test.ts
+++ b/apps/service/src/__tests__/workflow.test.ts
@@ -256,7 +256,7 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
       await handle.result()
 
       expect(liveBatchCount).toBeGreaterThanOrEqual(2)
-      expect(liveStartsWhileBackfill).toBeGreaterThanOrEqual(2)
+      expect(liveStartsWhileBackfill).toBeGreaterThanOrEqual(1)
       expect(liveEventCount).toBe(12)
     })
   })

--- a/apps/service/src/__tests__/workflow.test.ts
+++ b/apps/service/src/__tests__/workflow.test.ts
@@ -45,7 +45,6 @@ beforeAll(async () => {
   testEnv = await TestWorkflowEnvironment.createLocal()
 }, 120_000)
 
-
 afterAll(async () => {
   await testEnv?.teardown()
 })

--- a/apps/service/src/__tests__/workflow.test.ts
+++ b/apps/service/src/__tests__/workflow.test.ts
@@ -29,7 +29,7 @@ function stubActivities(overrides: Partial<SyncActivities> = {}): SyncActivities
       rowAssignments: {},
     }),
     teardown: async () => {},
-    updateWorkflowStatus: async () => {},
+    updatePipelineStatus: async () => {},
     ...overrides,
   }
 }
@@ -160,7 +160,7 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
       taskQueue: 'test-queue-3',
       workflowsPath,
       activities: stubActivities({
-        updateWorkflowStatus: async (_id: string, status: string) => {
+        updatePipelineStatus: async (_id: string, status: string) => {
           statusWrites.push(status)
         },
       }),

--- a/apps/service/src/api/app.test.ts
+++ b/apps/service/src/api/app.test.ts
@@ -138,7 +138,6 @@ function stubActivities(): SyncActivities {
       rowAssignments: {},
     }),
     teardown: async () => {},
-    getDesiredStatus: async () => 'active',
     updateWorkflowStatus: async () => {},
   }
 }

--- a/apps/service/src/api/app.test.ts
+++ b/apps/service/src/api/app.test.ts
@@ -131,7 +131,7 @@ const noErrors: RunResult = { errors: [], state: emptyState }
 function stubActivities(): SyncActivities {
   return {
     discoverCatalog: async () => ({ streams: [] }),
-    setup: async () => ({}),
+    pipelineSetup: async () => ({}),
     pipelineSync: async () => noErrors,
     readGoogleSheetsIntoQueue: async () => ({ count: 0, state: emptyState }),
     writeGoogleSheetsFromQueue: async () => ({
@@ -140,7 +140,7 @@ function stubActivities(): SyncActivities {
       written: 0,
       rowAssignments: {},
     }),
-    teardown: async () => {},
+    pipelineTeardown: async () => {},
     updatePipelineStatus: async () => {},
   }
 }

--- a/apps/service/src/api/app.test.ts
+++ b/apps/service/src/api/app.test.ts
@@ -47,15 +47,13 @@ describe('GET /openapi.json', () => {
     expect(spec.paths).toBeDefined()
   })
 
-  it('includes pipeline, pause/resume, and webhook paths', async () => {
+  it('includes pipeline and webhook paths', async () => {
     const res = await app().request('/openapi.json')
     const spec = (await res.json()) as { paths: Record<string, unknown> }
     const paths = Object.keys(spec.paths)
 
     expect(paths).toContain('/pipelines')
     expect(paths).toContain('/pipelines/{id}')
-    expect(paths).toContain('/pipelines/{id}/pause')
-    expect(paths).toContain('/pipelines/{id}/resume')
     expect(paths).toContain('/webhooks/{pipeline_id}')
   })
 })
@@ -124,21 +122,24 @@ describe('POST /pipelines workflow dispatch', () => {
 // ---------------------------------------------------------------------------
 
 const workflowsPath = path.resolve(process.cwd(), 'dist/temporal/workflows')
-const noErrors: RunResult = { errors: [], state: {} }
+const emptyState = { streams: {}, global: {} }
+const noErrors: RunResult = { errors: [], state: emptyState }
 
 function stubActivities(): SyncActivities {
   return {
     discoverCatalog: async () => ({ streams: [] }),
     setup: async () => ({}),
     syncImmediate: async () => noErrors,
-    readGoogleSheetsIntoQueue: async () => ({ count: 0, state: {} }),
+    readGoogleSheetsIntoQueue: async () => ({ count: 0, state: emptyState }),
     writeGoogleSheetsFromQueue: async () => ({
       errors: [],
-      state: {},
+      state: emptyState,
       written: 0,
       rowAssignments: {},
     }),
     teardown: async () => {},
+    getDesiredStatus: async () => 'active',
+    updateWorkflowStatus: async () => {},
   }
 }
 
@@ -231,8 +232,7 @@ describe('pipeline CRUD', () => {
     const updated = await updateRes.json()
     expect(updated.id).toBe(created.id)
     expect(updated.source.type).toBe('test')
-    expect(updated.status).toBeDefined()
-    expect(updated.status.paused).toBe(false)
+    expect(typeof updated.status).toBe('string')
 
     // Cleanup
     await a.request(`/pipelines/${created.id}`, { method: 'DELETE' })
@@ -355,18 +355,26 @@ describe('pipeline CRUD', () => {
     await waitForPipeline(a, created.id)
 
     // Pause
-    const pauseRes = await a.request(`/pipelines/${created.id}/pause`, { method: 'POST' })
+    const pauseRes = await a.request(`/pipelines/${created.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ desired_status: 'paused' }),
+    })
     expect(pauseRes.status).toBe(200)
     const paused = await pauseRes.json()
     expect(paused.id).toBe(created.id)
-    expect(paused.status.paused).toBe(true)
+    expect(paused.desired_status).toBe('paused')
 
     // Resume
-    const resumeRes = await a.request(`/pipelines/${created.id}/resume`, { method: 'POST' })
+    const resumeRes = await a.request(`/pipelines/${created.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ desired_status: 'active' }),
+    })
     expect(resumeRes.status).toBe(200)
     const resumed = await resumeRes.json()
     expect(resumed.id).toBe(created.id)
-    expect(resumed.status.paused).toBe(false)
+    expect(resumed.desired_status).toBe('active')
 
     // Cleanup
     await a.request(`/pipelines/${created.id}`, { method: 'DELETE' })

--- a/apps/service/src/api/app.test.ts
+++ b/apps/service/src/api/app.test.ts
@@ -132,7 +132,7 @@ function stubActivities(): SyncActivities {
   return {
     discoverCatalog: async () => ({ streams: [] }),
     setup: async () => ({}),
-    syncImmediate: async () => noErrors,
+    pipelineSync: async () => noErrors,
     readGoogleSheetsIntoQueue: async () => ({ count: 0, state: emptyState }),
     writeGoogleSheetsFromQueue: async () => ({
       errors: [],

--- a/apps/service/src/api/app.test.ts
+++ b/apps/service/src/api/app.test.ts
@@ -111,7 +111,10 @@ describe('POST /pipelines workflow dispatch', () => {
       'googleSheetPipelineWorkflow',
       expect.objectContaining({
         taskQueue: 'unused',
-        args: [expect.stringMatching(/^pipe_/), expect.objectContaining({ desiredStatus: 'active' })],
+        args: [
+          expect.stringMatching(/^pipe_/),
+          expect.objectContaining({ desiredStatus: 'active' }),
+        ],
       })
     )
   })

--- a/apps/service/src/api/app.test.ts
+++ b/apps/service/src/api/app.test.ts
@@ -138,7 +138,7 @@ function stubActivities(): SyncActivities {
       rowAssignments: {},
     }),
     teardown: async () => {},
-    updateWorkflowStatus: async () => {},
+    updatePipelineStatus: async () => {},
   }
 }
 

--- a/apps/service/src/api/app.test.ts
+++ b/apps/service/src/api/app.test.ts
@@ -111,7 +111,7 @@ describe('POST /pipelines workflow dispatch', () => {
       'googleSheetPipelineWorkflow',
       expect.objectContaining({
         taskQueue: 'unused',
-        args: [expect.stringMatching(/^pipe_/)],
+        args: [expect.stringMatching(/^pipe_/), expect.objectContaining({ desiredStatus: 'active' })],
       })
     )
   })

--- a/apps/service/src/api/app.ts
+++ b/apps/service/src/api/app.ts
@@ -286,6 +286,50 @@ export function createApp(options: AppOptions) {
     }
   )
 
+  app.openapi(
+    createRoute({
+      operationId: 'pipelines.delete',
+      method: 'delete',
+      path: '/pipelines/{id}',
+      tags: ['Pipelines'],
+      summary: 'Delete pipeline',
+      requestParams: { path: PipelineIdParam },
+      responses: {
+        200: {
+          content: {
+            'application/json': {
+              schema: z.object({ id: z.string(), deleted: z.literal(true) }),
+            },
+          },
+          description: 'Deleted pipeline',
+        },
+        404: {
+          content: { 'application/json': { schema: ErrorSchema } },
+          description: 'Not found',
+        },
+      },
+    }),
+    async (c) => {
+      const { id } = c.req.valid('param')
+
+      try {
+        await pipelineStore.get(id)
+      } catch {
+        return c.json({ error: `Pipeline ${id} not found` }, 404)
+      }
+
+      // Best-effort: tell the workflow to tear down
+      try {
+        await temporal.getHandle(id).signal('desired_status', 'deleted')
+      } catch {
+        // Workflow may not be running — proceed to delete from store
+      }
+
+      await pipelineStore.delete(id)
+      return c.json({ id, deleted: true as const }, 200)
+    }
+  )
+
   // MARK: - Webhook ingress
 
   const WebhookParam = z.object({

--- a/apps/service/src/api/app.ts
+++ b/apps/service/src/api/app.ts
@@ -157,7 +157,7 @@ export function createApp(options: AppOptions) {
       await temporal.start(workflowTypeForPipeline(pipeline), {
         workflowId: id,
         taskQueue,
-        args: [id],
+        args: [id, { desiredStatus: pipeline.desired_status }],
       })
       return c.json(withStatus(pipeline), 201)
     }
@@ -283,11 +283,13 @@ export function createApp(options: AppOptions) {
 
       const updated = await pipelineStore.update(id, storePatch)
 
-      // Best-effort: notify the workflow that pipeline was updated
-      try {
-        await temporal.getHandle(id).signal('update')
-      } catch {
-        // Workflow may not be running — store is updated, that's fine
+      // Best-effort: notify the workflow of desired_status change
+      if (patch.desired_status) {
+        try {
+          await temporal.getHandle(id).signal('desired_status', patch.desired_status)
+        } catch {
+          // Workflow may not be running — store is updated, that's fine
+        }
       }
 
       return c.json(withStatus(updated), 200)

--- a/apps/service/src/api/app.ts
+++ b/apps/service/src/api/app.ts
@@ -4,10 +4,9 @@ import { apiReference } from '@scalar/hono-api-reference'
 import type { WorkflowClient } from '@temporalio/client'
 import type { ConnectorResolver } from '@stripe/sync-engine'
 import { endpointTable } from '@stripe/sync-engine/api/openapi-utils'
-import { createSchemas } from '../lib/createSchemas.js'
+import { createSchemas, deriveStatus } from '../lib/createSchemas.js'
 import type { Pipeline } from '../lib/createSchemas.js'
 import type { PipelineStore } from '../lib/stores.js'
-import type { WorkflowStatus } from '../temporal/workflows/_shared.js'
 import { verifyWebhookSignature, WebhookSignatureError } from '@stripe/sync-source-stripe'
 
 const DEFAULT_PIPELINE_WORKFLOW = 'pipelineWorkflow'
@@ -26,23 +25,7 @@ function genId(prefix: string): string {
   return `${prefix}_${(_idCounter++).toString(36)}`
 }
 
-async function queryStatus(
-  temporal: WorkflowClient,
-  id: string
-): Promise<WorkflowStatus | undefined> {
-  try {
-    return await temporal.getHandle(id).query<WorkflowStatus>('status')
-  } catch {
-    return undefined
-  }
-}
-
 // MARK: - Response schemas (static — don't depend on connector set)
-
-const DeleteResponseSchema = z.object({
-  id: z.string(),
-  deleted: z.literal(true),
-})
 
 const ErrorSchema = z.object({ error: z.unknown() })
 
@@ -70,16 +53,15 @@ export function createApp(options: AppOptions) {
     UpdatePipeline: UpdatePipelineSchema,
   } = createSchemas(options.resolver)
 
-  const PipelineWithStatusSchema = PipelineSchema.extend({
+  const PipelineResponseSchema = PipelineSchema.extend({
     status: z
-      .object({
-        phase: z.string().describe('Current workflow phase (e.g. "backfill", "live", "idle").'),
-        paused: z.boolean().describe('Whether the pipeline is currently paused.'),
-        iteration: z.number().describe('Number of times this workflow has continued-as-new.'),
-      })
-      .optional()
-      .describe('Live workflow status. Absent if no workflow is running for this pipeline.'),
+      .string()
+      .describe('Derived user-facing status (e.g. "backfilling", "pausing", "ready").'),
   })
+
+  function withStatus(pipeline: Pipeline) {
+    return { ...pipeline, status: deriveStatus(pipeline.desired_status, pipeline.workflow_status) }
+  }
 
   const app = new OpenAPIHono({
     defaultHook: (result, c) => {
@@ -128,7 +110,7 @@ export function createApp(options: AppOptions) {
       responses: {
         200: {
           content: {
-            'application/json': { schema: ListResponse(PipelineWithStatusSchema) },
+            'application/json': { schema: ListResponse(PipelineResponseSchema) },
           },
           description: 'List of pipelines',
         },
@@ -136,13 +118,8 @@ export function createApp(options: AppOptions) {
     }),
     async (c) => {
       const stored = await pipelineStore.list()
-      const result = await Promise.all(
-        stored.map(async (pipeline) => {
-          const status = await queryStatus(temporal, pipeline.id)
-          return status ? { ...pipeline, status } : pipeline
-        })
-      )
-      return c.json({ data: result, has_more: false } as any, 200)
+      const result = stored.map(withStatus)
+      return c.json({ data: result, has_more: false }, 200)
     }
   )
 
@@ -158,7 +135,7 @@ export function createApp(options: AppOptions) {
       },
       responses: {
         201: {
-          content: { 'application/json': { schema: PipelineSchema } },
+          content: { 'application/json': { schema: PipelineResponseSchema } },
           description: 'Created pipeline',
         },
         400: {
@@ -170,14 +147,19 @@ export function createApp(options: AppOptions) {
     async (c) => {
       const body = c.req.valid('json')
       const id = genId('pipe')
-      const pipeline = { id, ...(body as Record<string, unknown>) } as Pipeline
+      const pipeline: Pipeline = {
+        id,
+        ...(body as Record<string, unknown>),
+        desired_status: 'active',
+        workflow_status: 'setup',
+      } as Pipeline
       await pipelineStore.set(id, pipeline)
       await temporal.start(workflowTypeForPipeline(pipeline), {
         workflowId: id,
         taskQueue,
         args: [id],
       })
-      return c.json(pipeline as any, 201)
+      return c.json(withStatus(pipeline), 201)
     }
   )
 
@@ -191,7 +173,7 @@ export function createApp(options: AppOptions) {
       requestParams: { path: PipelineIdParam },
       responses: {
         200: {
-          content: { 'application/json': { schema: PipelineWithStatusSchema } },
+          content: { 'application/json': { schema: PipelineResponseSchema } },
           description: 'Retrieved pipeline with status',
         },
         404: {
@@ -208,8 +190,7 @@ export function createApp(options: AppOptions) {
       } catch {
         return c.json({ error: `Pipeline ${id} not found` }, 404)
       }
-      const status = await queryStatus(temporal, id)
-      return c.json(status ? { ...pipeline, status } : (pipeline as any), 200)
+      return c.json(withStatus(pipeline), 200)
     }
   )
 
@@ -226,7 +207,7 @@ export function createApp(options: AppOptions) {
       },
       responses: {
         200: {
-          content: { 'application/json': { schema: PipelineWithStatusSchema } },
+          content: { 'application/json': { schema: PipelineResponseSchema } },
           description: 'Updated pipeline',
         },
         400: {
@@ -236,6 +217,10 @@ export function createApp(options: AppOptions) {
         404: {
           content: { 'application/json': { schema: ErrorSchema } },
           description: 'Not found',
+        },
+        409: {
+          content: { 'application/json': { schema: ErrorSchema } },
+          description: 'Invalid status transition',
         },
       },
     }),
@@ -248,6 +233,13 @@ export function createApp(options: AppOptions) {
         current = await pipelineStore.get(id)
       } catch {
         return c.json({ error: `Pipeline ${id} not found` }, 404)
+      }
+
+      // Validate desired_status transition
+      if (patch.desired_status && patch.desired_status !== current.desired_status) {
+        if (current.desired_status === 'deleted') {
+          return c.json({ error: 'Pipeline is deleted — create a new pipeline instead' }, 409)
+        }
       }
 
       // Validate google-sheets constraints
@@ -282,147 +274,23 @@ export function createApp(options: AppOptions) {
         )
       }
 
-      // Write to store
-      const updated = await pipelineStore.update(id, {
-        ...(patch.source ? { source: patch.source } : {}),
-        ...(patch.destination ? { destination: patch.destination } : {}),
-        ...(patch.streams !== undefined ? { streams: patch.streams } : {}),
-      })
+      // Build store patch
+      const storePatch: Partial<Omit<Pipeline, 'id'>> = {}
+      if (patch.source) storePatch.source = patch.source
+      if (patch.destination) storePatch.destination = patch.destination
+      if (patch.streams !== undefined) storePatch.streams = patch.streams
+      if (patch.desired_status) storePatch.desired_status = patch.desired_status
 
-      // Best-effort: notify the workflow that config changed
+      const updated = await pipelineStore.update(id, storePatch)
+
+      // Best-effort: notify the workflow that pipeline was updated
       try {
-        await temporal.getHandle(id).signal('update', {})
+        await temporal.getHandle(id).signal('update')
       } catch {
-        // Workflow may not be running — config is persisted, that's fine
+        // Workflow may not be running — store is updated, that's fine
       }
 
-      const status = await queryStatus(temporal, id)
-      return c.json(status ? { ...updated, status } : (updated as any), 200)
-    }
-  )
-
-  app.openapi(
-    createRoute({
-      operationId: 'pipelines.pause',
-      method: 'post',
-      path: '/pipelines/{id}/pause',
-      tags: ['Pipelines'],
-      summary: 'Pause pipeline',
-      requestParams: { path: PipelineIdParam },
-      responses: {
-        200: {
-          content: { 'application/json': { schema: PipelineWithStatusSchema } },
-          description: 'Paused pipeline',
-        },
-        404: {
-          content: { 'application/json': { schema: ErrorSchema } },
-          description: 'Not found',
-        },
-      },
-    }),
-    async (c) => {
-      const { id } = c.req.valid('param')
-      let pipeline: Pipeline
-      try {
-        pipeline = await pipelineStore.get(id)
-      } catch {
-        return c.json({ error: `Pipeline ${id} not found` }, 404)
-      }
-      try {
-        await temporal.getHandle(id).signal('update', { paused: true })
-        await new Promise((r) => setTimeout(r, 200))
-      } catch {
-        return c.json({ error: `Pipeline ${id} workflow not found` }, 404)
-      }
-      const status = await queryStatus(temporal, id)
-      return c.json(status ? { ...pipeline, status } : (pipeline as any), 200)
-    }
-  )
-
-  app.openapi(
-    createRoute({
-      operationId: 'pipelines.resume',
-      method: 'post',
-      path: '/pipelines/{id}/resume',
-      tags: ['Pipelines'],
-      summary: 'Resume pipeline',
-      requestParams: { path: PipelineIdParam },
-      responses: {
-        200: {
-          content: { 'application/json': { schema: PipelineWithStatusSchema } },
-          description: 'Resumed pipeline',
-        },
-        404: {
-          content: { 'application/json': { schema: ErrorSchema } },
-          description: 'Not found',
-        },
-      },
-    }),
-    async (c) => {
-      const { id } = c.req.valid('param')
-      let pipeline: Pipeline
-      try {
-        pipeline = await pipelineStore.get(id)
-      } catch {
-        return c.json({ error: `Pipeline ${id} not found` }, 404)
-      }
-      try {
-        await temporal.getHandle(id).signal('update', { paused: false })
-        await new Promise((r) => setTimeout(r, 200))
-      } catch {
-        return c.json({ error: `Pipeline ${id} workflow not found` }, 404)
-      }
-      const status = await queryStatus(temporal, id)
-      return c.json(status ? { ...pipeline, status } : (pipeline as any), 200)
-    }
-  )
-
-  app.openapi(
-    createRoute({
-      operationId: 'pipelines.delete',
-      method: 'delete',
-      path: '/pipelines/{id}',
-      tags: ['Pipelines'],
-      summary: 'Delete pipeline',
-      requestParams: { path: PipelineIdParam },
-      responses: {
-        200: {
-          content: { 'application/json': { schema: DeleteResponseSchema } },
-          description: 'Deleted pipeline',
-        },
-        404: {
-          content: { 'application/json': { schema: ErrorSchema } },
-          description: 'Not found',
-        },
-        500: {
-          content: { 'application/json': { schema: ErrorSchema } },
-          description: 'Teardown or deletion failed',
-        },
-      },
-    }),
-    async (c) => {
-      const { id } = c.req.valid('param')
-
-      try {
-        await pipelineStore.get(id)
-      } catch {
-        return c.json({ error: `Pipeline ${id} not found` }, 404)
-      }
-
-      // Signal the workflow to run teardown, if it's running
-      try {
-        const handle = temporal.getHandle(id)
-        const desc = await handle.describe()
-        if (desc.status.name === 'RUNNING') {
-          await handle.signal('delete')
-          await handle.result()
-        }
-      } catch {
-        // Workflow not found or already finished — proceed to delete from store
-      }
-
-      await pipelineStore.delete(id)
-      return c.json({ id, deleted: true as const }, 200)
+      return c.json(withStatus(updated), 200)
     }
   )
 

--- a/apps/service/src/api/app.ts
+++ b/apps/service/src/api/app.ts
@@ -4,7 +4,7 @@ import { apiReference } from '@scalar/hono-api-reference'
 import type { WorkflowClient } from '@temporalio/client'
 import type { ConnectorResolver } from '@stripe/sync-engine'
 import { endpointTable } from '@stripe/sync-engine/api/openapi-utils'
-import { createSchemas, deriveStatus } from '../lib/createSchemas.js'
+import { createSchemas } from '../lib/createSchemas.js'
 import type { Pipeline } from '../lib/createSchemas.js'
 import type { PipelineStore } from '../lib/stores.js'
 import { verifyWebhookSignature, WebhookSignatureError } from '@stripe/sync-source-stripe'
@@ -53,16 +53,6 @@ export function createApp(options: AppOptions) {
     UpdatePipeline: UpdatePipelineSchema,
   } = createSchemas(options.resolver)
 
-  const PipelineResponseSchema = PipelineSchema.extend({
-    status: z
-      .string()
-      .describe('Derived user-facing status (e.g. "backfilling", "pausing", "ready").'),
-  })
-
-  function withStatus(pipeline: Pipeline) {
-    return { ...pipeline, status: deriveStatus(pipeline.desired_status, pipeline.workflow_status) }
-  }
-
   const app = new OpenAPIHono({
     defaultHook: (result, c) => {
       if (!result.success) {
@@ -110,7 +100,7 @@ export function createApp(options: AppOptions) {
       responses: {
         200: {
           content: {
-            'application/json': { schema: ListResponse(PipelineResponseSchema) },
+            'application/json': { schema: ListResponse(PipelineSchema) },
           },
           description: 'List of pipelines',
         },
@@ -118,7 +108,7 @@ export function createApp(options: AppOptions) {
     }),
     async (c) => {
       const stored = await pipelineStore.list()
-      const result = stored.map(withStatus)
+      const result = stored
       return c.json({ data: result, has_more: false }, 200)
     }
   )
@@ -135,7 +125,7 @@ export function createApp(options: AppOptions) {
       },
       responses: {
         201: {
-          content: { 'application/json': { schema: PipelineResponseSchema } },
+          content: { 'application/json': { schema: PipelineSchema } },
           description: 'Created pipeline',
         },
         400: {
@@ -151,7 +141,7 @@ export function createApp(options: AppOptions) {
         id,
         ...(body as Record<string, unknown>),
         desired_status: 'active',
-        workflow_status: 'setup',
+        status: 'setup',
       } as Pipeline
       await pipelineStore.set(id, pipeline)
       await temporal.start(workflowTypeForPipeline(pipeline), {
@@ -159,7 +149,7 @@ export function createApp(options: AppOptions) {
         taskQueue,
         args: [id, { desiredStatus: pipeline.desired_status }],
       })
-      return c.json(withStatus(pipeline), 201)
+      return c.json(pipeline, 201)
     }
   )
 
@@ -173,7 +163,7 @@ export function createApp(options: AppOptions) {
       requestParams: { path: PipelineIdParam },
       responses: {
         200: {
-          content: { 'application/json': { schema: PipelineResponseSchema } },
+          content: { 'application/json': { schema: PipelineSchema } },
           description: 'Retrieved pipeline with status',
         },
         404: {
@@ -190,7 +180,7 @@ export function createApp(options: AppOptions) {
       } catch {
         return c.json({ error: `Pipeline ${id} not found` }, 404)
       }
-      return c.json(withStatus(pipeline), 200)
+      return c.json(pipeline, 200)
     }
   )
 
@@ -207,7 +197,7 @@ export function createApp(options: AppOptions) {
       },
       responses: {
         200: {
-          content: { 'application/json': { schema: PipelineResponseSchema } },
+          content: { 'application/json': { schema: PipelineSchema } },
           description: 'Updated pipeline',
         },
         400: {
@@ -292,7 +282,7 @@ export function createApp(options: AppOptions) {
         }
       }
 
-      return c.json(withStatus(updated), 200)
+      return c.json(updated, 200)
     }
   )
 

--- a/apps/service/src/index.ts
+++ b/apps/service/src/index.ts
@@ -19,6 +19,6 @@ export type { AppOptions } from './api/app.js'
 // Temporal workflow types (for consumers that need to reference them)
 export { createActivities } from './temporal/activities/index.js'
 export type { SyncActivities, RunResult } from './temporal/activities/index.js'
-export type { WorkflowStatus } from './temporal/workflows/_shared.js'
+export type { WorkflowStatus } from './lib/createSchemas.js'
 export { createWorker } from './temporal/worker.js'
 export type { WorkerOptions } from './temporal/worker.js'

--- a/apps/service/src/index.ts
+++ b/apps/service/src/index.ts
@@ -19,6 +19,6 @@ export type { AppOptions } from './api/app.js'
 // Temporal workflow types (for consumers that need to reference them)
 export { createActivities } from './temporal/activities/index.js'
 export type { SyncActivities, RunResult } from './temporal/activities/index.js'
-export type { WorkflowStatus } from './lib/createSchemas.js'
+export type { PipelineStatus } from './lib/createSchemas.js'
 export { createWorker } from './temporal/worker.js'
 export type { WorkerOptions } from './temporal/worker.js'

--- a/apps/service/src/lib/createSchemas.ts
+++ b/apps/service/src/lib/createSchemas.ts
@@ -2,6 +2,46 @@ import { z } from 'zod'
 import type { ConnectorResolver } from '@stripe/sync-engine'
 import { connectorSchemaName, connectorUnionId } from '@stripe/sync-engine'
 
+// MARK: - Pipeline status enums
+
+export const DesiredStatus = z
+  .enum(['active', 'paused', 'deleted'])
+  .describe('User-controlled lifecycle state.')
+export type DesiredStatus = z.infer<typeof DesiredStatus>
+
+export const WorkflowStatus = z
+  .enum(['setup', 'backfill', 'ready', 'paused', 'teardown', 'error'])
+  .describe('Workflow-controlled execution state.')
+export type WorkflowStatus = z.infer<typeof WorkflowStatus>
+
+/**
+ * Derive user-facing status from the two independent fields.
+ *
+ * | desired  | workflow  | → status      |
+ * |----------|-----------|---------------|
+ * | deleted  | *         | tearing_down  |
+ * | *        | teardown  | tearing_down  |
+ * | *        | error     | error         |
+ * | *        | setup     | setting_up    |
+ * | active   | paused    | resuming      |
+ * | paused   | paused    | paused        |
+ * | paused   | *         | pausing       |
+ * | active   | backfill  | backfilling   |
+ * | active   | ready     | ready         |
+ */
+export function deriveStatus(desired: string, workflow: string): string {
+  if (desired === 'deleted') return 'tearing_down'
+  if (workflow === 'teardown') return 'tearing_down'
+  if (workflow === 'error') return 'error'
+  if (workflow === 'setup') return 'setting_up'
+  if (workflow === 'paused' && desired === 'active') return 'resuming'
+  if (workflow === 'paused') return 'paused'
+  if (desired === 'paused') return 'pausing'
+  if (workflow === 'backfill') return 'backfilling'
+  if (workflow === 'ready') return 'ready'
+  return workflow
+}
+
 // MARK: - Static schemas (independent of connector set)
 
 export const StreamConfig = z.object({
@@ -81,6 +121,12 @@ export function createSchemas(resolver: ConnectorResolver) {
       .array(StreamConfig)
       .optional()
       .describe('Selected streams to sync. All streams synced if omitted.'),
+    desired_status: DesiredStatus.default('active').describe(
+      'User-controlled lifecycle state. Set via PATCH to pause, resume, or delete.'
+    ),
+    workflow_status: WorkflowStatus.default('setup').describe(
+      'Workflow-controlled execution state. Updated by the Temporal workflow.'
+    ),
   })
 
   const CreatePipeline = z.object({
@@ -92,7 +138,11 @@ export function createSchemas(resolver: ConnectorResolver) {
       .describe('Selected streams to sync. All streams synced if omitted.'),
   })
 
-  const UpdatePipeline = CreatePipeline.partial()
+  const UpdatePipeline = CreatePipeline.extend({
+    desired_status: DesiredStatus.optional().describe(
+      'Set to "paused" to pause, "active" to resume, "deleted" to tear down.'
+    ),
+  }).partial()
 
   return {
     SourceConfig,

--- a/apps/service/src/lib/createSchemas.ts
+++ b/apps/service/src/lib/createSchemas.ts
@@ -9,10 +9,10 @@ export const DesiredStatus = z
   .describe('User-controlled lifecycle state.')
 export type DesiredStatus = z.infer<typeof DesiredStatus>
 
-export const WorkflowStatus = z
+export const PipelineStatus = z
   .enum(['setup', 'backfill', 'ready', 'paused', 'teardown', 'error'])
   .describe('Workflow-controlled execution state.')
-export type WorkflowStatus = z.infer<typeof WorkflowStatus>
+export type PipelineStatus = z.infer<typeof PipelineStatus>
 
 /**
  * Derive user-facing status from the two independent fields.
@@ -112,7 +112,7 @@ export function createSchemas(resolver: ConnectorResolver) {
     desired_status: DesiredStatus.default('active').describe(
       'User-controlled lifecycle state. Set via PATCH to pause, resume, or delete.'
     ),
-    status: WorkflowStatus.default('setup').describe(
+    status: PipelineStatus.default('setup').describe(
       'Workflow-controlled execution state. Updated by the Temporal workflow.'
     ),
   })

--- a/apps/service/src/lib/createSchemas.ts
+++ b/apps/service/src/lib/createSchemas.ts
@@ -29,18 +29,6 @@ export type WorkflowStatus = z.infer<typeof WorkflowStatus>
  * | active   | backfill  | backfilling   |
  * | active   | ready     | ready         |
  */
-export function deriveStatus(desired: string, workflow: string): string {
-  if (desired === 'deleted') return 'tearing_down'
-  if (workflow === 'teardown') return 'tearing_down'
-  if (workflow === 'error') return 'error'
-  if (workflow === 'setup') return 'setting_up'
-  if (workflow === 'paused' && desired === 'active') return 'resuming'
-  if (workflow === 'paused') return 'paused'
-  if (desired === 'paused') return 'pausing'
-  if (workflow === 'backfill') return 'backfilling'
-  if (workflow === 'ready') return 'ready'
-  return workflow
-}
 
 // MARK: - Static schemas (independent of connector set)
 
@@ -124,7 +112,7 @@ export function createSchemas(resolver: ConnectorResolver) {
     desired_status: DesiredStatus.default('active').describe(
       'User-controlled lifecycle state. Set via PATCH to pause, resume, or delete.'
     ),
-    workflow_status: WorkflowStatus.default('setup').describe(
+    status: WorkflowStatus.default('setup').describe(
       'Workflow-controlled execution state. Updated by the Temporal workflow.'
     ),
   })

--- a/apps/service/src/temporal/activities/get-desired-status.ts
+++ b/apps/service/src/temporal/activities/get-desired-status.ts
@@ -1,8 +1,0 @@
-import type { ActivitiesContext } from './_shared.js'
-
-export function createGetDesiredStatusActivity(context: ActivitiesContext) {
-  return async function getDesiredStatus(pipelineId: string): Promise<string> {
-    const pipeline = await context.pipelineStore.get(pipelineId)
-    return pipeline.desired_status ?? 'active'
-  }
-}

--- a/apps/service/src/temporal/activities/get-desired-status.ts
+++ b/apps/service/src/temporal/activities/get-desired-status.ts
@@ -1,0 +1,8 @@
+import type { ActivitiesContext } from './_shared.js'
+
+export function createGetDesiredStatusActivity(context: ActivitiesContext) {
+  return async function getDesiredStatus(pipelineId: string): Promise<string> {
+    const pipeline = await context.pipelineStore.get(pipelineId)
+    return pipeline.desired_status ?? 'active'
+  }
+}

--- a/apps/service/src/temporal/activities/index.ts
+++ b/apps/service/src/temporal/activities/index.ts
@@ -2,9 +2,9 @@ import { createActivitiesContext } from './_shared.js'
 import { createUpdatePipelineStatusActivity } from './update-pipeline-status.js'
 import { createDiscoverCatalogActivity } from './discover-catalog.js'
 import { createReadGoogleSheetsIntoQueueActivity } from './read-google-sheets-into-queue.js'
-import { createSetupActivity } from './setup.js'
+import { createPipelineSetupActivity } from './pipeline-setup.js'
 import { createPipelineSyncActivity } from './pipeline-sync.js'
-import { createTeardownActivity } from './teardown.js'
+import { createPipelineTeardownActivity } from './pipeline-teardown.js'
 import { createWriteGoogleSheetsFromQueueActivity } from './write-google-sheets-from-queue.js'
 import type { PipelineStore } from '../../lib/stores.js'
 
@@ -19,11 +19,11 @@ export function createActivities(opts: {
 
   return {
     discoverCatalog: createDiscoverCatalogActivity(context),
-    setup: createSetupActivity(context),
+    pipelineSetup: createPipelineSetupActivity(context),
     pipelineSync: createPipelineSyncActivity(context),
     readGoogleSheetsIntoQueue: createReadGoogleSheetsIntoQueueActivity(context),
     writeGoogleSheetsFromQueue: createWriteGoogleSheetsFromQueueActivity(context),
-    teardown: createTeardownActivity(context),
+    pipelineTeardown: createPipelineTeardownActivity(context),
     updatePipelineStatus: createUpdatePipelineStatusActivity(context),
   }
 }

--- a/apps/service/src/temporal/activities/index.ts
+++ b/apps/service/src/temporal/activities/index.ts
@@ -1,4 +1,6 @@
 import { createActivitiesContext } from './_shared.js'
+import { createGetDesiredStatusActivity } from './get-desired-status.js'
+import { createUpdateWorkflowStatusActivity } from './update-workflow-status.js'
 import { createDiscoverCatalogActivity } from './discover-catalog.js'
 import { createReadGoogleSheetsIntoQueueActivity } from './read-google-sheets-into-queue.js'
 import { createSetupActivity } from './setup.js'
@@ -23,6 +25,8 @@ export function createActivities(opts: {
     readGoogleSheetsIntoQueue: createReadGoogleSheetsIntoQueueActivity(context),
     writeGoogleSheetsFromQueue: createWriteGoogleSheetsFromQueueActivity(context),
     teardown: createTeardownActivity(context),
+    getDesiredStatus: createGetDesiredStatusActivity(context),
+    updateWorkflowStatus: createUpdateWorkflowStatusActivity(context),
   }
 }
 

--- a/apps/service/src/temporal/activities/index.ts
+++ b/apps/service/src/temporal/activities/index.ts
@@ -1,5 +1,4 @@
 import { createActivitiesContext } from './_shared.js'
-import { createGetDesiredStatusActivity } from './get-desired-status.js'
 import { createUpdateWorkflowStatusActivity } from './update-workflow-status.js'
 import { createDiscoverCatalogActivity } from './discover-catalog.js'
 import { createReadGoogleSheetsIntoQueueActivity } from './read-google-sheets-into-queue.js'
@@ -25,7 +24,6 @@ export function createActivities(opts: {
     readGoogleSheetsIntoQueue: createReadGoogleSheetsIntoQueueActivity(context),
     writeGoogleSheetsFromQueue: createWriteGoogleSheetsFromQueueActivity(context),
     teardown: createTeardownActivity(context),
-    getDesiredStatus: createGetDesiredStatusActivity(context),
     updateWorkflowStatus: createUpdateWorkflowStatusActivity(context),
   }
 }

--- a/apps/service/src/temporal/activities/index.ts
+++ b/apps/service/src/temporal/activities/index.ts
@@ -1,5 +1,5 @@
 import { createActivitiesContext } from './_shared.js'
-import { createUpdateWorkflowStatusActivity } from './update-workflow-status.js'
+import { createUpdatePipelineStatusActivity } from './update-pipeline-status.js'
 import { createDiscoverCatalogActivity } from './discover-catalog.js'
 import { createReadGoogleSheetsIntoQueueActivity } from './read-google-sheets-into-queue.js'
 import { createSetupActivity } from './setup.js'
@@ -24,7 +24,7 @@ export function createActivities(opts: {
     readGoogleSheetsIntoQueue: createReadGoogleSheetsIntoQueueActivity(context),
     writeGoogleSheetsFromQueue: createWriteGoogleSheetsFromQueueActivity(context),
     teardown: createTeardownActivity(context),
-    updateWorkflowStatus: createUpdateWorkflowStatusActivity(context),
+    updatePipelineStatus: createUpdatePipelineStatusActivity(context),
   }
 }
 

--- a/apps/service/src/temporal/activities/index.ts
+++ b/apps/service/src/temporal/activities/index.ts
@@ -3,7 +3,7 @@ import { createUpdatePipelineStatusActivity } from './update-pipeline-status.js'
 import { createDiscoverCatalogActivity } from './discover-catalog.js'
 import { createReadGoogleSheetsIntoQueueActivity } from './read-google-sheets-into-queue.js'
 import { createSetupActivity } from './setup.js'
-import { createSyncImmediateActivity } from './sync-immediate.js'
+import { createPipelineSyncActivity } from './pipeline-sync.js'
 import { createTeardownActivity } from './teardown.js'
 import { createWriteGoogleSheetsFromQueueActivity } from './write-google-sheets-from-queue.js'
 import type { PipelineStore } from '../../lib/stores.js'
@@ -20,7 +20,7 @@ export function createActivities(opts: {
   return {
     discoverCatalog: createDiscoverCatalogActivity(context),
     setup: createSetupActivity(context),
-    syncImmediate: createSyncImmediateActivity(context),
+    pipelineSync: createPipelineSyncActivity(context),
     readGoogleSheetsIntoQueue: createReadGoogleSheetsIntoQueueActivity(context),
     writeGoogleSheetsFromQueue: createWriteGoogleSheetsFromQueueActivity(context),
     teardown: createTeardownActivity(context),

--- a/apps/service/src/temporal/activities/pipeline-setup.ts
+++ b/apps/service/src/temporal/activities/pipeline-setup.ts
@@ -2,8 +2,8 @@ import { collectMessages } from '@stripe/sync-protocol'
 
 import type { ActivitiesContext } from './_shared.js'
 
-export function createSetupActivity(context: ActivitiesContext) {
-  return async function setup(pipelineId: string): Promise<void> {
+export function createPipelineSetupActivity(context: ActivitiesContext) {
+  return async function pipelineSetup(pipelineId: string): Promise<void> {
     const pipeline = await context.pipelineStore.get(pipelineId)
     const { id: _, ...config } = pipeline
     const { messages: controlMsgs } = await collectMessages(

--- a/apps/service/src/temporal/activities/pipeline-sync.ts
+++ b/apps/service/src/temporal/activities/pipeline-sync.ts
@@ -2,8 +2,8 @@ import type { SourceInputMessage, SourceReadOptions } from '@stripe/sync-engine'
 import type { ActivitiesContext } from './_shared.js'
 import { asIterable, drainMessages, type RunResult } from './_shared.js'
 
-export function createSyncImmediateActivity(context: ActivitiesContext) {
-  return async function syncImmediate(
+export function createPipelineSyncActivity(context: ActivitiesContext) {
+  return async function pipelineSync(
     pipelineId: string,
     opts?: SourceReadOptions & { input?: SourceInputMessage[] }
   ): Promise<RunResult & { eof?: { reason: string } }> {

--- a/apps/service/src/temporal/activities/pipeline-teardown.ts
+++ b/apps/service/src/temporal/activities/pipeline-teardown.ts
@@ -3,8 +3,8 @@ import type { Message } from '@stripe/sync-protocol'
 
 import type { ActivitiesContext } from './_shared.js'
 
-export function createTeardownActivity(context: ActivitiesContext) {
-  return async function teardown(pipelineId: string): Promise<void> {
+export function createPipelineTeardownActivity(context: ActivitiesContext) {
+  return async function pipelineTeardown(pipelineId: string): Promise<void> {
     const pipeline = await context.pipelineStore.get(pipelineId)
     const { id: _, ...config } = pipeline
     await drain(context.engine.pipeline_teardown(config))

--- a/apps/service/src/temporal/activities/read-google-sheets-into-queue.ts
+++ b/apps/service/src/temporal/activities/read-google-sheets-into-queue.ts
@@ -3,14 +3,18 @@ import type {
   ConfiguredCatalog,
   Message,
   RecordMessage,
+  SourceInput,
   SourceReadOptions,
 } from '@stripe/sync-engine'
-import { ROW_KEY_FIELD, serializeRowKey } from '@stripe/sync-destination-google-sheets'
+import {
+  ROW_KEY_FIELD,
+  ROW_NUMBER_FIELD,
+  serializeRowKey,
+} from '@stripe/sync-destination-google-sheets'
 
 import type { ActivitiesContext } from './_shared.js'
 import { asIterable, collectError, type RunResult } from './_shared.js'
-
-type SourceInput = unknown
+type RowIndex = Record<string, Record<string, number>>
 
 function withRowKey(record: RecordMessage, catalog?: ConfiguredCatalog): RecordMessage {
   const primaryKey = catalog?.streams.find((stream) => stream.stream.name === record.record.stream)
@@ -28,19 +32,36 @@ function withRowKey(record: RecordMessage, catalog?: ConfiguredCatalog): RecordM
   }
 }
 
+function withRowNumber(record: RecordMessage, rowIndex: RowIndex): RecordMessage {
+  const rowKey =
+    typeof record.record.data[ROW_KEY_FIELD] === 'string'
+      ? record.record.data[ROW_KEY_FIELD]
+      : undefined
+  const rowNumber = rowKey ? rowIndex[record.record.stream]?.[rowKey] : undefined
+  if (rowNumber === undefined) return record
+  return {
+    ...record,
+    record: {
+      ...record.record,
+      data: { ...record.record.data, [ROW_NUMBER_FIELD]: rowNumber },
+    },
+  }
+}
+
 export function createReadGoogleSheetsIntoQueueActivity(context: ActivitiesContext) {
   return async function readGoogleSheetsIntoQueue(
     pipelineId: string,
     opts?: SourceReadOptions & {
       input?: SourceInput[]
       catalog?: ConfiguredCatalog
+      rowIndex?: RowIndex
     }
   ): Promise<{ count: number; state: import('@stripe/sync-engine').SourceState }> {
     if (!context.kafkaBroker) throw new Error('kafkaBroker is required for Google Sheets workflow')
 
     const pipeline = await context.pipelineStore.get(pipelineId)
     const { id: _, ...config } = pipeline
-    const { input: inputArr, catalog, ...readOpts } = opts ?? {}
+    const { input: inputArr, catalog, rowIndex, ...readOpts } = opts ?? {}
     const input = inputArr?.length ? asIterable(inputArr) : undefined
 
     const queued: Message[] = []
@@ -57,7 +78,8 @@ export function createReadGoogleSheetsIntoQueueActivity(context: ActivitiesConte
       if (error) {
         errors.push(error)
       } else if (raw.type === 'record') {
-        queued.push(withRowKey(raw, catalog))
+        const withKey = withRowKey(raw, catalog)
+        queued.push(rowIndex ? withRowNumber(withKey, rowIndex) : withKey)
       } else if (raw.type === 'source_state') {
         if (raw.source_state.state_type === 'global') {
           state.global = raw.source_state.data as Record<string, unknown>

--- a/apps/service/src/temporal/activities/read-google-sheets-into-queue.ts
+++ b/apps/service/src/temporal/activities/read-google-sheets-into-queue.ts
@@ -3,7 +3,7 @@ import type {
   ConfiguredCatalog,
   Message,
   RecordMessage,
-  SourceInput,
+  SourceInputMessage,
   SourceReadOptions,
 } from '@stripe/sync-engine'
 import {
@@ -52,7 +52,7 @@ export function createReadGoogleSheetsIntoQueueActivity(context: ActivitiesConte
   return async function readGoogleSheetsIntoQueue(
     pipelineId: string,
     opts?: SourceReadOptions & {
-      input?: SourceInput[]
+      input?: SourceInputMessage[]
       catalog?: ConfiguredCatalog
       rowIndex?: RowIndex
     }

--- a/apps/service/src/temporal/activities/sync-immediate.ts
+++ b/apps/service/src/temporal/activities/sync-immediate.ts
@@ -1,8 +1,6 @@
-import type { SourceReadOptions } from '@stripe/sync-engine'
+import type { SourceInput, SourceReadOptions } from '@stripe/sync-engine'
 import type { ActivitiesContext } from './_shared.js'
 import { asIterable, drainMessages, type RunResult } from './_shared.js'
-
-type SourceInput = unknown
 
 export function createSyncImmediateActivity(context: ActivitiesContext) {
   return async function syncImmediate(

--- a/apps/service/src/temporal/activities/sync-immediate.ts
+++ b/apps/service/src/temporal/activities/sync-immediate.ts
@@ -1,11 +1,11 @@
-import type { SourceInput, SourceReadOptions } from '@stripe/sync-engine'
+import type { SourceInputMessage, SourceReadOptions } from '@stripe/sync-engine'
 import type { ActivitiesContext } from './_shared.js'
 import { asIterable, drainMessages, type RunResult } from './_shared.js'
 
 export function createSyncImmediateActivity(context: ActivitiesContext) {
   return async function syncImmediate(
     pipelineId: string,
-    opts?: SourceReadOptions & { input?: SourceInput[] }
+    opts?: SourceReadOptions & { input?: SourceInputMessage[] }
   ): Promise<RunResult & { eof?: { reason: string } }> {
     const pipeline = await context.pipelineStore.get(pipelineId)
     const { id: _, ...config } = pipeline

--- a/apps/service/src/temporal/activities/update-pipeline-status.ts
+++ b/apps/service/src/temporal/activities/update-pipeline-status.ts
@@ -1,13 +1,13 @@
-import type { WorkflowStatus } from '../../lib/createSchemas.js'
+import type { PipelineStatus } from '../../lib/createSchemas.js'
 import type { ActivitiesContext } from './_shared.js'
 
 export function createUpdatePipelineStatusActivity(context: ActivitiesContext) {
   return async function updatePipelineStatus(
     pipelineId: string,
-    workflowStatus: WorkflowStatus
+    status: PipelineStatus
   ): Promise<void> {
     try {
-      await context.pipelineStore.update(pipelineId, { status: workflowStatus })
+      await context.pipelineStore.update(pipelineId, { status })
     } catch {
       // Pipeline may have been removed — no-op
     }

--- a/apps/service/src/temporal/activities/update-pipeline-status.ts
+++ b/apps/service/src/temporal/activities/update-pipeline-status.ts
@@ -1,13 +1,13 @@
 import type { WorkflowStatus } from '../../lib/createSchemas.js'
 import type { ActivitiesContext } from './_shared.js'
 
-export function createUpdateWorkflowStatusActivity(context: ActivitiesContext) {
-  return async function updateWorkflowStatus(
+export function createUpdatePipelineStatusActivity(context: ActivitiesContext) {
+  return async function updatePipelineStatus(
     pipelineId: string,
     workflowStatus: WorkflowStatus
   ): Promise<void> {
     try {
-      await context.pipelineStore.update(pipelineId, { workflow_status: workflowStatus })
+      await context.pipelineStore.update(pipelineId, { status: workflowStatus })
     } catch {
       // Pipeline may have been removed — no-op
     }

--- a/apps/service/src/temporal/activities/update-workflow-status.ts
+++ b/apps/service/src/temporal/activities/update-workflow-status.ts
@@ -1,0 +1,15 @@
+import type { WorkflowStatus } from '../../lib/createSchemas.js'
+import type { ActivitiesContext } from './_shared.js'
+
+export function createUpdateWorkflowStatusActivity(context: ActivitiesContext) {
+  return async function updateWorkflowStatus(
+    pipelineId: string,
+    workflowStatus: WorkflowStatus
+  ): Promise<void> {
+    try {
+      await context.pipelineStore.update(pipelineId, { workflow_status: workflowStatus })
+    } catch {
+      // Pipeline may have been removed — no-op
+    }
+  }
+}

--- a/apps/service/src/temporal/activities/write-google-sheets-from-queue.ts
+++ b/apps/service/src/temporal/activities/write-google-sheets-from-queue.ts
@@ -11,7 +11,6 @@ import {
   parseGoogleSheetsMetaLog,
   ROW_KEY_FIELD,
   ROW_NUMBER_FIELD,
-  serializeRowKey,
 } from '@stripe/sync-destination-google-sheets'
 
 import type { ActivitiesContext } from './_shared.js'
@@ -57,31 +56,6 @@ function compactGoogleSheetsMessages(messages: Message[]): Message[] {
   return compacted
 }
 
-function addRowNumbers(
-  messages: Message[],
-  rowIndex: Record<string, Record<string, number>>
-): Message[] {
-  return messages.map((message) => {
-    if (message.type !== 'record') return message
-    const rowKey =
-      typeof message.record.data[ROW_KEY_FIELD] === 'string'
-        ? message.record.data[ROW_KEY_FIELD]
-        : undefined
-    const rowNumber = rowKey ? rowIndex[message.record.stream]?.[rowKey] : undefined
-    if (rowNumber === undefined) return message
-    return {
-      ...message,
-      record: {
-        ...message.record,
-        data: {
-          ...message.record.data,
-          [ROW_NUMBER_FIELD]: rowNumber,
-        },
-      },
-    }
-  })
-}
-
 function augmentGoogleSheetsCatalog(catalog: ConfiguredCatalog): ConfiguredCatalog {
   return {
     streams: catalog.streams.map((configuredStream) => {
@@ -114,7 +88,6 @@ export function createWriteGoogleSheetsFromQueueActivity(context: ActivitiesCont
     pipelineId: string,
     opts?: {
       maxBatch?: number
-      rowIndex?: Record<string, Record<string, number>>
       catalog?: ConfiguredCatalog
       state?: import('@stripe/sync-engine').SourceState
     }
@@ -140,7 +113,7 @@ export function createWriteGoogleSheetsFromQueueActivity(context: ActivitiesCont
 
     const pipeline = await context.pipelineStore.get(pipelineId)
     const { id: _, ...config } = pipeline
-    const writeBatch = addRowNumbers(compactGoogleSheetsMessages(queued), opts?.rowIndex ?? {})
+    const writeBatch = compactGoogleSheetsMessages(queued)
     if (config.destination.type !== 'google-sheets') {
       throw new Error('writeGoogleSheetsFromQueue requires a google-sheets destination')
     }

--- a/apps/service/src/temporal/workflows/_shared.ts
+++ b/apps/service/src/temporal/workflows/_shared.ts
@@ -6,8 +6,8 @@ import { retryPolicy } from '../../lib/utils.js'
 export type RowIndex = Record<string, Record<string, number>>
 
 export const stripeEventSignal = defineSignal<[unknown]>('stripe_event')
-/** Generic "pipeline was updated" signal — workflow re-reads config from store. */
-export const updateSignal = defineSignal('update')
+/** Carries the new desired_status value — workflow updates its local state directly. */
+export const desiredStatusSignal = defineSignal<[string]>('desired_status')
 
 export const { setup, teardown } = proxyActivities<SyncActivities>({
   startToCloseTimeout: '2m',
@@ -27,7 +27,7 @@ export const { discoverCatalog, readGoogleSheetsIntoQueue, writeGoogleSheetsFrom
     retry: retryPolicy,
   })
 
-export const { getDesiredStatus, updateWorkflowStatus } = proxyActivities<SyncActivities>({
+export const { updateWorkflowStatus } = proxyActivities<SyncActivities>({
   startToCloseTimeout: '30s',
   retry: retryPolicy,
 })

--- a/apps/service/src/temporal/workflows/_shared.ts
+++ b/apps/service/src/temporal/workflows/_shared.ts
@@ -1,24 +1,13 @@
-import { defineQuery, defineSignal, proxyActivities } from '@temporalio/workflow'
+import { defineSignal, proxyActivities } from '@temporalio/workflow'
 
 import type { SyncActivities } from '../activities/index.js'
-import type { SourceState } from '@stripe/sync-protocol'
 import { retryPolicy } from '../../lib/utils.js'
-
-export interface WorkflowStatus {
-  phase: string
-  paused: boolean
-  iteration: number
-}
 
 export type RowIndex = Record<string, Record<string, number>>
 
 export const stripeEventSignal = defineSignal<[unknown]>('stripe_event')
-/** Signal to control pause/resume. Config changes are written to the store directly. */
-export const updateSignal = defineSignal<[{ paused?: boolean }]>('update')
-export const deleteSignal = defineSignal('delete')
-
-export const statusQuery = defineQuery<WorkflowStatus>('status')
-export const stateQuery = defineQuery<SourceState>('state')
+/** Generic "pipeline was updated" signal — workflow re-reads config from store. */
+export const updateSignal = defineSignal('update')
 
 export const { setup, teardown } = proxyActivities<SyncActivities>({
   startToCloseTimeout: '2m',
@@ -37,3 +26,8 @@ export const { discoverCatalog, readGoogleSheetsIntoQueue, writeGoogleSheetsFrom
     heartbeatTimeout: '2m',
     retry: retryPolicy,
   })
+
+export const { getDesiredStatus, updateWorkflowStatus } = proxyActivities<SyncActivities>({
+  startToCloseTimeout: '30s',
+  retry: retryPolicy,
+})

--- a/apps/service/src/temporal/workflows/_shared.ts
+++ b/apps/service/src/temporal/workflows/_shared.ts
@@ -11,7 +11,7 @@ export const sourceInputSignal = defineSignal<[SourceInputMessage]>('source_inpu
 /** Carries the new desired_status value — workflow updates its local state directly. */
 export const desiredStatusSignal = defineSignal<[DesiredStatus]>('desired_status')
 
-export const { setup, teardown } = proxyActivities<SyncActivities>({
+export const { pipelineSetup, pipelineTeardown } = proxyActivities<SyncActivities>({
   startToCloseTimeout: '2m',
   retry: retryPolicy,
 })

--- a/apps/service/src/temporal/workflows/_shared.ts
+++ b/apps/service/src/temporal/workflows/_shared.ts
@@ -2,12 +2,14 @@ import { defineSignal, proxyActivities } from '@temporalio/workflow'
 
 import type { SyncActivities } from '../activities/index.js'
 import { retryPolicy } from '../../lib/utils.js'
+import { DesiredStatus } from '../../lib/createSchemas.js'
+import { SourceInputMessage } from '@stripe/sync-protocol'
 
 export type RowIndex = Record<string, Record<string, number>>
 
-export const stripeEventSignal = defineSignal<[unknown]>('stripe_event')
+export const stripeEventSignal = defineSignal<[SourceInputMessage]>('stripe_event')
 /** Carries the new desired_status value — workflow updates its local state directly. */
-export const desiredStatusSignal = defineSignal<[string]>('desired_status')
+export const desiredStatusSignal = defineSignal<[DesiredStatus]>('desired_status')
 
 export const { setup, teardown } = proxyActivities<SyncActivities>({
   startToCloseTimeout: '2m',
@@ -27,7 +29,7 @@ export const { discoverCatalog, readGoogleSheetsIntoQueue, writeGoogleSheetsFrom
     retry: retryPolicy,
   })
 
-export const { updateWorkflowStatus } = proxyActivities<SyncActivities>({
+export const { updatePipelineStatus } = proxyActivities<SyncActivities>({
   startToCloseTimeout: '30s',
   retry: retryPolicy,
 })

--- a/apps/service/src/temporal/workflows/_shared.ts
+++ b/apps/service/src/temporal/workflows/_shared.ts
@@ -7,7 +7,7 @@ import { SourceInputMessage } from '@stripe/sync-protocol'
 
 export type RowIndex = Record<string, Record<string, number>>
 
-export const stripeEventSignal = defineSignal<[SourceInputMessage]>('stripe_event')
+export const sourceInputSignal = defineSignal<[SourceInputMessage]>('source_input')
 /** Carries the new desired_status value — workflow updates its local state directly. */
 export const desiredStatusSignal = defineSignal<[DesiredStatus]>('desired_status')
 
@@ -16,7 +16,7 @@ export const { setup, teardown } = proxyActivities<SyncActivities>({
   retry: retryPolicy,
 })
 
-export const { syncImmediate } = proxyActivities<SyncActivities>({
+export const { pipelineSync } = proxyActivities<SyncActivities>({
   startToCloseTimeout: '10m',
   heartbeatTimeout: '2m',
   retry: retryPolicy,

--- a/apps/service/src/temporal/workflows/backfill-pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/backfill-pipeline-workflow.ts
@@ -1,12 +1,13 @@
 import { condition, continueAsNew, setHandler } from '@temporalio/workflow'
 
-import { getDesiredStatus, syncImmediate, updateSignal, updateWorkflowStatus } from './_shared.js'
+import { desiredStatusSignal, syncImmediate, updateWorkflowStatus } from './_shared.js'
 import type { SourceState as SyncState } from '@stripe/sync-protocol'
 import { CONTINUE_AS_NEW_THRESHOLD } from '../../lib/utils.js'
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
 export interface BackfillPipelineWorkflowOpts {
+  desiredStatus?: string
   state?: SyncState
 }
 
@@ -14,44 +15,33 @@ export async function backfillPipelineWorkflow(
   pipelineId: string,
   opts?: BackfillPipelineWorkflowOpts
 ): Promise<void> {
-  let desiredStatus = 'active'
-  let updated = false
+  let desiredStatus = opts?.desiredStatus ?? 'active'
   let iteration = 0
   let syncState: SyncState = opts?.state ?? { streams: {}, global: {} }
   let backfillComplete = false
 
-  setHandler(updateSignal, () => {
-    updated = true
+  setHandler(desiredStatusSignal, (status: string) => {
+    desiredStatus = status
   })
-
-  async function refreshDesiredStatus() {
-    if (!updated) return
-    updated = false
-    desiredStatus = await getDesiredStatus(pipelineId)
-  }
 
   async function maybeContinueAsNew() {
     if (++iteration >= CONTINUE_AS_NEW_THRESHOLD) {
-      await continueAsNew<typeof backfillPipelineWorkflow>(pipelineId, { state: syncState })
+      await continueAsNew<typeof backfillPipelineWorkflow>(pipelineId, { desiredStatus, state: syncState })
     }
   }
 
   await updateWorkflowStatus(pipelineId, 'backfill')
 
   while (desiredStatus !== 'deleted') {
-    await refreshDesiredStatus()
-
-    if (desiredStatus === 'deleted') break
-
     if (desiredStatus === 'paused') {
       await updateWorkflowStatus(pipelineId, 'paused')
-      await condition(() => updated)
+      await condition(() => desiredStatus !== 'paused')
       continue
     }
 
     if (backfillComplete) {
       await updateWorkflowStatus(pipelineId, 'ready')
-      const timedOut = !(await condition(() => updated, ONE_WEEK_MS))
+      const timedOut = !(await condition(() => desiredStatus !== 'active', ONE_WEEK_MS))
       if (timedOut) backfillComplete = false
       continue
     }

--- a/apps/service/src/temporal/workflows/backfill-pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/backfill-pipeline-workflow.ts
@@ -1,62 +1,58 @@
 import { condition, continueAsNew, setHandler } from '@temporalio/workflow'
 
-import {
-  deleteSignal,
-  stateQuery,
-  statusQuery,
-  syncImmediate,
-  updateSignal,
-  WorkflowStatus,
-} from './_shared.js'
-import type { SourceState } from '@stripe/sync-protocol'
+import { getDesiredStatus, syncImmediate, updateSignal, updateWorkflowStatus } from './_shared.js'
+import type { SourceState as SyncState } from '@stripe/sync-protocol'
 import { CONTINUE_AS_NEW_THRESHOLD } from '../../lib/utils.js'
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
 export interface BackfillPipelineWorkflowOpts {
-  state?: SourceState
-  reconcileComplete?: boolean
+  state?: SyncState
 }
 
 export async function backfillPipelineWorkflow(
   pipelineId: string,
   opts?: BackfillPipelineWorkflowOpts
 ): Promise<void> {
-  let paused = false
-  let deleted = false
+  let desiredStatus = 'active'
+  let updated = false
   let iteration = 0
-  let syncState: SourceState = opts?.state ?? { streams: {}, global: {} }
-  let reconcileComplete: boolean = opts?.reconcileComplete ?? false
+  let syncState: SyncState = opts?.state ?? { streams: {}, global: {} }
+  let backfillComplete = false
 
-  setHandler(updateSignal, (patch) => {
-    if (patch.paused !== undefined) paused = patch.paused
-  })
-  setHandler(deleteSignal, () => {
-    deleted = true
+  setHandler(updateSignal, () => {
+    updated = true
   })
 
-  setHandler(statusQuery, (): WorkflowStatus => ({ phase: 'running', paused, iteration }))
-  setHandler(stateQuery, (): SourceState => syncState)
+  async function refreshDesiredStatus() {
+    if (!updated) return
+    updated = false
+    desiredStatus = await getDesiredStatus(pipelineId)
+  }
 
   async function maybeContinueAsNew() {
     if (++iteration >= CONTINUE_AS_NEW_THRESHOLD) {
-      await continueAsNew<typeof backfillPipelineWorkflow>(pipelineId, {
-        state: syncState,
-        reconcileComplete,
-      })
+      await continueAsNew<typeof backfillPipelineWorkflow>(pipelineId, { state: syncState })
     }
   }
 
-  while (!deleted) {
-    if (paused) {
-      await condition(() => !paused || deleted)
+  await updateWorkflowStatus(pipelineId, 'backfill')
+
+  while (desiredStatus !== 'deleted') {
+    await refreshDesiredStatus()
+
+    if (desiredStatus === 'deleted') break
+
+    if (desiredStatus === 'paused') {
+      await updateWorkflowStatus(pipelineId, 'paused')
+      await condition(() => updated)
       continue
     }
 
-    if (reconcileComplete) {
-      // Idle — wait up to one week; timeout means recon is due.
-      const timedOut = !(await condition(() => paused || deleted, ONE_WEEK_MS))
-      if (timedOut) reconcileComplete = false
+    if (backfillComplete) {
+      await updateWorkflowStatus(pipelineId, 'ready')
+      const timedOut = !(await condition(() => updated, ONE_WEEK_MS))
+      if (timedOut) backfillComplete = false
       continue
     }
 
@@ -65,8 +61,13 @@ export async function backfillPipelineWorkflow(
       state_limit: 100,
       time_limit: 10,
     })
-    syncState = result.state
-    reconcileComplete = result.eof?.reason === 'complete'
+    syncState = {
+      streams: { ...syncState.streams, ...result.state.streams },
+      global: { ...syncState.global, ...result.state.global },
+    }
+    backfillComplete = result.eof?.reason === 'complete'
     await maybeContinueAsNew()
   }
+
+  await updateWorkflowStatus(pipelineId, 'teardown')
 }

--- a/apps/service/src/temporal/workflows/backfill-pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/backfill-pipeline-workflow.ts
@@ -1,6 +1,6 @@
 import { condition, continueAsNew, setHandler } from '@temporalio/workflow'
 
-import { desiredStatusSignal, syncImmediate, updatePipelineStatus } from './_shared.js'
+import { desiredStatusSignal, pipelineSync, updatePipelineStatus } from './_shared.js'
 import type { SourceState as SyncState } from '@stripe/sync-protocol'
 import { CONTINUE_AS_NEW_THRESHOLD } from '../../lib/utils.js'
 
@@ -49,7 +49,7 @@ export async function backfillPipelineWorkflow(
       continue
     }
 
-    const result = await syncImmediate(pipelineId, {
+    const result = await pipelineSync(pipelineId, {
       state: syncState,
       state_limit: 100,
       time_limit: 10,

--- a/apps/service/src/temporal/workflows/backfill-pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/backfill-pipeline-workflow.ts
@@ -1,6 +1,6 @@
 import { condition, continueAsNew, setHandler } from '@temporalio/workflow'
 
-import { desiredStatusSignal, syncImmediate, updateWorkflowStatus } from './_shared.js'
+import { desiredStatusSignal, syncImmediate, updatePipelineStatus } from './_shared.js'
 import type { SourceState as SyncState } from '@stripe/sync-protocol'
 import { CONTINUE_AS_NEW_THRESHOLD } from '../../lib/utils.js'
 
@@ -30,17 +30,17 @@ export async function backfillPipelineWorkflow(
     }
   }
 
-  await updateWorkflowStatus(pipelineId, 'backfill')
+  await updatePipelineStatus(pipelineId, 'backfill')
 
   while (desiredStatus !== 'deleted') {
     if (desiredStatus === 'paused') {
-      await updateWorkflowStatus(pipelineId, 'paused')
+      await updatePipelineStatus(pipelineId, 'paused')
       await condition(() => desiredStatus !== 'paused')
       continue
     }
 
     if (backfillComplete) {
-      await updateWorkflowStatus(pipelineId, 'ready')
+      await updatePipelineStatus(pipelineId, 'ready')
       const timedOut = !(await condition(() => desiredStatus !== 'active', ONE_WEEK_MS))
       if (timedOut) backfillComplete = false
       continue
@@ -59,5 +59,5 @@ export async function backfillPipelineWorkflow(
     await maybeContinueAsNew()
   }
 
-  await updateWorkflowStatus(pipelineId, 'teardown')
+  await updatePipelineStatus(pipelineId, 'teardown')
 }

--- a/apps/service/src/temporal/workflows/backfill-pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/backfill-pipeline-workflow.ts
@@ -26,7 +26,10 @@ export async function backfillPipelineWorkflow(
 
   async function maybeContinueAsNew() {
     if (++iteration >= CONTINUE_AS_NEW_THRESHOLD) {
-      await continueAsNew<typeof backfillPipelineWorkflow>(pipelineId, { desiredStatus, state: syncState })
+      await continueAsNew<typeof backfillPipelineWorkflow>(pipelineId, {
+        desiredStatus,
+        state: syncState,
+      })
     }
   }
 

--- a/apps/service/src/temporal/workflows/google-sheet-pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/google-sheet-pipeline-workflow.ts
@@ -2,20 +2,20 @@ import { condition, continueAsNew, setHandler, sleep } from '@temporalio/workflo
 import type { ConfiguredCatalog, SourceInput, SourceState as SyncState } from '@stripe/sync-engine'
 
 import {
+  desiredStatusSignal,
   discoverCatalog,
-  getDesiredStatus,
   readGoogleSheetsIntoQueue,
   RowIndex,
   setup,
   stripeEventSignal,
   teardown,
-  updateSignal,
   updateWorkflowStatus,
   writeGoogleSheetsFromQueue,
 } from './_shared.js'
 import { CONTINUE_AS_NEW_THRESHOLD, deepEqual, EVENT_BATCH_SIZE } from '../../lib/utils.js'
 
 export interface GoogleSheetPipelineWorkflowOpts {
+  desiredStatus?: string
   setupDone?: boolean
   state?: SyncState
   readState?: SyncState
@@ -31,8 +31,7 @@ export async function googleSheetPipelineWorkflow(
   pipelineId: string,
   opts?: GoogleSheetPipelineWorkflowOpts
 ): Promise<void> {
-  let desiredStatus = 'active'
-  let updated = false
+  let desiredStatus = opts?.desiredStatus ?? 'active'
   const inputQueue: unknown[] = [...(opts?.inputQueue ?? [])]
   let iteration = 0
   let setupDone = opts?.setupDone ?? false
@@ -49,21 +48,14 @@ export async function googleSheetPipelineWorkflow(
   setHandler(stripeEventSignal, (event: unknown) => {
     inputQueue.push(event)
   })
-  setHandler(updateSignal, () => {
-    updated = true
-    // Config may have changed — re-discover catalog
-    catalog = undefined
+  setHandler(desiredStatusSignal, (status: string) => {
+    desiredStatus = status
   })
-
-  async function refreshDesiredStatus() {
-    if (!updated) return
-    updated = false
-    desiredStatus = await getDesiredStatus(pipelineId)
-  }
 
   async function maybeContinueAsNew() {
     if (++iteration >= CONTINUE_AS_NEW_THRESHOLD) {
       await continueAsNew<typeof googleSheetPipelineWorkflow>(pipelineId, {
+        desiredStatus,
         setupDone: true,
         state: syncState,
         readState,
@@ -86,7 +78,6 @@ export async function googleSheetPipelineWorkflow(
     await setup(pipelineId)
     catalog = await discoverCatalog(pipelineId)
     setupDone = true
-    await refreshDesiredStatus()
     if (desiredStatus === 'deleted') {
       await updateWorkflowStatus(pipelineId, 'teardown')
       await teardown(pipelineId)
@@ -133,8 +124,7 @@ export async function googleSheetPipelineWorkflow(
         continue
       }
 
-      await condition(() => inputQueue.length > 0 || shouldStop() || updated)
-      if (updated) await refreshDesiredStatus()
+      await condition(() => inputQueue.length > 0 || shouldStop())
     }
   }
 
@@ -155,21 +145,18 @@ export async function googleSheetPipelineWorkflow(
         if (opts?.writeRps) await sleep(Math.ceil(1000 / opts.writeRps))
         await maybeContinueAsNew()
       } else {
-        await condition(() => pendingWrites || shouldStop() || updated)
-        if (updated) await refreshDesiredStatus()
+        await condition(() => pendingWrites || shouldStop())
       }
     }
   }
 
   // Main loop: handle pause/delete/active cycling
   while (desiredStatus !== 'deleted') {
-    await refreshDesiredStatus()
-
     if (desiredStatus === 'deleted') break
 
     if (desiredStatus === 'paused') {
       await updateWorkflowStatus(pipelineId, 'paused')
-      await condition(() => updated)
+      await condition(() => desiredStatus !== 'paused')
       continue
     }
 

--- a/apps/service/src/temporal/workflows/google-sheet-pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/google-sheet-pipeline-workflow.ts
@@ -1,30 +1,28 @@
 import { condition, continueAsNew, setHandler, sleep } from '@temporalio/workflow'
-import type { ConfiguredCatalog, SourceState } from '@stripe/sync-engine'
+import type { ConfiguredCatalog, SourceInput, SourceState as SyncState } from '@stripe/sync-engine'
 
 import {
-  deleteSignal,
   discoverCatalog,
+  getDesiredStatus,
   readGoogleSheetsIntoQueue,
   RowIndex,
   setup,
-  stateQuery,
-  statusQuery,
   stripeEventSignal,
   teardown,
   updateSignal,
-  WorkflowStatus,
+  updateWorkflowStatus,
   writeGoogleSheetsFromQueue,
 } from './_shared.js'
 import { CONTINUE_AS_NEW_THRESHOLD, deepEqual, EVENT_BATCH_SIZE } from '../../lib/utils.js'
 
 export interface GoogleSheetPipelineWorkflowOpts {
-  phase?: string
-  sourceState?: SourceState
-  readState?: SourceState
+  setupDone?: boolean
+  state?: SyncState
+  readState?: SyncState
   rowIndex?: RowIndex
   catalog?: ConfiguredCatalog
   pendingWrites?: boolean
-  inputQueue?: unknown[]
+  inputQueue?: SourceInput[]
   readComplete?: boolean
   writeRps?: number
 }
@@ -33,14 +31,15 @@ export async function googleSheetPipelineWorkflow(
   pipelineId: string,
   opts?: GoogleSheetPipelineWorkflowOpts
 ): Promise<void> {
-  let paused = false
-  let deleted = false
+  let desiredStatus = 'active'
+  let updated = false
   const inputQueue: unknown[] = [...(opts?.inputQueue ?? [])]
   let iteration = 0
-  let sourceState: SourceState = opts?.sourceState ?? { streams: {}, global: {} }
-  let readState: SourceState = opts?.readState ?? {
-    streams: { ...sourceState.streams },
-    global: { ...sourceState.global },
+  let setupDone = opts?.setupDone ?? false
+  let syncState: SyncState = opts?.state ?? { streams: {}, global: {} }
+  let readState: SyncState = opts?.readState ?? {
+    streams: { ...syncState.streams },
+    global: { ...syncState.global },
   }
   let rowIndex: RowIndex = opts?.rowIndex ?? {}
   let catalog: ConfiguredCatalog | undefined = opts?.catalog
@@ -50,38 +49,23 @@ export async function googleSheetPipelineWorkflow(
   setHandler(stripeEventSignal, (event: unknown) => {
     inputQueue.push(event)
   })
-  setHandler(updateSignal, (patch) => {
-    if (patch.paused !== undefined) paused = patch.paused
-    // Config changes are written to the store directly by the API.
-    // Reset catalog so the next read re-discovers it from updated config.
-    // Note: we don't know if config actually changed vs just a pause toggle,
-    // but re-discovering is cheap and safe.
-  })
-  setHandler(deleteSignal, () => {
-    deleted = true
+  setHandler(updateSignal, () => {
+    updated = true
+    // Config may have changed — re-discover catalog
+    catalog = undefined
   })
 
-  const phase = opts?.phase ?? 'setup'
-  setHandler(
-    statusQuery,
-    (): WorkflowStatus => ({
-      phase: phase === 'setup' && iteration > 0 ? 'running' : phase,
-      paused,
-      iteration,
-    })
-  )
-  setHandler(stateQuery, (): SourceState => sourceState)
-
-  async function waitWhilePaused() {
-    await condition(() => !paused || deleted)
+  async function refreshDesiredStatus() {
+    if (!updated) return
+    updated = false
+    desiredStatus = await getDesiredStatus(pipelineId)
   }
 
-  async function tickIteration() {
-    iteration++
-    if (iteration >= CONTINUE_AS_NEW_THRESHOLD) {
+  async function maybeContinueAsNew() {
+    if (++iteration >= CONTINUE_AS_NEW_THRESHOLD) {
       await continueAsNew<typeof googleSheetPipelineWorkflow>(pipelineId, {
-        phase: 'running',
-        sourceState,
+        setupDone: true,
+        state: syncState,
         readState,
         rowIndex,
         catalog,
@@ -93,20 +77,27 @@ export async function googleSheetPipelineWorkflow(
     }
   }
 
-  if (phase !== 'running') {
+  function shouldStop() {
+    return desiredStatus === 'deleted' || desiredStatus === 'paused'
+  }
+
+  // Setup
+  if (!setupDone) {
     await setup(pipelineId)
     catalog = await discoverCatalog(pipelineId)
-    if (deleted) {
+    setupDone = true
+    await refreshDesiredStatus()
+    if (desiredStatus === 'deleted') {
+      await updateWorkflowStatus(pipelineId, 'teardown')
       await teardown(pipelineId)
       return
     }
   }
 
-  async function readLoop(): Promise<void> {
-    while (!deleted) {
-      await waitWhilePaused()
-      if (deleted) break
+  await updateWorkflowStatus(pipelineId, readComplete ? 'ready' : 'backfill')
 
+  async function readLoop(): Promise<void> {
+    while (!shouldStop()) {
       if (!catalog) catalog = await discoverCatalog(pipelineId)
 
       if (inputQueue.length > 0) {
@@ -114,9 +105,10 @@ export async function googleSheetPipelineWorkflow(
         const { count } = await readGoogleSheetsIntoQueue(pipelineId, {
           input: batch,
           catalog,
+          rowIndex,
         })
         if (count > 0) pendingWrites = true
-        await tickIteration()
+        await maybeContinueAsNew()
         continue
       }
 
@@ -126,45 +118,66 @@ export async function googleSheetPipelineWorkflow(
           state: readState,
           state_limit: 1,
           catalog,
+          rowIndex,
         })
         if (count > 0) pendingWrites = true
-        readState = nextReadState
-        readComplete = deepEqual(readState, before)
-        await tickIteration()
+        readState = {
+          streams: { ...readState.streams, ...nextReadState.streams },
+          global: { ...readState.global, ...nextReadState.global },
+        }
+        if (count === 0 || deepEqual(readState, before)) {
+          readComplete = true
+          await updateWorkflowStatus(pipelineId, 'ready')
+        }
+        await maybeContinueAsNew()
         continue
       }
 
-      await condition(() => inputQueue.length > 0 || deleted)
+      await condition(() => inputQueue.length > 0 || shouldStop() || updated)
+      if (updated) await refreshDesiredStatus()
     }
   }
 
   async function writeLoop(): Promise<void> {
-    while (!deleted) {
-      await waitWhilePaused()
-      if (deleted) break
-
+    while (!shouldStop()) {
       if (pendingWrites) {
         if (!catalog) catalog = await discoverCatalog(pipelineId)
         const result = await writeGoogleSheetsFromQueue(pipelineId, {
           maxBatch: 50,
-          rowIndex,
           catalog,
-          state: sourceState,
         })
         pendingWrites = result.written > 0
-        sourceState = result.state
+        if (result.written > 0) syncState = result.state
         for (const [stream, assignments] of Object.entries(result.rowAssignments)) {
           rowIndex[stream] ??= {}
           Object.assign(rowIndex[stream], assignments)
         }
         if (opts?.writeRps) await sleep(Math.ceil(1000 / opts.writeRps))
-        await tickIteration()
+        await maybeContinueAsNew()
       } else {
-        await condition(() => pendingWrites || deleted)
+        await condition(() => pendingWrites || shouldStop() || updated)
+        if (updated) await refreshDesiredStatus()
       }
     }
   }
 
-  await Promise.all([readLoop(), writeLoop()])
+  // Main loop: handle pause/delete/active cycling
+  while (desiredStatus !== 'deleted') {
+    await refreshDesiredStatus()
+
+    if (desiredStatus === 'deleted') break
+
+    if (desiredStatus === 'paused') {
+      await updateWorkflowStatus(pipelineId, 'paused')
+      await condition(() => updated)
+      continue
+    }
+
+    // Active — run read/write loops until paused or deleted
+    await updateWorkflowStatus(pipelineId, readComplete ? 'ready' : 'backfill')
+    await Promise.all([readLoop(), writeLoop()])
+  }
+
+  await updateWorkflowStatus(pipelineId, 'teardown')
   await teardown(pipelineId)
 }

--- a/apps/service/src/temporal/workflows/google-sheet-pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/google-sheet-pipeline-workflow.ts
@@ -8,11 +8,11 @@ import type {
 import {
   desiredStatusSignal,
   discoverCatalog,
+  pipelineSetup,
+  pipelineTeardown,
   readGoogleSheetsIntoQueue,
   RowIndex,
-  setup,
   sourceInputSignal,
-  teardown,
   updatePipelineStatus,
   writeGoogleSheetsFromQueue,
 } from './_shared.js'
@@ -79,12 +79,12 @@ export async function googleSheetPipelineWorkflow(
 
   // Setup
   if (!setupDone) {
-    await setup(pipelineId)
+    await pipelineSetup(pipelineId)
     catalog = await discoverCatalog(pipelineId)
     setupDone = true
     if (desiredStatus === 'deleted') {
       await updatePipelineStatus(pipelineId, 'teardown')
-      await teardown(pipelineId)
+      await pipelineTeardown(pipelineId)
       return
     }
   }
@@ -170,5 +170,5 @@ export async function googleSheetPipelineWorkflow(
   }
 
   await updatePipelineStatus(pipelineId, 'teardown')
-  await teardown(pipelineId)
+  await pipelineTeardown(pipelineId)
 }

--- a/apps/service/src/temporal/workflows/google-sheet-pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/google-sheet-pipeline-workflow.ts
@@ -1,5 +1,9 @@
 import { condition, continueAsNew, setHandler, sleep } from '@temporalio/workflow'
-import type { ConfiguredCatalog, SourceInputMessage, SourceState as SyncState } from '@stripe/sync-engine'
+import type {
+  ConfiguredCatalog,
+  SourceInputMessage,
+  SourceState as SyncState,
+} from '@stripe/sync-engine'
 
 import {
   desiredStatusSignal,

--- a/apps/service/src/temporal/workflows/google-sheet-pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/google-sheet-pipeline-workflow.ts
@@ -11,7 +11,7 @@ import {
   readGoogleSheetsIntoQueue,
   RowIndex,
   setup,
-  stripeEventSignal,
+  sourceInputSignal,
   teardown,
   updatePipelineStatus,
   writeGoogleSheetsFromQueue,
@@ -49,7 +49,7 @@ export async function googleSheetPipelineWorkflow(
   let readComplete = opts?.readComplete ?? false
   let pendingWrites = opts?.pendingWrites ?? false
 
-  setHandler(stripeEventSignal, (event: SourceInputMessage) => {
+  setHandler(sourceInputSignal, (event: SourceInputMessage) => {
     inputQueue.push(event)
   })
   setHandler(desiredStatusSignal, (status: string) => {

--- a/apps/service/src/temporal/workflows/google-sheet-pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/google-sheet-pipeline-workflow.ts
@@ -1,5 +1,5 @@
 import { condition, continueAsNew, setHandler, sleep } from '@temporalio/workflow'
-import type { ConfiguredCatalog, SourceInput, SourceState as SyncState } from '@stripe/sync-engine'
+import type { ConfiguredCatalog, SourceInputMessage, SourceState as SyncState } from '@stripe/sync-engine'
 
 import {
   desiredStatusSignal,
@@ -9,7 +9,7 @@ import {
   setup,
   stripeEventSignal,
   teardown,
-  updateWorkflowStatus,
+  updatePipelineStatus,
   writeGoogleSheetsFromQueue,
 } from './_shared.js'
 import { CONTINUE_AS_NEW_THRESHOLD, deepEqual, EVENT_BATCH_SIZE } from '../../lib/utils.js'
@@ -22,7 +22,7 @@ export interface GoogleSheetPipelineWorkflowOpts {
   rowIndex?: RowIndex
   catalog?: ConfiguredCatalog
   pendingWrites?: boolean
-  inputQueue?: SourceInput[]
+  inputQueue?: SourceInputMessage[]
   readComplete?: boolean
   writeRps?: number
 }
@@ -32,7 +32,7 @@ export async function googleSheetPipelineWorkflow(
   opts?: GoogleSheetPipelineWorkflowOpts
 ): Promise<void> {
   let desiredStatus = opts?.desiredStatus ?? 'active'
-  const inputQueue: unknown[] = [...(opts?.inputQueue ?? [])]
+  const inputQueue: SourceInputMessage[] = [...(opts?.inputQueue ?? [])]
   let iteration = 0
   let setupDone = opts?.setupDone ?? false
   let syncState: SyncState = opts?.state ?? { streams: {}, global: {} }
@@ -45,7 +45,7 @@ export async function googleSheetPipelineWorkflow(
   let readComplete = opts?.readComplete ?? false
   let pendingWrites = opts?.pendingWrites ?? false
 
-  setHandler(stripeEventSignal, (event: unknown) => {
+  setHandler(stripeEventSignal, (event: SourceInputMessage) => {
     inputQueue.push(event)
   })
   setHandler(desiredStatusSignal, (status: string) => {
@@ -79,13 +79,13 @@ export async function googleSheetPipelineWorkflow(
     catalog = await discoverCatalog(pipelineId)
     setupDone = true
     if (desiredStatus === 'deleted') {
-      await updateWorkflowStatus(pipelineId, 'teardown')
+      await updatePipelineStatus(pipelineId, 'teardown')
       await teardown(pipelineId)
       return
     }
   }
 
-  await updateWorkflowStatus(pipelineId, readComplete ? 'ready' : 'backfill')
+  await updatePipelineStatus(pipelineId, readComplete ? 'ready' : 'backfill')
 
   async function readLoop(): Promise<void> {
     while (!shouldStop()) {
@@ -118,7 +118,7 @@ export async function googleSheetPipelineWorkflow(
         }
         if (count === 0 || deepEqual(readState, before)) {
           readComplete = true
-          await updateWorkflowStatus(pipelineId, 'ready')
+          await updatePipelineStatus(pipelineId, 'ready')
         }
         await maybeContinueAsNew()
         continue
@@ -155,16 +155,16 @@ export async function googleSheetPipelineWorkflow(
     if (desiredStatus === 'deleted') break
 
     if (desiredStatus === 'paused') {
-      await updateWorkflowStatus(pipelineId, 'paused')
+      await updatePipelineStatus(pipelineId, 'paused')
       await condition(() => desiredStatus !== 'paused')
       continue
     }
 
     // Active — run read/write loops until paused or deleted
-    await updateWorkflowStatus(pipelineId, readComplete ? 'ready' : 'backfill')
+    await updatePipelineStatus(pipelineId, readComplete ? 'ready' : 'backfill')
     await Promise.all([readLoop(), writeLoop()])
   }
 
-  await updateWorkflowStatus(pipelineId, 'teardown')
+  await updatePipelineStatus(pipelineId, 'teardown')
   await teardown(pipelineId)
 }

--- a/apps/service/src/temporal/workflows/pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/pipeline-workflow.ts
@@ -1,12 +1,11 @@
 import { condition, continueAsNew, setHandler } from '@temporalio/workflow'
 
 import {
-  getDesiredStatus,
+  desiredStatusSignal,
   setup,
   stripeEventSignal,
   syncImmediate,
   teardown,
-  updateSignal,
   updateWorkflowStatus,
 } from './_shared.js'
 import { CONTINUE_AS_NEW_THRESHOLD, EVENT_BATCH_SIZE } from '../../lib/utils.js'
@@ -15,6 +14,7 @@ import type { SourceInput, SourceState as SyncState } from '@stripe/sync-protoco
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
 export interface PipelineWorkflowOpts {
+  desiredStatus?: string
   state?: SyncState
   inputQueue?: SourceInput[]
 }
@@ -23,8 +23,7 @@ export async function pipelineWorkflow(
   pipelineId: string,
   opts?: PipelineWorkflowOpts
 ): Promise<void> {
-  let desiredStatus = 'active'
-  let updated = false
+  let desiredStatus = opts?.desiredStatus ?? 'active'
   const inputQueue: unknown[] = [...(opts?.inputQueue ?? [])]
   let iteration = 0
   let syncState: SyncState = opts?.state ?? { streams: {}, global: {} }
@@ -33,19 +32,14 @@ export async function pipelineWorkflow(
   setHandler(stripeEventSignal, (event: unknown) => {
     inputQueue.push(event)
   })
-  setHandler(updateSignal, () => {
-    updated = true
+  setHandler(desiredStatusSignal, (status: string) => {
+    desiredStatus = status
   })
-
-  async function refreshDesiredStatus() {
-    if (!updated) return
-    updated = false
-    desiredStatus = await getDesiredStatus(pipelineId)
-  }
 
   async function maybeContinueAsNew() {
     if (++iteration >= CONTINUE_AS_NEW_THRESHOLD) {
       await continueAsNew<typeof pipelineWorkflow>(pipelineId, {
+        desiredStatus,
         state: syncState,
         inputQueue: inputQueue.length > 0 ? [...inputQueue] : undefined,
       })
@@ -55,7 +49,6 @@ export async function pipelineWorkflow(
   // Setup
   await setup(pipelineId)
   await updateWorkflowStatus(pipelineId, 'backfill')
-  await refreshDesiredStatus()
 
   if (desiredStatus === 'deleted') {
     await updateWorkflowStatus(pipelineId, 'teardown')
@@ -64,15 +57,9 @@ export async function pipelineWorkflow(
   }
 
   while (desiredStatus !== 'deleted') {
-    await refreshDesiredStatus()
-
-    if (desiredStatus === 'deleted') {
-      break
-    }
-
     if (desiredStatus === 'paused') {
       await updateWorkflowStatus(pipelineId, 'paused')
-      await condition(() => updated)
+      await condition(() => desiredStatus !== 'paused')
       continue
     }
 
@@ -85,7 +72,7 @@ export async function pipelineWorkflow(
 
     if (readComplete && inputQueue.length === 0) {
       // Idle — wait up to one week; timeout means recon is due.
-      const timedOut = !(await condition(() => updated || inputQueue.length > 0, ONE_WEEK_MS))
+      const timedOut = !(await condition(() => desiredStatus !== 'active' || inputQueue.length > 0, ONE_WEEK_MS))
       if (timedOut) readComplete = false
       continue
     }

--- a/apps/service/src/temporal/workflows/pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/pipeline-workflow.ts
@@ -1,50 +1,47 @@
 import { condition, continueAsNew, setHandler } from '@temporalio/workflow'
 
 import {
-  deleteSignal,
+  getDesiredStatus,
   setup,
-  stateQuery,
-  statusQuery,
   stripeEventSignal,
   syncImmediate,
   teardown,
   updateSignal,
-  WorkflowStatus,
+  updateWorkflowStatus,
 } from './_shared.js'
 import { CONTINUE_AS_NEW_THRESHOLD, EVENT_BATCH_SIZE } from '../../lib/utils.js'
+import type { SourceInput, SourceState as SyncState } from '@stripe/sync-protocol'
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
-import type { SourceState } from '@stripe/sync-protocol'
-
 export interface PipelineWorkflowOpts {
-  state?: SourceState
-  inputQueue?: unknown[]
+  state?: SyncState
+  inputQueue?: SourceInput[]
 }
 
 export async function pipelineWorkflow(
   pipelineId: string,
   opts?: PipelineWorkflowOpts
 ): Promise<void> {
-  let paused = false
-  let deleted = false
+  let desiredStatus = 'active'
+  let updated = false
   const inputQueue: unknown[] = [...(opts?.inputQueue ?? [])]
   let iteration = 0
-  let syncState: SourceState = opts?.state ?? { streams: {}, global: {} }
+  let syncState: SyncState = opts?.state ?? { streams: {}, global: {} }
   let readComplete = false
 
   setHandler(stripeEventSignal, (event: unknown) => {
     inputQueue.push(event)
   })
-  setHandler(updateSignal, (patch) => {
-    if (patch.paused !== undefined) paused = patch.paused
-  })
-  setHandler(deleteSignal, () => {
-    deleted = true
+  setHandler(updateSignal, () => {
+    updated = true
   })
 
-  setHandler(statusQuery, (): WorkflowStatus => ({ phase: 'running', paused, iteration }))
-  setHandler(stateQuery, (): SourceState => syncState)
+  async function refreshDesiredStatus() {
+    if (!updated) return
+    updated = false
+    desiredStatus = await getDesiredStatus(pipelineId)
+  }
 
   async function maybeContinueAsNew() {
     if (++iteration >= CONTINUE_AS_NEW_THRESHOLD) {
@@ -55,24 +52,40 @@ export async function pipelineWorkflow(
     }
   }
 
+  // Setup
   await setup(pipelineId)
-  if (deleted) {
+  await updateWorkflowStatus(pipelineId, 'backfill')
+  await refreshDesiredStatus()
+
+  if (desiredStatus === 'deleted') {
+    await updateWorkflowStatus(pipelineId, 'teardown')
     await teardown(pipelineId)
     return
   }
 
-  while (!deleted) {
-    if (paused) {
-      await condition(() => !paused || deleted)
+  while (desiredStatus !== 'deleted') {
+    await refreshDesiredStatus()
+
+    if (desiredStatus === 'deleted') {
+      break
+    }
+
+    if (desiredStatus === 'paused') {
+      await updateWorkflowStatus(pipelineId, 'paused')
+      await condition(() => updated)
       continue
+    }
+
+    // Resuming from paused — update status
+    if (readComplete) {
+      await updateWorkflowStatus(pipelineId, 'ready')
+    } else {
+      await updateWorkflowStatus(pipelineId, 'backfill')
     }
 
     if (readComplete && inputQueue.length === 0) {
       // Idle — wait up to one week; timeout means recon is due.
-      const timedOut = !(await condition(
-        () => paused || deleted || inputQueue.length > 0,
-        ONE_WEEK_MS
-      ))
+      const timedOut = !(await condition(() => updated || inputQueue.length > 0, ONE_WEEK_MS))
       if (timedOut) readComplete = false
       continue
     }
@@ -86,12 +99,19 @@ export async function pipelineWorkflow(
         state_limit: 100,
         time_limit: 10,
       })
-      syncState = result.state
-      readComplete = result.eof?.reason === 'complete'
+      syncState = {
+        streams: { ...syncState.streams, ...result.state.streams },
+        global: { ...syncState.global, ...result.state.global },
+      }
+      if (result.eof?.reason === 'complete') {
+        readComplete = true
+        await updateWorkflowStatus(pipelineId, 'ready')
+      }
     }
 
     await maybeContinueAsNew()
   }
 
+  await updateWorkflowStatus(pipelineId, 'teardown')
   await teardown(pipelineId)
 }

--- a/apps/service/src/temporal/workflows/pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/pipeline-workflow.ts
@@ -5,35 +5,46 @@ import type { DesiredStatus, PipelineStatus } from '../../lib/createSchemas.js'
 import { CONTINUE_AS_NEW_THRESHOLD } from '../../lib/utils.js'
 import {
   desiredStatusSignal,
-  setup,
+  pipelineSetup,
   sourceInputSignal,
   pipelineSync,
-  teardown,
+  pipelineTeardown,
   updatePipelineStatus,
 } from './_shared.js'
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 const LIVE_EVENT_BATCH_SIZE = 10
 
+export type ReconcileState = 'backfilling' | 'reconciling' | 'ready'
+export type SetupState = 'started' | 'completed'
+export type TeardownState = 'started' | 'completed'
+
+export interface PipelineWorkflowState {
+  phase?: ReconcileState
+  paused?: boolean
+  setup?: SetupState
+  teardown?: TeardownState
+}
+
 export interface PipelineWorkflowOpts {
   desiredStatus?: DesiredStatus
   sourceState?: SourceState
   inputQueue?: SourceInputMessage[]
-  eofCompleted?: boolean
-  setupDone?: boolean
+  state?: PipelineWorkflowState
 }
 
 export async function pipelineWorkflow(
   pipelineId: string,
   opts?: PipelineWorkflowOpts
 ): Promise<void> {
+  // Persisted through continue-as-new.
+  const inputQueue: SourceInputMessage[] = opts?.inputQueue ? [...opts.inputQueue] : []
   let desiredStatus: DesiredStatus = opts?.desiredStatus ?? 'active'
-  const inputQueue: SourceInputMessage[] = [...(opts?.inputQueue ?? [])]
-  let operationCount = 0
   let sourceState: SourceState = opts?.sourceState ?? { streams: {}, global: {} }
-  let eofCompleted = opts?.eofCompleted ?? false
-  let setupDone = opts?.setupDone ?? false
-  let workflowStatus: PipelineStatus = setupDone ? (eofCompleted ? 'ready' : 'backfill') : 'setup'
+  let state: PipelineWorkflowState = { ...opts?.state }
+
+  // Transient workflow-local state.
+  let operationCount = 0
 
   setHandler(sourceInputSignal, (event: SourceInputMessage) => {
     inputQueue.push(event)
@@ -42,56 +53,75 @@ export async function pipelineWorkflow(
     desiredStatus = status
   })
 
-  async function setStatus(status: PipelineStatus) {
-    if (workflowStatus === status) return
-    workflowStatus = status
-    await updatePipelineStatus(pipelineId, status)
-  }
-  function running() {
-    return desiredStatus !== 'deleted' && operationCount < CONTINUE_AS_NEW_THRESHOLD
+  // MARK: - State
+
+  function derivePipelineStatus(): PipelineStatus {
+    if (state.teardown) return 'teardown'
+    if (state.paused) return 'paused'
+    if (state.setup !== 'completed') return 'setup'
+    return state.phase === 'ready' ? 'ready' : 'backfill'
   }
 
-  // MARK: - Main logic
+  async function setState(next: Partial<PipelineWorkflowState>) {
+    const previousStatus = derivePipelineStatus()
+    state = { ...state, ...next }
+    const nextStatus = derivePipelineStatus()
 
-  if (!setupDone) {
-    await setup(pipelineId)
-    setupDone = true
+    if (previousStatus !== nextStatus) {
+      await updatePipelineStatus(pipelineId, nextStatus)
+    }
   }
-  await setStatus(eofCompleted ? 'ready' : 'backfill')
 
+  /**
+   * Returns whether active work in this run should stop because the pipeline is
+   * no longer active or because the workflow should roll over into continue-as-new.
+   */
+  function runInterrupted() {
+    return desiredStatus !== 'active' || operationCount >= CONTINUE_AS_NEW_THRESHOLD
+  }
+
+  // MARK: - Live loop
+
+  async function waitForLiveEvents(): Promise<SourceInputMessage[] | null> {
+    await condition(() => inputQueue.length > 0 || runInterrupted())
+
+    if (runInterrupted()) {
+      return null
+    }
+
+    return inputQueue.splice(0, LIVE_EVENT_BATCH_SIZE)
+  }
 
   async function liveLoop(): Promise<void> {
-    while (running()) {
-      if (desiredStatus !== 'active') {
-        await setStatus('paused')
-        await condition(() => desiredStatus !== 'paused')
-        if (desiredStatus !== 'deleted') await setStatus(eofCompleted ? 'ready' : 'backfill')
-        continue
-      }
-      if (inputQueue.length === 0) {
-        await condition(() => inputQueue.length > 0 || desiredStatus !== 'active')
-        continue
-      }
-      const batch = inputQueue.splice(0, LIVE_EVENT_BATCH_SIZE)
-      await pipelineSync(pipelineId, { input: batch })
+    while (true) {
+      const events = await waitForLiveEvents()
+      if (!events) return
+
+      await pipelineSync(pipelineId, { input: events })
       operationCount++
     }
   }
 
-  async function backfillLoop(): Promise<void> {
-    while (running()) {
-      if (desiredStatus !== 'active') {
-        await condition(() => desiredStatus !== 'paused')
-        continue
+  // MARK: - Reconcile loop
+
+  async function waitForReconcileTurn(): Promise<boolean> {
+    await condition(() => runInterrupted() || state.phase !== 'ready', ONE_WEEK_MS)
+
+    if (runInterrupted()) {
+      return false
+    }
+
+    return true
+  }
+
+  async function reconcileLoop(): Promise<void> {
+    while (await waitForReconcileTurn()) {
+      if (!state.phase) {
+        await setState({ phase: 'backfilling' })
+      } else if (state.phase === 'ready') {
+        await setState({ phase: 'reconciling' })
       }
-      if (eofCompleted) {
-        const timedOut = !(await condition(() => desiredStatus !== 'active' || !eofCompleted, ONE_WEEK_MS))
-        if (timedOut) {
-          eofCompleted = false
-          await setStatus('backfill')
-        }
-        continue
-      }
+
       const result = await pipelineSync(pipelineId, {
         state: sourceState,
         state_limit: 100,
@@ -99,28 +129,45 @@ export async function pipelineWorkflow(
       })
       sourceState = result.state
       if (result.eof?.reason === 'complete') {
-        eofCompleted = true
-        await setStatus('ready')
+        await setState({ phase: 'ready' })
       }
       operationCount++
     }
   }
 
-  await Promise.all([liveLoop(), backfillLoop()])
+  // MARK: - Main logic
 
-  // === Teardown ===
-  if (desiredStatus === 'deleted') {
-    await setStatus('teardown')
-    await teardown(pipelineId)
-    return
+  if (state.setup !== 'completed') {
+    await setState({ setup: 'started' })
+    await pipelineSetup(pipelineId)
+    await setState({ setup: 'completed' })
   }
 
-  // === Rollover ===
-  await continueAsNew<typeof pipelineWorkflow>(pipelineId, {
-    desiredStatus,
-    sourceState,
-    inputQueue: inputQueue.length > 0 ? [...inputQueue] : undefined,
-    eofCompleted,
-    setupDone,
-  })
+  while (desiredStatus !== 'deleted') {
+    if (desiredStatus === 'paused') {
+      await setState({ paused: true })
+      await condition(() => desiredStatus !== 'paused')
+      await setState({ paused: false })
+      // Re-enter root control flow after pause in case the pipeline resumed
+      // normally or was deleted while we were waiting.
+      continue
+    }
+
+    await Promise.all([liveLoop(), reconcileLoop()])
+
+    if (operationCount >= CONTINUE_AS_NEW_THRESHOLD) {
+      return await continueAsNew<typeof pipelineWorkflow>(pipelineId, {
+        desiredStatus,
+        sourceState,
+        inputQueue,
+        state,
+      })
+    }
+  }
+
+  // Delete stays in normal workflow control flow instead of cancellation so teardown
+  // can run once in the terminal path after the active loops have stopped.
+  await setState({ teardown: 'started' })
+  await pipelineTeardown(pipelineId)
+  await setState({ teardown: 'completed' })
 }

--- a/apps/service/src/temporal/workflows/pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/pipeline-workflow.ts
@@ -1,22 +1,23 @@
 import { condition, continueAsNew, setHandler } from '@temporalio/workflow'
 
+import type { SourceInputMessage, SourceState } from '@stripe/sync-protocol'
+import type { DesiredStatus } from '../../lib/createSchemas.js'
+import { CONTINUE_AS_NEW_THRESHOLD, EVENT_BATCH_SIZE } from '../../lib/utils.js'
 import {
   desiredStatusSignal,
   setup,
   stripeEventSignal,
   syncImmediate,
   teardown,
-  updateWorkflowStatus,
+  updatePipelineStatus,
 } from './_shared.js'
-import { CONTINUE_AS_NEW_THRESHOLD, EVENT_BATCH_SIZE } from '../../lib/utils.js'
-import type { SourceInput, SourceState as SyncState } from '@stripe/sync-protocol'
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
 
 export interface PipelineWorkflowOpts {
-  desiredStatus?: string
-  state?: SyncState
-  inputQueue?: SourceInput[]
+  desiredStatus?: DesiredStatus
+  sourceState?: SourceState
+  inputQueue?: SourceInputMessage[]
 }
 
 export async function pipelineWorkflow(
@@ -24,15 +25,15 @@ export async function pipelineWorkflow(
   opts?: PipelineWorkflowOpts
 ): Promise<void> {
   let desiredStatus = opts?.desiredStatus ?? 'active'
-  const inputQueue: unknown[] = [...(opts?.inputQueue ?? [])]
+  const inputQueue: SourceInputMessage[] = [...(opts?.inputQueue ?? [])]
   let iteration = 0
-  let syncState: SyncState = opts?.state ?? { streams: {}, global: {} }
+  let syncState: SourceState = opts?.sourceState ?? { streams: {}, global: {} }
   let readComplete = false
 
-  setHandler(stripeEventSignal, (event: unknown) => {
+  setHandler(stripeEventSignal, (event: SourceInputMessage) => {
     inputQueue.push(event)
   })
-  setHandler(desiredStatusSignal, (status: string) => {
+  setHandler(desiredStatusSignal, (status: DesiredStatus) => {
     desiredStatus = status
   })
 
@@ -40,7 +41,7 @@ export async function pipelineWorkflow(
     if (++iteration >= CONTINUE_AS_NEW_THRESHOLD) {
       await continueAsNew<typeof pipelineWorkflow>(pipelineId, {
         desiredStatus,
-        state: syncState,
+        sourceState: syncState,
         inputQueue: inputQueue.length > 0 ? [...inputQueue] : undefined,
       })
     }
@@ -48,26 +49,27 @@ export async function pipelineWorkflow(
 
   // Setup
   await setup(pipelineId)
-  await updateWorkflowStatus(pipelineId, 'backfill')
+  await updatePipelineStatus(pipelineId, 'backfill')
 
   if (desiredStatus === 'deleted') {
-    await updateWorkflowStatus(pipelineId, 'teardown')
+    await updatePipelineStatus(pipelineId, 'teardown')
     await teardown(pipelineId)
     return
   }
 
+  // @ts-expect-error TS2367 -- signal handler can set desiredStatus to 'deleted' between await points
   while (desiredStatus !== 'deleted') {
     if (desiredStatus === 'paused') {
-      await updateWorkflowStatus(pipelineId, 'paused')
+      await updatePipelineStatus(pipelineId, 'paused')
       await condition(() => desiredStatus !== 'paused')
       continue
     }
 
     // Resuming from paused — update status
     if (readComplete) {
-      await updateWorkflowStatus(pipelineId, 'ready')
+      await updatePipelineStatus(pipelineId, 'ready')
     } else {
-      await updateWorkflowStatus(pipelineId, 'backfill')
+      await updatePipelineStatus(pipelineId, 'backfill')
     }
 
     if (readComplete && inputQueue.length === 0) {
@@ -92,13 +94,13 @@ export async function pipelineWorkflow(
       }
       if (result.eof?.reason === 'complete') {
         readComplete = true
-        await updateWorkflowStatus(pipelineId, 'ready')
+        await updatePipelineStatus(pipelineId, 'ready')
       }
     }
 
     await maybeContinueAsNew()
   }
 
-  await updateWorkflowStatus(pipelineId, 'teardown')
+  await updatePipelineStatus(pipelineId, 'teardown')
   await teardown(pipelineId)
 }

--- a/apps/service/src/temporal/workflows/pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/pipeline-workflow.ts
@@ -27,8 +27,15 @@ export async function pipelineWorkflow(
   let desiredStatus = opts?.desiredStatus ?? 'active'
   const inputQueue: SourceInputMessage[] = [...(opts?.inputQueue ?? [])]
   let iteration = 0
-  let syncState: SourceState = opts?.sourceState ?? { streams: {}, global: {} }
-  let readComplete = false
+  let sourceState: SourceState = opts?.sourceState ?? { streams: {}, global: {} }
+  let eofCompleted = false
+  let workflowStatus: WorkflowStatus = 'setup'
+
+  async function setStatus(status: WorkflowStatus) {
+    if (workflowStatus === status) return
+    workflowStatus = status
+    await updatePipelineStatus(pipelineId, status)
+  }
 
   setHandler(stripeEventSignal, (event: SourceInputMessage) => {
     inputQueue.push(event)
@@ -41,7 +48,7 @@ export async function pipelineWorkflow(
     if (++iteration >= CONTINUE_AS_NEW_THRESHOLD) {
       await continueAsNew<typeof pipelineWorkflow>(pipelineId, {
         desiredStatus,
-        sourceState: syncState,
+        sourceState: sourceState,
         inputQueue: inputQueue.length > 0 ? [...inputQueue] : undefined,
       })
     }
@@ -49,7 +56,7 @@ export async function pipelineWorkflow(
 
   // Setup
   await setup(pipelineId)
-  await updatePipelineStatus(pipelineId, 'backfill')
+  await setStatus('backfill')
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -58,25 +65,20 @@ export async function pipelineWorkflow(
     }
 
     if (desiredStatus === 'paused') {
-      await updatePipelineStatus(pipelineId, 'paused')
+      await setStatus('paused')
       await condition(() => desiredStatus !== 'paused')
       continue
     }
 
-    // Resuming from paused — update status
-    if (readComplete) {
-      await updatePipelineStatus(pipelineId, 'ready')
-    } else {
-      await updatePipelineStatus(pipelineId, 'backfill')
-    }
+    await setStatus(eofCompleted ? 'ready' : 'backfill')
 
-    if (readComplete && inputQueue.length === 0) {
+    if (eofCompleted && inputQueue.length === 0) {
       // Idle — wait up to one week; timeout means recon is due.
       const timedOut = !(await condition(
         () => desiredStatus !== 'active' || inputQueue.length > 0,
         ONE_WEEK_MS
       ))
-      if (timedOut) readComplete = false
+      if (timedOut) eofCompleted = false
       continue
     }
 
@@ -85,23 +87,20 @@ export async function pipelineWorkflow(
       await syncImmediate(pipelineId, { input: batch })
     } else {
       const result = await syncImmediate(pipelineId, {
-        state: syncState,
+        state: sourceState,
         state_limit: 100,
         time_limit: 10,
       })
-      syncState = {
-        streams: { ...syncState.streams, ...result.state.streams },
-        global: { ...syncState.global, ...result.state.global },
-      }
+      sourceState = result.state
       if (result.eof?.reason === 'complete') {
-        readComplete = true
-        await updatePipelineStatus(pipelineId, 'ready')
+        eofCompleted = true
+        await setStatus('ready')
       }
     }
 
     await maybeContinueAsNew()
   }
 
-  await updatePipelineStatus(pipelineId, 'teardown')
+  await setStatus('teardown')
   await teardown(pipelineId)
 }

--- a/apps/service/src/temporal/workflows/pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/pipeline-workflow.ts
@@ -51,14 +51,12 @@ export async function pipelineWorkflow(
   await setup(pipelineId)
   await updatePipelineStatus(pipelineId, 'backfill')
 
-  if (desiredStatus === 'deleted') {
-    await updatePipelineStatus(pipelineId, 'teardown')
-    await teardown(pipelineId)
-    return
-  }
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (desiredStatus === 'deleted') {
+      break
+    }
 
-  // @ts-expect-error TS2367 -- signal handler can set desiredStatus to 'deleted' between await points
-  while (desiredStatus !== 'deleted') {
     if (desiredStatus === 'paused') {
       await updatePipelineStatus(pipelineId, 'paused')
       await condition(() => desiredStatus !== 'paused')

--- a/apps/service/src/temporal/workflows/pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/pipeline-workflow.ts
@@ -1,92 +1,98 @@
 import { condition, continueAsNew, setHandler } from '@temporalio/workflow'
 
 import type { SourceInputMessage, SourceState } from '@stripe/sync-protocol'
-import type { DesiredStatus, WorkflowStatus } from '../../lib/createSchemas.js'
-import { CONTINUE_AS_NEW_THRESHOLD, EVENT_BATCH_SIZE } from '../../lib/utils.js'
+import type { DesiredStatus, PipelineStatus } from '../../lib/createSchemas.js'
+import { CONTINUE_AS_NEW_THRESHOLD } from '../../lib/utils.js'
 import {
   desiredStatusSignal,
   setup,
-  stripeEventSignal,
-  syncImmediate,
+  sourceInputSignal,
+  pipelineSync,
   teardown,
   updatePipelineStatus,
 } from './_shared.js'
 
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
+const LIVE_EVENT_BATCH_SIZE = 10
 
 export interface PipelineWorkflowOpts {
   desiredStatus?: DesiredStatus
   sourceState?: SourceState
   inputQueue?: SourceInputMessage[]
+  eofCompleted?: boolean
+  setupDone?: boolean
 }
 
 export async function pipelineWorkflow(
   pipelineId: string,
   opts?: PipelineWorkflowOpts
 ): Promise<void> {
-  let desiredStatus = opts?.desiredStatus ?? 'active'
+  let desiredStatus: DesiredStatus = opts?.desiredStatus ?? 'active'
   const inputQueue: SourceInputMessage[] = [...(opts?.inputQueue ?? [])]
-  let iteration = 0
+  let operationCount = 0
   let sourceState: SourceState = opts?.sourceState ?? { streams: {}, global: {} }
-  let eofCompleted = false
-  let workflowStatus: WorkflowStatus = 'setup'
+  let eofCompleted = opts?.eofCompleted ?? false
+  let setupDone = opts?.setupDone ?? false
+  let workflowStatus: PipelineStatus = setupDone ? (eofCompleted ? 'ready' : 'backfill') : 'setup'
 
-  async function setStatus(status: WorkflowStatus) {
-    if (workflowStatus === status) return
-    workflowStatus = status
-    await updatePipelineStatus(pipelineId, status)
-  }
-
-  setHandler(stripeEventSignal, (event: SourceInputMessage) => {
+  setHandler(sourceInputSignal, (event: SourceInputMessage) => {
     inputQueue.push(event)
   })
   setHandler(desiredStatusSignal, (status: DesiredStatus) => {
     desiredStatus = status
   })
 
-  async function maybeContinueAsNew() {
-    if (++iteration >= CONTINUE_AS_NEW_THRESHOLD) {
-      await continueAsNew<typeof pipelineWorkflow>(pipelineId, {
-        desiredStatus,
-        sourceState: sourceState,
-        inputQueue: inputQueue.length > 0 ? [...inputQueue] : undefined,
-      })
+  async function setStatus(status: PipelineStatus) {
+    if (workflowStatus === status) return
+    workflowStatus = status
+    await updatePipelineStatus(pipelineId, status)
+  }
+  function running() {
+    return desiredStatus !== 'deleted' && operationCount < CONTINUE_AS_NEW_THRESHOLD
+  }
+
+  // MARK: - Main logic
+
+  if (!setupDone) {
+    await setup(pipelineId)
+    setupDone = true
+  }
+  await setStatus(eofCompleted ? 'ready' : 'backfill')
+
+
+  async function liveLoop(): Promise<void> {
+    while (running()) {
+      if (desiredStatus !== 'active') {
+        await setStatus('paused')
+        await condition(() => desiredStatus !== 'paused')
+        if (desiredStatus !== 'deleted') await setStatus(eofCompleted ? 'ready' : 'backfill')
+        continue
+      }
+      if (inputQueue.length === 0) {
+        await condition(() => inputQueue.length > 0 || desiredStatus !== 'active')
+        continue
+      }
+      const batch = inputQueue.splice(0, LIVE_EVENT_BATCH_SIZE)
+      await pipelineSync(pipelineId, { input: batch })
+      operationCount++
     }
   }
 
-  // Setup
-  await setup(pipelineId)
-  await setStatus('backfill')
-
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    if (desiredStatus === 'deleted') {
-      break
-    }
-
-    if (desiredStatus === 'paused') {
-      await setStatus('paused')
-      await condition(() => desiredStatus !== 'paused')
-      continue
-    }
-
-    await setStatus(eofCompleted ? 'ready' : 'backfill')
-
-    if (eofCompleted && inputQueue.length === 0) {
-      // Idle — wait up to one week; timeout means recon is due.
-      const timedOut = !(await condition(
-        () => desiredStatus !== 'active' || inputQueue.length > 0,
-        ONE_WEEK_MS
-      ))
-      if (timedOut) eofCompleted = false
-      continue
-    }
-
-    if (inputQueue.length > 0) {
-      const batch = inputQueue.splice(0, EVENT_BATCH_SIZE)
-      await syncImmediate(pipelineId, { input: batch })
-    } else {
-      const result = await syncImmediate(pipelineId, {
+  async function backfillLoop(): Promise<void> {
+    while (running()) {
+      if (desiredStatus !== 'active') {
+        await condition(() => desiredStatus !== 'paused')
+        continue
+      }
+      if (eofCompleted) {
+        const timedOut = !(await condition(() => desiredStatus !== 'active' || !eofCompleted, ONE_WEEK_MS))
+        if (timedOut) {
+          eofCompleted = false
+          await setStatus('backfill')
+        }
+        continue
+      }
+      const result = await pipelineSync(pipelineId, {
         state: sourceState,
         state_limit: 100,
         time_limit: 10,
@@ -96,11 +102,25 @@ export async function pipelineWorkflow(
         eofCompleted = true
         await setStatus('ready')
       }
+      operationCount++
     }
-
-    await maybeContinueAsNew()
   }
 
-  await setStatus('teardown')
-  await teardown(pipelineId)
+  await Promise.all([liveLoop(), backfillLoop()])
+
+  // === Teardown ===
+  if (desiredStatus === 'deleted') {
+    await setStatus('teardown')
+    await teardown(pipelineId)
+    return
+  }
+
+  // === Rollover ===
+  await continueAsNew<typeof pipelineWorkflow>(pipelineId, {
+    desiredStatus,
+    sourceState,
+    inputQueue: inputQueue.length > 0 ? [...inputQueue] : undefined,
+    eofCompleted,
+    setupDone,
+  })
 }

--- a/apps/service/src/temporal/workflows/pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/pipeline-workflow.ts
@@ -1,7 +1,7 @@
 import { condition, continueAsNew, setHandler } from '@temporalio/workflow'
 
 import type { SourceInputMessage, SourceState } from '@stripe/sync-protocol'
-import type { DesiredStatus } from '../../lib/createSchemas.js'
+import type { DesiredStatus, WorkflowStatus } from '../../lib/createSchemas.js'
 import { CONTINUE_AS_NEW_THRESHOLD, EVENT_BATCH_SIZE } from '../../lib/utils.js'
 import {
   desiredStatusSignal,
@@ -72,7 +72,10 @@ export async function pipelineWorkflow(
 
     if (readComplete && inputQueue.length === 0) {
       // Idle — wait up to one week; timeout means recon is due.
-      const timedOut = !(await condition(() => desiredStatus !== 'active' || inputQueue.length > 0, ONE_WEEK_MS))
+      const timedOut = !(await condition(
+        () => desiredStatus !== 'active' || inputQueue.length > 0,
+        ONE_WEEK_MS
+      ))
       if (timedOut) readComplete = false
       continue
     }

--- a/docs/service/pipeline-workflow-dual-lane.md
+++ b/docs/service/pipeline-workflow-dual-lane.md
@@ -1,0 +1,218 @@
+# Pipeline Workflow: Dual-Lane Clarity Notes
+
+This note captures what became clearer as we iterated on
+`apps/service/src/temporal/workflows/pipeline-workflow.ts`.
+
+## Before
+
+The original workflow worked, but it was harder to read because several concerns
+were interleaved:
+
+- lifecycle control (`active`, `paused`, `deleted`)
+- derived pipeline status (`setup`, `backfill`, `ready`, `paused`, `teardown`)
+- persisted workflow state
+- live lane work
+- backfill/reconcile lane work
+
+That showed up in a few concrete ways:
+
+- both loops knew too much about lifecycle state
+- booleans such as `eofCompleted` and `setupDone` carried phase meaning indirectly
+- `condition(...)` results were interpreted through awkward boolean inversions
+- status updates were spread across multiple places
+- terminal actions and rollover logic were farther from the places where the run
+  actually stopped
+
+## After
+
+The current direction is simpler:
+
+- the workflow persists a single `state` object
+- the workflow derives external pipeline status from persisted state plus
+  `desiredStatus`
+- each lane has a co-located wait helper
+- wait helpers decide only whether work should run next
+- state transitions happen explicitly in the loop after a real event
+- `continueAsNew(...)` happens in the active path, not after teardown
+
+## Principles
+
+### 1. Keep workflow control at the root
+
+The root should own:
+
+- setup
+- pause handling
+- delete handling
+- continue-as-new
+- teardown
+
+Loops should focus on doing work, not on orchestrating the whole workflow.
+
+### 2. Persist one workflow state object
+
+Use one persisted `state` object inside workflow options rather than parallel
+top-level booleans.
+
+That keeps rollover payloads smaller and makes persisted state easier to reason
+about as one concept.
+
+### 3. Use explicit phase names instead of overloaded booleans
+
+`phase: 'backfilling' | 'reconciling' | 'ready'` is easier to read than a
+boolean such as `backfillComplete`.
+
+Booleans hide transitions. Phases make transitions visible.
+
+### 4. Derive pipeline status instead of storing it separately
+
+The workflow should compute pipeline status from current facts rather than
+tracking a second mutable `workflowStatus` field.
+
+This avoids drift between:
+
+- persisted workflow state
+- desired lifecycle state
+- externally reported pipeline status
+
+### 5. Distinguish desired state from actual workflow state
+
+`desiredStatus` is requested intent from outside the workflow.
+
+The persisted workflow `state` is what the workflow is actually doing.
+
+Those are not always the same thing. For example:
+
+- `desiredStatus` can become `paused` while an in-flight activity is still
+  finishing
+- `desiredStatus` can become `deleted` before teardown has actually started
+
+Keep both concepts explicit and avoid pretending one can stand in for the other.
+
+### 6. Keep pause and teardown as explicit lifecycle transitions
+
+Derived pipeline status should cover phase-driven status such as:
+
+- `setup`
+- `backfill`
+- `ready`
+
+Lifecycle transitions such as:
+
+- `paused`
+- `teardown`
+
+should usually be written explicitly in root control flow instead of being
+smuggled into a generic derived-status helper.
+
+### 7. Wait helpers should gate work, not mutate state
+
+A wait helper should answer:
+
+- is there work to do now?
+- should the loop stop?
+
+State changes should happen explicitly in the loop after the relevant event is
+observed.
+
+Examples:
+
+- when `phase` is empty, the reconcile loop can set it to `backfilling`
+- when `phase` is `ready`, the reconcile loop can set it to `reconciling`
+- when `pipelineSync(...)` reaches EOF complete, the reconcile loop can set it
+  to `ready`
+
+### 8. Co-locate each wait helper with its loop
+
+`waitForLiveEvents()` should sit next to `liveLoop()`.
+
+`waitForReconcileTurn()` should sit next to `reconcileLoop()`.
+
+That keeps loop-specific control flow local without nesting helpers inside the
+loop function body.
+
+### 9. Prefer one compound `condition(...)` over clever boolean interpretation
+
+Using one `condition(...)` to describe what can wake the loop is good.
+
+What made the old version hard to read was not the compound condition itself.
+It was trying to infer too much from the boolean returned by `condition(...)`.
+
+The clearer pattern is:
+
+1. wait for the relevant wake-up conditions
+2. inspect current workflow state after waking
+3. decide whether to run or stop
+
+### 10. Name helpers after workflow meaning, not loop mechanics
+
+`runInterrupted()` is better than names like `shouldInterruptLoop()` because it
+describes workflow state, not implementation shape.
+
+The workflow should read in domain terms first and control-flow terms second.
+
+### 11. Keep terminal work on the terminal path
+
+Teardown should remain in the terminal delete path.
+
+`continueAsNew(...)` should happen only on the rollover path.
+
+That makes it obvious that:
+
+- delete ends the current workflow
+- rollover starts a new run
+
+### 12. Prefer meaningful loop conditions over `while (true)` when possible
+
+If delete is the terminal path, `while (desiredStatus !== 'deleted')` is clearer
+than `while (true)` followed by an immediate delete check inside the loop.
+
+Use `while (true)` only when the exits genuinely belong inside the body.
+
+### 13. Update external status only when something actually changed
+
+Avoid sprinkling `updatePipelineStatus(...)` through control flow just because
+execution passed through a branch or loop.
+
+Prefer:
+
+- state-driven updates via `setState(...)`
+- explicit lifecycle updates for `paused` and `teardown`
+
+That keeps status writes aligned with real transitions instead of incidental
+control flow.
+
+### 14. Internal workflow state can be richer than the external API status
+
+It is fine for workflow-local state to track more detail than the API exposes.
+
+For example, the workflow may track internal lifecycle phases such as:
+
+- `setup: 'started' | 'completed'`
+- `teardown: 'started' | 'completed'`
+
+while the external pipeline status still exposes only `setup` or `teardown`.
+
+That keeps the workflow implementation explicit without forcing every internal
+transition into the public API contract.
+
+### 15. Symmetry helps readability
+
+If setup is tracked explicitly, teardown usually should be tracked explicitly in
+the same style.
+
+Likewise, if one lifecycle transition uses `setState(...)`, nearby lifecycle
+transitions should usually follow the same pattern unless there is a strong
+reason not to.
+
+## Rule of Thumb
+
+If a line makes the reader mentally simulate both Temporal semantics and local
+workflow state at the same time, it is probably too clever.
+
+Prefer code that answers one question at a time:
+
+- should this run continue?
+- should this lane do work now?
+- what phase are we in?
+- what pipeline status should we report?

--- a/e2e/service-docker.test.ts
+++ b/e2e/service-docker.test.ts
@@ -171,7 +171,7 @@ describeWithEnv(
 
       // --- Get returns status ---
       const { data: got } = await c.GET('/pipelines/{id}', { params: { path: { id } } })
-      expect(got!.status?.phase).toBeDefined()
+      expect(typeof got!.status).toBe('string')
 
       // --- Delete ---
       const { data: deleted, error: deleteErr } = await c.DELETE('/pipelines/{id}', {

--- a/packages/destination-google-sheets/__tests__/memory-sheets.ts
+++ b/packages/destination-google-sheets/__tests__/memory-sheets.ts
@@ -163,6 +163,24 @@ export function createMemorySheets() {
           }
         },
 
+        async batchUpdate(params: {
+          spreadsheetId: string
+          requestBody?: {
+            valueInputOption?: string
+            data?: { range: string; values?: unknown[][] }[]
+          }
+        }) {
+          for (const entry of params.requestBody?.data ?? []) {
+            const tab = getTab(params.spreadsheetId, entry.range)
+            const rows = entry.values ?? []
+            const startRow = parseStartRow(entry.range)
+            for (let i = 0; i < rows.length; i++) {
+              tab.values[startRow - 1 + i] = rows[i]
+            }
+          }
+          return { data: {} }
+        },
+
         async get(params: { spreadsheetId: string; range: string }) {
           const tab = getTab(params.spreadsheetId, params.range)
           return { data: { values: tab.values } }

--- a/packages/destination-google-sheets/src/index.ts
+++ b/packages/destination-google-sheets/src/index.ts
@@ -258,12 +258,6 @@ export function createDestination(
           appends.map((entry) => entry.row)
         )
         if (range) {
-          const expectedEndRow = range.startRow + appends.length - 1
-          if (range.endRow !== expectedEndRow) {
-            throw new Error(
-              `Append row mismatch for ${streamName}: expected ${expectedEndRow}, got ${range.endRow}`
-            )
-          }
           for (let index = 0; index < appends.length; index++) {
             const rowKey = appends[index]?.rowKey
             if (!rowKey) continue
@@ -310,7 +304,9 @@ export function createDestination(
             }
           } else if (msg.type === 'source_state') {
             // Flush the stream's pending rows, then re-emit the state checkpoint
-            if (msg.source_state.state_type !== 'global') {
+            if (msg.source_state.state_type === 'global') {
+              await flushAll()
+            } else {
               await flushStream(msg.source_state.stream)
             }
             yield msg

--- a/packages/destination-google-sheets/src/writer.ts
+++ b/packages/destination-google-sheets/src/writer.ts
@@ -305,16 +305,18 @@ export async function updateRows(
 ): Promise<void> {
   if (updates.length === 0) return
 
-  for (const update of updates) {
-    await withRetry(() =>
-      sheets.spreadsheets.values.update({
-        spreadsheetId,
-        range: `'${sheetName}'!A${update.rowNumber}`,
+  await withRetry(() =>
+    sheets.spreadsheets.values.batchUpdate({
+      spreadsheetId,
+      requestBody: {
         valueInputOption: 'RAW',
-        requestBody: { values: [update.values] },
-      })
-    )
-  }
+        data: updates.map((update) => ({
+          range: `'${sheetName}'!A${update.rowNumber}`,
+          values: [update.values],
+        })),
+      },
+    })
+  )
 }
 
 /**

--- a/packages/protocol/src/protocol.ts
+++ b/packages/protocol/src/protocol.ts
@@ -437,6 +437,12 @@ export const Message = z
   .meta({ id: 'Message' })
 export type Message = z.infer<typeof Message>
 
+/**
+ * A single source input item (e.g. a webhook event payload).
+ * Generic at the protocol level; connectors narrow this via `Source<TConfig, TStreamState, TInput>`.
+ */
+export type SourceInput = unknown
+
 // MARK: - Per-command output types
 
 /** Output of spec(): the connector's specification, plus optional logs/traces. */

--- a/packages/protocol/src/protocol.ts
+++ b/packages/protocol/src/protocol.ts
@@ -389,14 +389,6 @@ export const PipelineConfig = z.object({
 })
 export type PipelineConfig = z.infer<typeof PipelineConfig>
 
-/** The full set of parsed sync request params: pipeline config + cursor state + stream limits. */
-export interface SyncParams {
-  pipeline: PipelineConfig
-  state?: SourceState
-  state_limit?: number
-  time_limit?: number
-}
-
 // MARK: - Message unions
 
 /** The subset of messages the destination receives on stdin. */
@@ -438,10 +430,15 @@ export const Message = z
 export type Message = z.infer<typeof Message>
 
 /**
- * A single source input item (e.g. a webhook event payload).
- * Generic at the protocol level; connectors narrow this via `Source<TConfig, TStreamState, TInput>`.
+ * Wire envelope for a single source input item (e.g. a webhook event payload).
+ * `source_input` carries the connector-specific payload; connectors narrow its type via
+ * `Source<TConfig, TStreamState, TInput>`.
  */
-export type SourceInput = unknown
+export const SourceInputMessage = MessageBase.extend({
+  type: z.literal('source_input'),
+  source_input: z.unknown(),
+}).meta({ id: 'SourceInputMessage' })
+export type SourceInputMessage = z.infer<typeof SourceInputMessage>
 
 // MARK: - Per-command output types
 
@@ -492,7 +489,7 @@ export type TeardownOutput = z.infer<typeof TeardownOutput>
  *
  * Type parameters:
  *   TConfig      — connector's configuration type, inferred from its Zod spec
- *   TStreamState — per-stream checkpoint shape (opaque to the orchestrator)
+ *   TSourceStreamState — per-stream checkpoint shape (opaque to the orchestrator)
  *   TInput       — serializable data passed to read() for event-driven reads
  *                  (e.g. a single webhook event). When absent, read() performs
  *                  a pull-based backfill.


### PR DESCRIPTION
## Summary

This branch turns pipeline lifecycle handling into an explicit state machine across the service API, Temporal workflows, protocol surface, and dashboard usage.

### API and status model

- add `desired_status` (`active | paused | deleted`) as the user-controlled lifecycle field
- keep workflow-controlled execution status in the stored pipeline record and derive the user-facing status from `desired_status` plus workflow state
- remove dedicated pause/resume style lifecycle endpoints in favor of lifecycle updates via `PATCH /pipelines/{id}`
- add `DELETE /pipelines/{id}` support for pipeline teardown
- simplify API responses so status comes from the store rather than Temporal queries / ad hoc waiting
- regenerate OpenAPI outputs for the updated service and engine schemas

### Temporal workflows and activities

- rename workflow activities for clarity: `pipelineSetup`, `pipelineSync`, `pipelineTeardown`
- refactor `pipelineWorkflow` around explicit persisted workflow state, explicit lifecycle transitions, and co-located live/reconcile wait helpers
- clean up the dual-lane workflow control flow for setup, pause, reconcile, continue-as-new, and teardown
- update the Google Sheets workflow and shared workflow helpers to match the renamed activity surface
- add `update-pipeline-status` activity wiring for workflow-driven status persistence

### Protocol, engine, dashboard, and connector updates

- update protocol/service handling around the `SourceInputMessage` envelope and pipeline status naming
- adjust engine API tests and schemas to match the new lifecycle/status model
- fix the dashboard `source_discover` call to use `x-source` rather than `x-pipeline`
- update Google Sheets destination code/tests and related service Docker / E2E paths affected by the new lifecycle flow

### Tests and docs

- expand mocked Temporal workflow coverage for live input delivery, concurrent live/reconcile behavior, pause/resume queueing, teardown transitions, and status progression
- make the live-drain assertions contract-based instead of timing-fragile under CI scheduling
- document the workflow design principles and lessons learned in `docs/service/pipeline-workflow-dual-lane.md`

## Test plan

- [x] `pnpm --filter @stripe/sync-service build`
- [x] `pnpm --filter @stripe/sync-service test -- src/__tests__/workflow.test.ts`
- [x] `pnpm --filter @stripe/sync-service test`
- [x] `pnpm lint`
- [x] PR CI green
