### PR TITLE
Wrap pipeline_sync logging and restore backfill concurrency

### DIFF
--- a/apps/engine/src/__generated__/openapi.d.ts
+++ b/apps/engine/src/__generated__/openapi.d.ts
@@ -571,7 +571,7 @@ export interface components {
             backfill_limit?: number;
             /** @description Max Stripe API requests per second (default: 25) */
             rate_limit?: number;
-            /** @description Number of time-range segments for parallel backfill (default: 200) */
+            /** @description Number of time-range segments for parallel backfill (default: 10) */
             backfill_concurrency?: number;
         };
         DestinationConfig: {

--- a/apps/engine/src/__generated__/openapi.json
+++ b/apps/engine/src/__generated__/openapi.json
@@ -1599,7 +1599,7 @@
             "type": "integer",
             "exclusiveMinimum": 0,
             "maximum": 9007199254740991,
-            "description": "Number of time-range segments for parallel backfill (default: 200)"
+            "description": "Number of time-range segments for parallel backfill (default: 10)"
           }
         },
         "required": [

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -541,11 +541,12 @@ export async function createApp(resolver: ConnectorResolver) {
     const pipeline = c.req.valid('header')['x-pipeline']
     const state = c.req.valid('header')['x-source-state']
     const { state_limit, time_limit } = c.req.valid('query')
+    const context = { path: '/pipeline_sync', ...syncRequestContext(pipeline) }
     const input = hasBody(c)
       ? verboseInput('pipeline_sync', parseNdjsonStream(c.req.raw.body!))
       : undefined
     const output = engine.pipeline_sync(pipeline, { state, state_limit, time_limit }, input)
-    return ndjsonResponse(output)
+    return ndjsonResponse(logApiStream('Engine API /pipeline_sync', output, context))
   })
 
   app.openapi(

--- a/apps/service/src/__generated__/openapi.d.ts
+++ b/apps/service/src/__generated__/openapi.d.ts
@@ -120,7 +120,7 @@ export interface components {
             backfill_limit?: number;
             /** @description Max Stripe API requests per second (default: 25) */
             rate_limit?: number;
-            /** @description Number of time-range segments for parallel backfill (default: 200) */
+            /** @description Number of time-range segments for parallel backfill (default: 10) */
             backfill_concurrency?: number;
         };
         DestinationConfig: {

--- a/apps/service/src/__generated__/openapi.json
+++ b/apps/service/src/__generated__/openapi.json
@@ -887,7 +887,7 @@
             "type": "integer",
             "exclusiveMinimum": 0,
             "maximum": 9007199254740991,
-            "description": "Number of time-range segments for parallel backfill (default: 200)"
+            "description": "Number of time-range segments for parallel backfill (default: 10)"
           }
         },
         "required": [

--- a/packages/source-stripe/src/index.test.ts
+++ b/packages/source-stripe/src/index.test.ts
@@ -623,21 +623,19 @@ describe('StripeSource', () => {
       }
 
       const mockClient = {
-        getAccount: vi
-          .fn()
-          .mockRejectedValueOnce(
-            new StripeRequestError(
-              401,
-              {
-                error: {
-                  type: 'invalid_request_error',
-                  message: 'Invalid API Key provided: sk_test_bad',
-                },
+        getAccount: vi.fn().mockRejectedValueOnce(
+          new StripeRequestError(
+            401,
+            {
+              error: {
+                type: 'invalid_request_error',
+                message: 'Invalid API Key provided: sk_test_bad',
               },
-              'GET',
-              '/v1/account'
-            )
-          ),
+            },
+            'GET',
+            '/v1/account'
+          )
+        ),
       } as unknown as StripeClient
 
       const messages = await collect(
@@ -675,21 +673,19 @@ describe('StripeSource', () => {
     })
 
     it('emits TraceMessage error for Invalid API Key on sequential streams', async () => {
-      const listFn = vi
-        .fn()
-        .mockRejectedValueOnce(
-          new StripeRequestError(
-            401,
-            {
-              error: {
-                type: 'invalid_request_error',
-                message: 'Invalid API Key provided: sk_test_bad',
-              },
+      const listFn = vi.fn().mockRejectedValueOnce(
+        new StripeRequestError(
+          401,
+          {
+            error: {
+              type: 'invalid_request_error',
+              message: 'Invalid API Key provided: sk_test_bad',
             },
-            'GET',
-            '/v1/tax_ids'
-          )
+          },
+          'GET',
+          '/v1/tax_ids'
         )
+      )
 
       const registry: Record<string, ResourceConfig> = {
         tax_ids: makeConfig({

--- a/packages/source-stripe/src/spec.ts
+++ b/packages/source-stripe/src/spec.ts
@@ -55,7 +55,7 @@ export const configSchema = z.object({
     .int()
     .positive()
     .optional()
-    .describe('Number of time-range segments for parallel backfill (default: 200)'),
+    .describe('Number of time-range segments for parallel backfill (default: 10)'),
 })
 
 export type Config = z.infer<typeof configSchema>

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -32,7 +32,7 @@ const SKIPPABLE_ERROR_PATTERNS = [
   'not set up to use',
 ]
 
-const DEFAULT_BACKFILL_CONCURRENCY = 1 // Used to be 200, but for now default to just 1 to make it easier to reason about. Chane back when ready.
+const DEFAULT_BACKFILL_CONCURRENCY = 10
 
 // MARK: - Compact state (generative — O(concurrency) not O(total segments))
 

--- a/scripts/drop-all-tables.sh
+++ b/scripts/drop-all-tables.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Drop all tables and functions in the public schema of a given Postgres database.
+# Idempotent — safe to run multiple times.
+# Usage: ./scripts/drop-all-tables.sh <database_url>
+
+set -euo pipefail
+
+DB_URL="${1:?Usage: $0 <database_url>}"
+
+psql "$DB_URL" -t -A -c "
+  SELECT 'DROP TABLE IF EXISTS \"' || tablename || '\" CASCADE;'
+  FROM pg_tables WHERE schemaname = 'public';
+
+  SELECT 'DROP FUNCTION IF EXISTS \"' || routine_name || '\" CASCADE;'
+  FROM information_schema.routines WHERE routine_schema = 'public';
+" | psql "$DB_URL"
+
+echo "Done. Public schema is clean."


### PR DESCRIPTION
## Summary

- wrap `/pipeline_sync` in `logApiStream` so it has the same request/stream logging shape as the other NDJSON pipeline routes
- restore the default Stripe backfill concurrency from `1` to `10`
- align the source config schema and generated engine/service OpenAPI descriptions with that default
- include the current `packages/source-stripe/src/index.test.ts` cleanup and add `scripts/drop-all-tables.sh` for resetting a Postgres public schema

## How to test (optional)

- `pnpm --filter @stripe/sync-source-stripe test -- --runInBand`
- `pnpm --filter @stripe/sync-engine test`

## Related

- Closes #
