### PR TITLE
feat: eliminate dist/ dependency during development via customConditions

### DIFF
--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -333,7 +333,9 @@ export async function createApp(resolver: ConnectorResolver) {
   app.openapi(sourceDiscoverRoute, (c) => {
     const source = c.req.valid('header')['x-source']
     const context = { path: '/source_discover', sourceName: source.type }
-    return ndjsonResponse(logApiStream('Engine API /source_discover', engine.source_discover(source), context))
+    return ndjsonResponse(
+      logApiStream('Engine API /source_discover', engine.source_discover(source), context)
+    )
   })
 
   const pipelineReadRoute = createRoute({

--- a/docs/slides/_common.sh
+++ b/docs/slides/_common.sh
@@ -4,5 +4,5 @@
 set -euo pipefail
 [ -f "$ROOT/.env" ] && set -a && source "$ROOT/.env" && set +a
 
-source-stripe() { node "$ROOT/packages/source-stripe/dist/bin.js" "$@"; }
-dest-postgres()  { node "$ROOT/packages/destination-postgres/dist/bin.js" "$@"; }
+source-stripe() { "$ROOT/scripts/ts-run" "$ROOT/packages/source-stripe/src/bin.ts" "$@"; }
+dest-postgres()  { "$ROOT/scripts/ts-run" "$ROOT/packages/destination-postgres/src/bin.ts" "$@"; }

--- a/docs/slides/step5-engine.sh
+++ b/docs/slides/step5-engine.sh
@@ -8,7 +8,7 @@ PORT=3099
 trap "kill \$ENGINE_PID 2>/dev/null || true" EXIT
 
 kill $(lsof -ti:$PORT 2>/dev/null) 2>/dev/null || true
-(cd "$ROOT/apps/engine" && PORT=$PORT node dist/api/index.js) &>/dev/null & ENGINE_PID=$!
+(cd "$ROOT/apps/engine" && PORT=$PORT "$ROOT/scripts/ts-run" src/api/index.ts) &>/dev/null & ENGINE_PID=$!
 until nc -z 127.0.0.1 $PORT 2>/dev/null; do sleep 0.3; done
 
 PARAMS='{"source":{"name":"stripe","api_key":"'"$STRIPE_API_KEY"'","backfill_limit":5},"destination":{"name":"postgres","connection_string":"'"$POSTGRES_URL"'","schema":"'"$SCHEMA"'"},"streams":[{"name":"products","fields":["id","name"]}]}'

--- a/packages/source-stripe/src/transport.test.ts
+++ b/packages/source-stripe/src/transport.test.ts
@@ -120,9 +120,13 @@ describe('fetchWithProxy', () => {
     const mockFetch = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }))
     vi.stubGlobal('fetch', mockFetch)
 
-    await fetchWithProxy('https://api.stripe.com/v1/customers', {}, {
-      HTTPS_PROXY: 'http://proxy.example.test:8080',
-    })
+    await fetchWithProxy(
+      'https://api.stripe.com/v1/customers',
+      {},
+      {
+        HTTPS_PROXY: 'http://proxy.example.test:8080',
+      }
+    )
 
     expect(mockFetch).toHaveBeenCalledOnce()
     const [, init] = mockFetch.mock.calls[0]
@@ -133,9 +137,13 @@ describe('fetchWithProxy', () => {
     const mockFetch = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }))
     vi.stubGlobal('fetch', mockFetch)
 
-    await fetchWithProxy('http://localhost:12111/v1/customers', {}, {
-      HTTPS_PROXY: 'http://proxy.example.test:8080',
-    })
+    await fetchWithProxy(
+      'http://localhost:12111/v1/customers',
+      {},
+      {
+        HTTPS_PROXY: 'http://proxy.example.test:8080',
+      }
+    )
 
     expect(mockFetch).toHaveBeenCalledOnce()
     const [, init] = mockFetch.mock.calls[0]
@@ -146,10 +154,14 @@ describe('fetchWithProxy', () => {
     const mockFetch = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }))
     vi.stubGlobal('fetch', mockFetch)
 
-    await fetchWithProxy('https://stripe-sync.dev/stripe-api-specs/manifest.json', {}, {
-      HTTPS_PROXY: 'http://proxy.example.test:8080',
-      NO_PROXY: 'stripe-sync.dev',
-    })
+    await fetchWithProxy(
+      'https://stripe-sync.dev/stripe-api-specs/manifest.json',
+      {},
+      {
+        HTTPS_PROXY: 'http://proxy.example.test:8080',
+        NO_PROXY: 'stripe-sync.dev',
+      }
+    )
 
     expect(mockFetch).toHaveBeenCalledOnce()
     const [, init] = mockFetch.mock.calls[0]

--- a/scripts/ts-run
+++ b/scripts/ts-run
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Universal TypeScript runner.
-# Uses bun if available; otherwise remaps src/…ts → dist/…js and runs with node.
+# Uses bun if available; otherwise falls back to tsx with the "bun" condition
+# so cross-package imports resolve to source .ts files (no dist/ needed).
 #
 # Usage: scripts/ts-run <src/path/to/file.ts> [args...]
 
@@ -9,7 +10,5 @@ FILE="$1"; shift
 if command -v bun &>/dev/null; then
   exec bun "$FILE" "$@"
 else
-  NODE_FILE="${FILE/\/src\//\/dist\/}"
-  NODE_FILE="${NODE_FILE%.ts}.js"
-  exec node "$NODE_FILE" "$@"
+  exec npx tsx --conditions bun "$FILE" "$@"
 fi

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "customConditions": ["bun"],
     "target": "esnext",
     "module": "nodenext",
     "moduleResolution": "nodenext",


### PR DESCRIPTION
## Summary

- Add `\"customConditions\": [\"bun\"]` to `tsconfig.base.json` — the entire fix in one line. TypeScript now resolves workspace imports through the `\"bun\"` export condition (`./src/index.ts`) instead of `\"types\"` (`./dist/index.d.ts`), so no `dist/` is needed before type-checking or developing.
- Update `scripts/ts-run` Node fallback to use `npx tsx --conditions bun` (removes the `src/→dist/` path remap).
- Update `docs/slides` demo scripts to invoke connectors and engine via `scripts/ts-run` instead of `node dist/` paths.

External consumers and CI production builds are unaffected — they don't set `customConditions`, so they continue resolving via `\"types\"`/`\"import\"`.

## How it works

Each package's `package.json` export map has a `\"bun\"` condition pointing to source `.ts` files. Without `customConditions`, TypeScript skips it and lands on `\"types\": \"./dist/index.d.ts\"` — requiring a prior build. With `customConditions: [\"bun\"]`, TypeScript matches `\"bun\"` first and reads source directly.

## Verification

- `tsc --noEmit` on `apps/engine` with all `dist/` deleted: ✅ zero errors
- `pnpm build` (all packages except `apps/supabase`): ✅
- `apps/supabase` build in `node:24-alpine` Docker: ✅ (`apps/supabase` uses esbuild which has a pre-existing native binary crash on this Mac, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)