### PR TITLE
Parallelize and batch Postgres DDL for pipeline setup

### DIFF
--- a/packages/destination-postgres/src/index.ts
+++ b/packages/destination-postgres/src/index.ts
@@ -10,7 +10,7 @@ import {
   withQueryLogging,
 } from '@stripe/sync-util-postgres'
 import { z } from 'zod'
-import { buildCreateTableWithSchema, runSqlAdditive } from './schemaProjection.js'
+import { buildCreateTableDDL } from './schemaProjection.js'
 import defaultSpec, { configSchema } from './spec.js'
 import type { Config } from './spec.js'
 
@@ -87,6 +87,7 @@ export async function upsertMany(
 
 // Schema projection (JSON Schema -> Postgres DDL)
 export {
+  buildCreateTableDDL,
   buildCreateTableWithSchema,
   jsonSchemaToColumns,
   runSqlAdditive,
@@ -149,34 +150,35 @@ const destination = {
         END;
         $$;
       `)
-      for (const [i, cs] of catalog.streams.entries()) {
-        const start = Date.now()
-        if (cs.stream.json_schema) {
-          const stmts = buildCreateTableWithSchema(
-            config.schema,
-            cs.stream.name,
-            cs.stream.json_schema,
-            {
-              system_columns: cs.system_columns,
-            }
-          )
-          for (const stmt of stmts) {
-            await runSqlAdditive(pool, stmt)
+      const total = catalog.streams.length
+      const logs: { index: number; name: string; ms: number }[] = []
+      await Promise.all(
+        catalog.streams.map(async (cs, i) => {
+          const start = Date.now()
+          if (cs.stream.json_schema) {
+            await pool.query(buildCreateTableDDL(
+              config.schema,
+              cs.stream.name,
+              cs.stream.json_schema,
+              { system_columns: cs.system_columns }
+            ))
+          } else {
+            await pool.query(sql`
+              CREATE TABLE IF NOT EXISTS "${config.schema}"."${cs.stream.name}" (
+                "_raw_data" jsonb NOT NULL,
+                "_last_synced_at" timestamptz,
+                "_updated_at" timestamptz NOT NULL DEFAULT now(),
+                "id" text GENERATED ALWAYS AS (("_raw_data"->>'id')::text) STORED,
+                PRIMARY KEY ("id")
+              )
+            `)
           }
-        } else {
-          await pool.query(sql`
-            CREATE TABLE IF NOT EXISTS "${config.schema}"."${cs.stream.name}" (
-              "_raw_data" jsonb NOT NULL,
-              "_last_synced_at" timestamptz,
-              "_updated_at" timestamptz NOT NULL DEFAULT now(),
-              "id" text GENERATED ALWAYS AS (("_raw_data"->>'id')::text) STORED,
-              PRIMARY KEY ("id")
-            )
-          `)
-        }
-        yield logMsg(
-          `[${i + 1}/${catalog.streams.length}] Table "${cs.stream.name}" ready (${Date.now() - start}ms)`
-        )
+          logs.push({ index: i, name: cs.stream.name, ms: Date.now() - start })
+        })
+      )
+      logs.sort((a, b) => a.index - b.index)
+      for (const l of logs) {
+        yield logMsg(`[${l.index + 1}/${total}] Table "${l.name}" ready (${l.ms}ms)`)
       }
     } finally {
       await pool.end()

--- a/packages/destination-postgres/src/index.ts
+++ b/packages/destination-postgres/src/index.ts
@@ -150,18 +150,14 @@ const destination = {
         END;
         $$;
       `)
-      const total = catalog.streams.length
-      const logs: { index: number; name: string; ms: number }[] = []
       await Promise.all(
-        catalog.streams.map(async (cs, i) => {
-          const start = Date.now()
+        catalog.streams.map(async (cs) => {
           if (cs.stream.json_schema) {
-            await pool.query(buildCreateTableDDL(
-              config.schema,
-              cs.stream.name,
-              cs.stream.json_schema,
-              { system_columns: cs.system_columns }
-            ))
+            await pool.query(
+              buildCreateTableDDL(config.schema, cs.stream.name, cs.stream.json_schema, {
+                system_columns: cs.system_columns,
+              })
+            )
           } else {
             await pool.query(sql`
               CREATE TABLE IF NOT EXISTS "${config.schema}"."${cs.stream.name}" (
@@ -173,13 +169,8 @@ const destination = {
               )
             `)
           }
-          logs.push({ index: i, name: cs.stream.name, ms: Date.now() - start })
         })
       )
-      logs.sort((a, b) => a.index - b.index)
-      for (const l of logs) {
-        yield logMsg(`[${l.index + 1}/${total}] Table "${l.name}" ready (${l.ms}ms)`)
-      }
     } finally {
       await pool.end()
     }

--- a/packages/destination-postgres/src/schemaProjection.test.ts
+++ b/packages/destination-postgres/src/schemaProjection.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { jsonSchemaToColumns, buildCreateTableWithSchema } from './schemaProjection.js'
+import {
+  jsonSchemaToColumns,
+  buildCreateTableWithSchema,
+  buildCreateTableDDL,
+} from './schemaProjection.js'
 
 const SAMPLE_JSON_SCHEMA: Record<string, unknown> = {
   type: 'object',
@@ -62,9 +66,13 @@ describe('buildCreateTableWithSchema', () => {
     expect(stmts[0]).toContain('"created" bigint GENERATED ALWAYS AS')
     expect(stmts[0]).toContain('"metadata" jsonb GENERATED ALWAYS AS')
 
-    // ALTER TABLE ADD COLUMN IF NOT EXISTS for each column
+    // Single batched ALTER TABLE with all ADD COLUMN IF NOT EXISTS clauses
     const alterStmts = stmts.filter((s) => s.includes('ADD COLUMN IF NOT EXISTS'))
-    expect(alterStmts.length).toBe(4) // created, deleted, metadata, expires_at
+    expect(alterStmts.length).toBe(1)
+    expect(alterStmts[0]).toContain('ADD COLUMN IF NOT EXISTS "created"')
+    expect(alterStmts[0]).toContain('ADD COLUMN IF NOT EXISTS "deleted"')
+    expect(alterStmts[0]).toContain('ADD COLUMN IF NOT EXISTS "metadata"')
+    expect(alterStmts[0]).toContain('ADD COLUMN IF NOT EXISTS "expires_at"')
 
     // No FK constraint
     expect(stmts.some((s) => s.includes('FOREIGN KEY'))).toBe(false)
@@ -116,6 +124,76 @@ describe('buildCreateTableWithSchema', () => {
   it('produces stable output across repeated calls', () => {
     const first = buildCreateTableWithSchema('mydata', 'customers', SAMPLE_JSON_SCHEMA)
     const second = buildCreateTableWithSchema('mydata', 'customers', SAMPLE_JSON_SCHEMA)
+    expect(second).toEqual(first)
+  })
+})
+
+describe('buildCreateTableDDL', () => {
+  it('returns a single DO block containing all DDL', () => {
+    const ddl = buildCreateTableDDL('mydata', 'repos', SAMPLE_JSON_SCHEMA)
+
+    expect(ddl).toMatch(/^DO \$ddl\$/)
+    expect(ddl).toMatch(/\$ddl\$;$/)
+
+    expect(ddl).toContain('CREATE TABLE "mydata"."repos"')
+    expect(ddl).toContain('"_raw_data" jsonb NOT NULL')
+    expect(ddl).toContain("GENERATED ALWAYS AS ((_raw_data->>'id')::text) STORED")
+    expect(ddl).toContain('"created" bigint GENERATED ALWAYS AS')
+
+    expect(ddl).toContain('ADD COLUMN IF NOT EXISTS "created"')
+    expect(ddl).toContain('ADD COLUMN IF NOT EXISTS "deleted"')
+    expect(ddl).toContain('ADD COLUMN IF NOT EXISTS "metadata"')
+    expect(ddl).toContain('ADD COLUMN IF NOT EXISTS "expires_at"')
+
+    expect(ddl).toContain('DROP TRIGGER IF EXISTS handle_updated_at')
+    expect(ddl).toContain('CREATE TRIGGER handle_updated_at')
+  })
+
+  it('wraps every DDL statement in exception handlers', () => {
+    const ddl = buildCreateTableDDL('stripe', 'customers', SAMPLE_JSON_SCHEMA, {
+      system_columns: [{ name: '_account_id', type: 'text', index: true }],
+    })
+
+    expect(ddl).toContain('EXCEPTION WHEN duplicate_table')
+    expect(ddl).toContain('CREATE INDEX')
+    expect(ddl).toContain('"_account_id"')
+
+    // Count exception handlers: CREATE TABLE, ALTER, CREATE INDEX, CREATE TRIGGER = 4
+    const exceptionCount = (ddl.match(/EXCEPTION WHEN/g) || []).length
+    expect(exceptionCount).toBe(4)
+  })
+
+  it('contains every SQL statement from buildCreateTableWithSchema', () => {
+    const collapse = (s: string) => s.replace(/\s+/g, ' ').trim()
+
+    const schemas = [SAMPLE_JSON_SCHEMA, EXPANDABLE_REF_SCHEMA]
+    const optionSets = [
+      {},
+      { system_columns: [{ name: '_account_id', type: 'text' as const, index: true }] },
+      {
+        system_columns: [
+          { name: '_account_id', type: 'text' as const, index: true },
+          { name: '_tenant_id', type: 'uuid' as const, index: false },
+        ],
+      },
+    ]
+
+    for (const schema of schemas) {
+      for (const opts of optionSets) {
+        const stmts = buildCreateTableWithSchema('s', 't', schema, opts)
+        const ddlCollapsed = collapse(buildCreateTableDDL('s', 't', schema, opts))
+
+        for (const stmt of stmts) {
+          const stmtCollapsed = collapse(stmt.replace(/;\s*$/, ''))
+          expect(ddlCollapsed).toContain(stmtCollapsed)
+        }
+      }
+    }
+  })
+
+  it('produces stable output across repeated calls', () => {
+    const first = buildCreateTableDDL('mydata', 'customers', SAMPLE_JSON_SCHEMA)
+    const second = buildCreateTableDDL('mydata', 'customers', SAMPLE_JSON_SCHEMA)
     expect(second).toEqual(first)
   })
 })

--- a/packages/destination-postgres/src/schemaProjection.ts
+++ b/packages/destination-postgres/src/schemaProjection.ts
@@ -101,90 +101,9 @@ export type BuildTableOptions = {
 }
 
 /**
- * Build a single SQL string (a DO block) that idempotently creates a table with
- * generated columns from JSON Schema, adds missing columns, indexes, and the
- * updated_at trigger.  Sends exactly **one round trip** to the database.
- */
-export function buildCreateTableDDL(
-  schema: string,
-  tableName: string,
-  jsonSchema: Record<string, unknown>,
-  options: BuildTableOptions = {}
-): string {
-  const quotedSchema = quoteIdent(schema)
-  const quotedTable = quoteIdent(tableName)
-
-  const columns = jsonSchemaToColumns(jsonSchema)
-
-  const generatedColumnDefs = columns.map(
-    (col) => `${quoteIdent(col.name)} ${col.pgType} GENERATED ALWAYS AS (${col.expression}) STORED`
-  )
-
-  const systemColumnDefs = (options.system_columns ?? []).map(
-    (col) => `${quoteIdent(col.name)} ${col.type}`
-  )
-
-  const columnDefs = [
-    '"_raw_data" jsonb NOT NULL',
-    '"_last_synced_at" timestamptz',
-    '"_updated_at" timestamptz NOT NULL DEFAULT now()',
-    ...systemColumnDefs,
-    `"id" text GENERATED ALWAYS AS ((_raw_data->>'id')::text) STORED`,
-    ...generatedColumnDefs,
-    'PRIMARY KEY ("id")',
-  ]
-
-  // Every DDL is wrapped in BEGIN…EXCEPTION to match runSqlAdditive error handling
-  const blocks: string[] = []
-
-  // 1. CREATE TABLE
-  blocks.push(wrapAdditive(
-    `CREATE TABLE ${quotedSchema}.${quotedTable} (\n    ${columnDefs.join(',\n    ')}\n  );`
-  ))
-
-  // 2. Idempotent column additions for pre-existing tables
-  if (generatedColumnDefs.length > 0) {
-    const addClauses = generatedColumnDefs.map(
-      (colDef) => `ADD COLUMN IF NOT EXISTS ${colDef}`
-    )
-    blocks.push(wrapAdditive(
-      `ALTER TABLE ${quotedSchema}.${quotedTable}\n    ${addClauses.join(',\n    ')};`
-    ))
-  }
-
-  // 3. Indexes on system columns
-  for (const col of options.system_columns ?? []) {
-    if (col.index) {
-      const idxName = safeIdentifier(`idx_${tableName}_${col.name}`)
-      blocks.push(wrapAdditive(
-        `CREATE INDEX ${quoteIdent(idxName)} ON ${quotedSchema}.${quotedTable} (${quoteIdent(col.name)});`
-      ))
-    }
-  }
-
-  // 4. Trigger (DROP is already idempotent; CREATE is wrapped for concurrent callers)
-  blocks.push(
-    `DROP TRIGGER IF EXISTS handle_updated_at ON ${quotedSchema}.${quotedTable};`
-  )
-  blocks.push(wrapAdditive(
-    `CREATE TRIGGER handle_updated_at BEFORE UPDATE ON ${quotedSchema}.${quotedTable} FOR EACH ROW EXECUTE FUNCTION ${quotedSchema}.set_updated_at();`
-  ))
-
-  return `DO $ddl$\nBEGIN\n  ${blocks.join('\n  ')}\nEND;\n$ddl$;`
-}
-
-/**
- * Wrap a DDL statement in BEGIN…EXCEPTION so it's skipped when the object already
- * exists.  Mirrors the error codes handled by {@link runSqlAdditive}.
- */
-function wrapAdditive(stmt: string): string {
-  return `BEGIN\n    ${stmt}\n  EXCEPTION WHEN duplicate_table OR duplicate_object OR duplicate_column OR invalid_table_definition THEN NULL;\n  END;`
-}
-
-/**
  * Build DDL statements to create a table with generated columns from JSON Schema.
- * Returns an array of individual SQL statements for callers that need per-statement
- * control; prefer {@link buildCreateTableDDL} for fewer round trips.
+ * Returns an array of individual SQL statements (CREATE TABLE, ALTER TABLE,
+ * indexes, triggers). Prefer {@link buildCreateTableDDL} for fewer round trips.
  */
 export function buildCreateTableWithSchema(
   schema: string,
@@ -220,12 +139,8 @@ export function buildCreateTableWithSchema(
   ]
 
   if (generatedColumnDefs.length > 0) {
-    const addClauses = generatedColumnDefs.map(
-      (colDef) => `ADD COLUMN IF NOT EXISTS ${colDef}`
-    )
-    stmts.push(
-      `ALTER TABLE ${quotedSchema}.${quotedTable}\n  ${addClauses.join(',\n  ')};`
-    )
+    const addClauses = generatedColumnDefs.map((colDef) => `ADD COLUMN IF NOT EXISTS ${colDef}`)
+    stmts.push(`ALTER TABLE ${quotedSchema}.${quotedTable}\n  ${addClauses.join(',\n  ')};`)
   }
 
   for (const col of options.system_columns ?? []) {
@@ -246,9 +161,39 @@ export function buildCreateTableWithSchema(
 }
 
 /**
+ * Wrap a DDL statement in BEGIN…EXCEPTION so it's skipped when the object already
+ * exists.  Mirrors the error codes handled by {@link runSqlAdditive}.
+ */
+function wrapAdditive(stmt: string): string {
+  return `BEGIN\n    ${stmt}\n  EXCEPTION WHEN duplicate_table OR duplicate_object OR duplicate_column OR invalid_table_definition THEN NULL;\n  END;`
+}
+
+/**
+ * Build a single SQL string (a DO block) that idempotently creates a table with
+ * generated columns from JSON Schema, adds missing columns, indexes, and the
+ * updated_at trigger.  Sends exactly **one round trip** to the database.
+ *
+ * Delegates to {@link buildCreateTableWithSchema} for the statement list, then
+ * wraps each mutating statement in BEGIN…EXCEPTION for idempotency.
+ */
+export function buildCreateTableDDL(
+  schema: string,
+  tableName: string,
+  jsonSchema: Record<string, unknown>,
+  options: BuildTableOptions = {}
+): string {
+  const stmts = buildCreateTableWithSchema(schema, tableName, jsonSchema, options)
+  const blocks = stmts.map((stmt) => (/^DROP\s/i.test(stmt) ? stmt : wrapAdditive(stmt)))
+  return `DO $ddl$\nBEGIN\n  ${blocks.join('\n  ')}\nEND;\n$ddl$;`
+}
+
+/**
  * Execute a DDL statement, skipping if the object already exists.
  * Handles: 42P07 (table exists), 42710 (constraint exists),
  * 42P16 (invalid constraint definition), 42701 (column exists).
+ *
+ * @deprecated No longer used internally — {@link buildCreateTableDDL} handles
+ * idempotency inside a PL/pgSQL DO block instead. Kept for external callers.
  */
 export async function runSqlAdditive(client: PgClient, sql: string): Promise<void> {
   try {
@@ -368,6 +313,10 @@ export type ApplySchemaFromCatalogConfig = {
 /**
  * Apply schema from a catalog's json_schema fields to the database.
  * Uses migration markers to avoid redundant DDL.
+ *
+ * Tables are migrated concurrently via `Promise.all`. For true parallelism,
+ * pass a `pg.Pool` (which multiplexes across connections); a single `pg.Client`
+ * will serialize queries on its connection.
  */
 export async function applySchemaFromCatalog(
   client: PgClient,
@@ -415,14 +364,17 @@ export async function applySchemaFromCatalog(
   const schemasToMigrate = streams.filter((s) => s.json_schema)
   config.onLog?.(`Migrating ${schemasToMigrate.length} tables (marker: ${marker.slice(0, 24)}…)`)
   const total = schemasToMigrate.length
+  let completed = 0
   await Promise.all(
-    schemasToMigrate.map(async (stream, i) => {
+    schemasToMigrate.map(async (stream) => {
       const start = Date.now()
-      await client.query(buildCreateTableDDL(dataSchema, stream.name, stream.json_schema!, {
-        system_columns: config.system_columns,
-      }))
+      await client.query(
+        buildCreateTableDDL(dataSchema, stream.name, stream.json_schema!, {
+          system_columns: config.system_columns,
+        })
+      )
       config.onLog?.(
-        `[${i + 1}/${total}] Migrated "${stream.name}" (${Date.now() - start}ms)`
+        `[${++completed}/${total}] Migrated "${stream.name}" (${Date.now() - start}ms)`
       )
     })
   )

--- a/packages/destination-postgres/src/schemaProjection.ts
+++ b/packages/destination-postgres/src/schemaProjection.ts
@@ -89,11 +89,6 @@ export function jsonSchemaToColumns(jsonSchema: Record<string, unknown>): Column
   return columns
 }
 
-/**
- * Build DDL statements to create a table with generated columns from JSON Schema.
- * Returns an array of SQL statements (CREATE TABLE + ALTER TABLE ADD COLUMN for each column
- * + indexes + trigger).
- */
 export type SystemColumn = {
   name: string
   type: string
@@ -105,6 +100,92 @@ export type BuildTableOptions = {
   system_columns?: SystemColumn[]
 }
 
+/**
+ * Build a single SQL string (a DO block) that idempotently creates a table with
+ * generated columns from JSON Schema, adds missing columns, indexes, and the
+ * updated_at trigger.  Sends exactly **one round trip** to the database.
+ */
+export function buildCreateTableDDL(
+  schema: string,
+  tableName: string,
+  jsonSchema: Record<string, unknown>,
+  options: BuildTableOptions = {}
+): string {
+  const quotedSchema = quoteIdent(schema)
+  const quotedTable = quoteIdent(tableName)
+
+  const columns = jsonSchemaToColumns(jsonSchema)
+
+  const generatedColumnDefs = columns.map(
+    (col) => `${quoteIdent(col.name)} ${col.pgType} GENERATED ALWAYS AS (${col.expression}) STORED`
+  )
+
+  const systemColumnDefs = (options.system_columns ?? []).map(
+    (col) => `${quoteIdent(col.name)} ${col.type}`
+  )
+
+  const columnDefs = [
+    '"_raw_data" jsonb NOT NULL',
+    '"_last_synced_at" timestamptz',
+    '"_updated_at" timestamptz NOT NULL DEFAULT now()',
+    ...systemColumnDefs,
+    `"id" text GENERATED ALWAYS AS ((_raw_data->>'id')::text) STORED`,
+    ...generatedColumnDefs,
+    'PRIMARY KEY ("id")',
+  ]
+
+  // Every DDL is wrapped in BEGIN…EXCEPTION to match runSqlAdditive error handling
+  const blocks: string[] = []
+
+  // 1. CREATE TABLE
+  blocks.push(wrapAdditive(
+    `CREATE TABLE ${quotedSchema}.${quotedTable} (\n    ${columnDefs.join(',\n    ')}\n  );`
+  ))
+
+  // 2. Idempotent column additions for pre-existing tables
+  if (generatedColumnDefs.length > 0) {
+    const addClauses = generatedColumnDefs.map(
+      (colDef) => `ADD COLUMN IF NOT EXISTS ${colDef}`
+    )
+    blocks.push(wrapAdditive(
+      `ALTER TABLE ${quotedSchema}.${quotedTable}\n    ${addClauses.join(',\n    ')};`
+    ))
+  }
+
+  // 3. Indexes on system columns
+  for (const col of options.system_columns ?? []) {
+    if (col.index) {
+      const idxName = safeIdentifier(`idx_${tableName}_${col.name}`)
+      blocks.push(wrapAdditive(
+        `CREATE INDEX ${quoteIdent(idxName)} ON ${quotedSchema}.${quotedTable} (${quoteIdent(col.name)});`
+      ))
+    }
+  }
+
+  // 4. Trigger (DROP is already idempotent; CREATE is wrapped for concurrent callers)
+  blocks.push(
+    `DROP TRIGGER IF EXISTS handle_updated_at ON ${quotedSchema}.${quotedTable};`
+  )
+  blocks.push(wrapAdditive(
+    `CREATE TRIGGER handle_updated_at BEFORE UPDATE ON ${quotedSchema}.${quotedTable} FOR EACH ROW EXECUTE FUNCTION ${quotedSchema}.set_updated_at();`
+  ))
+
+  return `DO $ddl$\nBEGIN\n  ${blocks.join('\n  ')}\nEND;\n$ddl$;`
+}
+
+/**
+ * Wrap a DDL statement in BEGIN…EXCEPTION so it's skipped when the object already
+ * exists.  Mirrors the error codes handled by {@link runSqlAdditive}.
+ */
+function wrapAdditive(stmt: string): string {
+  return `BEGIN\n    ${stmt}\n  EXCEPTION WHEN duplicate_table OR duplicate_object OR duplicate_column OR invalid_table_definition THEN NULL;\n  END;`
+}
+
+/**
+ * Build DDL statements to create a table with generated columns from JSON Schema.
+ * Returns an array of individual SQL statements for callers that need per-statement
+ * control; prefer {@link buildCreateTableDDL} for fewer round trips.
+ */
 export function buildCreateTableWithSchema(
   schema: string,
   tableName: string,
@@ -118,10 +199,6 @@ export function buildCreateTableWithSchema(
 
   const generatedColumnDefs = columns.map(
     (col) => `${quoteIdent(col.name)} ${col.pgType} GENERATED ALWAYS AS (${col.expression}) STORED`
-  )
-
-  const generatedColumnAlters = generatedColumnDefs.map(
-    (colDef) => `ALTER TABLE ${quotedSchema}.${quotedTable} ADD COLUMN IF NOT EXISTS ${colDef};`
   )
 
   const systemColumnDefs = (options.system_columns ?? []).map(
@@ -140,8 +217,16 @@ export function buildCreateTableWithSchema(
 
   const stmts: string[] = [
     `CREATE TABLE ${quotedSchema}.${quotedTable} (\n  ${columnDefs.join(',\n  ')}\n);`,
-    ...generatedColumnAlters,
   ]
+
+  if (generatedColumnDefs.length > 0) {
+    const addClauses = generatedColumnDefs.map(
+      (colDef) => `ADD COLUMN IF NOT EXISTS ${colDef}`
+    )
+    stmts.push(
+      `ALTER TABLE ${quotedSchema}.${quotedTable}\n  ${addClauses.join(',\n  ')};`
+    )
+  }
 
   for (const col of options.system_columns ?? []) {
     if (col.index) {
@@ -329,18 +414,18 @@ export async function applySchemaFromCatalog(
 
   const schemasToMigrate = streams.filter((s) => s.json_schema)
   config.onLog?.(`Migrating ${schemasToMigrate.length} tables (marker: ${marker.slice(0, 24)}…)`)
-  for (const [i, stream] of schemasToMigrate.entries()) {
-    const start = Date.now()
-    const stmts = buildCreateTableWithSchema(dataSchema, stream.name, stream.json_schema!, {
-      system_columns: config.system_columns,
+  const total = schemasToMigrate.length
+  await Promise.all(
+    schemasToMigrate.map(async (stream, i) => {
+      const start = Date.now()
+      await client.query(buildCreateTableDDL(dataSchema, stream.name, stream.json_schema!, {
+        system_columns: config.system_columns,
+      }))
+      config.onLog?.(
+        `[${i + 1}/${total}] Migrated "${stream.name}" (${Date.now() - start}ms)`
+      )
     })
-    for (const stmt of stmts) {
-      await runSqlAdditive(client, stmt)
-    }
-    config.onLog?.(
-      `[${i + 1}/${schemasToMigrate.length}] Migrated "${stream.name}" (${Date.now() - start}ms)`
-    )
-  }
+  )
 
   await insertMigrationMarker(client, syncSchema, markerColumn, marker, fingerprint)
 }


### PR DESCRIPTION
### Summary

- Batch ALTER TABLE statements
- Single DO block per table
- Parallelize across tables: run table creation concurrently via Promise.all