### PR TITLE
Better debugging: trace-level logging, per-stream record counts, and fixes

### DIFF
--- a/apps/engine/package.json
+++ b/apps/engine/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "build": "tsc",
     "x:watch": "sh -c 'if command -v bun > /dev/null 2>&1; then bun --watch \"$@\"; else tsx --watch --conditions bun \"$@\"; fi' --",
-    "dev": "LOG_LEVEL=debug LOG_PRETTY=true DANGEROUSLY_VERBOSE_LOGGING=true pnpm x:watch src/api/index.ts",
+    "dev": "LOG_LEVEL=${LOG_LEVEL:-trace} LOG_PRETTY=${LOG_PRETTY:-true} DANGEROUSLY_VERBOSE_LOGGING=true pnpm x:watch src/api/index.ts",
     "test": "vitest run",
     "generate:types": "openapi-typescript src/__generated__/openapi.json -o src/__generated__/openapi.d.ts"
   },

--- a/apps/engine/src/__generated__/openapi.d.ts
+++ b/apps/engine/src/__generated__/openapi.d.ts
@@ -502,6 +502,10 @@ export interface components {
                  * @enum {string}
                  */
                 reason: "complete" | "state_limit" | "time_limit" | "error";
+                /** @description Per-stream record counts: { stream_name: count }. */
+                record_count?: {
+                    [key: string]: number;
+                };
             };
         };
         SourceStripeInput: {

--- a/apps/engine/src/__generated__/openapi.json
+++ b/apps/engine/src/__generated__/openapi.json
@@ -1325,6 +1325,16 @@
                   "error"
                 ],
                 "description": "Why the stream ended."
+              },
+              "record_count": {
+                "description": "Per-stream record counts: { stream_name: count }.",
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "number"
+                }
               }
             },
             "required": [

--- a/apps/engine/src/api/index.ts
+++ b/apps/engine/src/api/index.ts
@@ -28,7 +28,7 @@ async function main() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (typeof (globalThis as any).Bun !== 'undefined') {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(globalThis as any).Bun.serve({ fetch: app.fetch, port })
+    ;(globalThis as any).Bun.serve({ fetch: app.fetch, port, idleTimeout: 60 })
     logger.warn(
       { port, server: 'Bun.serve' },
       `Sync Engine API listening on http://localhost:${port}`

--- a/apps/engine/src/lib/pipeline.test.ts
+++ b/apps/engine/src/lib/pipeline.test.ts
@@ -568,7 +568,10 @@ describe('takeLimits()', () => {
       type: 'source_state',
       source_state: { data: { cursor: '1' } },
     })
-    expect(result[2]).toMatchObject({ type: 'eof', eof: { reason: 'state_limit' } })
+    expect(result[2]).toMatchObject({
+      type: 'eof',
+      eof: { reason: 'state_limit', record_count: { customers: 1 } },
+    })
   })
 
   it('emits eof with complete reason when source exhausts', async () => {
@@ -588,7 +591,10 @@ describe('takeLimits()', () => {
     ]
     const result = await drain(takeLimits<Message>({ state_limit: 5 })(toAsync(msgs)))
     expect(result).toHaveLength(3)
-    expect(result[2]).toMatchObject({ type: 'eof', eof: { reason: 'complete' } })
+    expect(result[2]).toMatchObject({
+      type: 'eof',
+      eof: { reason: 'complete', record_count: { customers: 1 } },
+    })
   })
 
   it('emits eof complete with no limits set', async () => {
@@ -648,7 +654,10 @@ describe('takeLimits()', () => {
       type: 'source_state',
       source_state: { state_type: 'stream', stream: 'products' },
     })
-    expect(result[4]).toMatchObject({ type: 'eof', eof: { reason: 'state_limit' } })
+    expect(result[4]).toMatchObject({
+      type: 'eof',
+      eof: { reason: 'state_limit', record_count: { customers: 1, products: 1 } },
+    })
   })
 
   it('stops on time limit at any message boundary', async () => {
@@ -709,6 +718,8 @@ describe('takeLimits()', () => {
     const result = await drain(takeLimits<Message>()(toAsync([])))
     expect(result).toHaveLength(1)
     expect(result[0]).toMatchObject({ type: 'eof', eof: { reason: 'complete' } })
+    // No records means no record_count field
+    expect((result[0] as any).eof.record_count).toBeUndefined()
   })
 })
 

--- a/apps/engine/src/lib/pipeline.ts
+++ b/apps/engine/src/lib/pipeline.ts
@@ -133,18 +133,25 @@ export function takeLimits<T extends { type: string }>(
   return async function* (messages) {
     const deadline = opts.time_limit ? Date.now() + opts.time_limit * 1000 : undefined
     let stateCount = 0
+    const recordCount = new Map<string, number>()
     for await (const msg of messages) {
+      if (msg.type === 'record' && 'record' in msg) {
+        const stream = (msg as any).record.stream as string
+        recordCount.set(stream, (recordCount.get(stream) ?? 0) + 1)
+      }
       yield msg
+      const record_count = recordCount.size > 0 ? Object.fromEntries(recordCount) : undefined
       if (deadline && Date.now() >= deadline) {
-        yield { type: 'eof', eof: { reason: 'time_limit' } } as unknown as T
+        yield { type: 'eof', eof: { reason: 'time_limit', record_count } } as unknown as T
         return
       }
       if (msg.type === 'source_state' && opts.state_limit && ++stateCount >= opts.state_limit) {
-        yield { type: 'eof', eof: { reason: 'state_limit' } } as unknown as T
+        yield { type: 'eof', eof: { reason: 'state_limit', record_count } } as unknown as T
         return
       }
     }
-    yield { type: 'eof', eof: { reason: 'complete' } } as unknown as T
+    const record_count = recordCount.size > 0 ? Object.fromEntries(recordCount) : undefined
+    yield { type: 'eof', eof: { reason: 'complete', record_count } } as unknown as T
   }
 }
 

--- a/apps/service/src/temporal/activities/_shared.ts
+++ b/apps/service/src/temporal/activities/_shared.ts
@@ -1,5 +1,6 @@
 import { heartbeat } from '@temporalio/activity'
 import type { Message, Engine, SourceState, SourceStateMessage } from '@stripe/sync-engine'
+import type { EofPayload } from '@stripe/sync-protocol'
 import { createRemoteEngine } from '@stripe/sync-engine'
 import { Kafka } from 'kafkajs'
 import type { Producer } from 'kafkajs'
@@ -147,20 +148,20 @@ export async function drainMessages(
   records: Message[]
   sourceConfig?: Record<string, unknown>
   destConfig?: Record<string, unknown>
-  eof?: { reason: string }
+  eof?: EofPayload
 }> {
   const errors: RunResult['errors'] = []
   let state: SourceState = initialState ?? { streams: {}, global: {} }
   const records: Message[] = []
   let sourceConfig: Record<string, unknown> | undefined
   let destConfig: Record<string, unknown> | undefined
-  let eof: { reason: string } | undefined
+  let eof: EofPayload | undefined
   let count = 0
 
   for await (const message of stream) {
     count++
     if (message.type === 'eof') {
-      eof = { reason: message.eof.reason }
+      eof = { reason: message.eof.reason, record_count: message.eof.record_count }
     } else if (message.type === 'control') {
       if (message.control.control_type === 'source_config') {
         sourceConfig = message.control.source_config!

--- a/apps/service/src/temporal/activities/pipeline-sync.ts
+++ b/apps/service/src/temporal/activities/pipeline-sync.ts
@@ -1,5 +1,6 @@
 import { ApplicationFailure } from '@temporalio/activity'
 import type { SourceInputMessage, SourceReadOptions } from '@stripe/sync-engine'
+import type { EofPayload } from '@stripe/sync-protocol'
 import type { ActivitiesContext } from './_shared.js'
 import { asIterable, drainMessages, type RunResult } from './_shared.js'
 import { classifySyncErrors, summarizeSyncErrors } from '../sync-errors.js'
@@ -8,7 +9,7 @@ export function createPipelineSyncActivity(context: ActivitiesContext) {
   return async function pipelineSync(
     pipelineId: string,
     opts?: SourceReadOptions & { input?: SourceInputMessage[] }
-  ): Promise<RunResult & { eof?: { reason: string } }> {
+  ): Promise<RunResult & { eof?: EofPayload }> {
     const pipeline = await context.pipelineStore.get(pipelineId)
     const { id: _, ...config } = pipeline
     const { input: inputArr, ...readOpts } = opts ?? {}

--- a/apps/service/src/temporal/activities/read-into-queue.ts
+++ b/apps/service/src/temporal/activities/read-into-queue.ts
@@ -1,5 +1,6 @@
 import { heartbeat } from '@temporalio/activity'
 import type { Message, SourceInputMessage, SourceReadOptions } from '@stripe/sync-engine'
+import type { EofPayload } from '@stripe/sync-protocol'
 
 import type { ActivitiesContext } from './_shared.js'
 import { mergeStateMessage, asIterable, collectError, type RunResult } from './_shared.js'
@@ -11,7 +12,7 @@ export function createReadIntoQueueActivity(context: ActivitiesContext) {
   ): Promise<{
     count: number
     state: import('@stripe/sync-engine').SourceState
-    eof?: { reason: string }
+    eof?: EofPayload
   }> {
     if (!context.kafkaBroker) throw new Error('kafkaBroker is required for Google Sheets workflow')
 
@@ -26,13 +27,13 @@ export function createReadIntoQueueActivity(context: ActivitiesContext) {
       global: {},
     }
     const errors: RunResult['errors'] = []
-    let eof: { reason: string } | undefined
+    let eof: EofPayload | undefined
     let seen = 0
 
     for await (const raw of context.engine.pipeline_read(config, readOpts, input)) {
       seen++
       if (raw.type === 'eof') {
-        eof = { reason: raw.eof.reason }
+        eof = { reason: raw.eof.reason, record_count: raw.eof.record_count }
       } else {
         const error = collectError(raw)
         if (error) {

--- a/packages/protocol/src/protocol.ts
+++ b/packages/protocol/src/protocol.ts
@@ -200,6 +200,10 @@ export const EofPayload = z
     reason: z
       .enum(['complete', 'state_limit', 'time_limit', 'error'])
       .describe('Why the stream ended.'),
+    record_count: z
+      .record(z.string(), z.number())
+      .optional()
+      .describe('Per-stream record counts: { stream_name: count }.'),
   })
   .describe('Terminal payload — tells the client why the stream ended.')
 export type EofPayload = z.infer<typeof EofPayload>

--- a/packages/source-stripe/package.json
+++ b/packages/source-stripe/package.json
@@ -30,6 +30,7 @@
     "@stripe/sync-openapi": "workspace:*",
     "@stripe/sync-protocol": "workspace:*",
     "https-proxy-agent": "^7.0.6",
+    "pino": "^10",
     "undici": "^7.16.0",
     "ws": "^8.18.0",
     "zod": "^4.3.6"

--- a/packages/source-stripe/src/transport.ts
+++ b/packages/source-stripe/src/transport.ts
@@ -233,7 +233,9 @@ export function fetchWithProxy(
 
   return fetch(input, fetchInit).then((res) => {
     const resClone = res.clone()
-    logger.trace(`[http ${reqId}] ← ${method} ${String(input)} ${res.status} (${Date.now() - start}ms)`)
+    logger.trace(
+      `[http ${reqId}] ← ${method} ${String(input)} ${res.status} (${Date.now() - start}ms)`
+    )
     resClone
       .text()
       .then((body) => {

--- a/packages/source-stripe/src/transport.ts
+++ b/packages/source-stripe/src/transport.ts
@@ -1,5 +1,8 @@
 import { ProxyAgent } from 'undici'
 import { HttpsProxyAgent } from 'https-proxy-agent'
+import pino from 'pino'
+
+const logger = pino({ level: process.env.LOG_LEVEL ?? 'info' })
 
 export type TransportEnv = Record<string, string | undefined>
 type ProxyTarget = URL | string
@@ -210,7 +213,7 @@ export function fetchWithProxy(
     ? { ...init, dispatcher: getProxyAgent(proxyUrl) }
     : init
 
-  if (!DANGEROUSLY_VERBOSE_LOGGING) {
+  if (!DANGEROUSLY_VERBOSE_LOGGING || !logger.isLevelEnabled('trace')) {
     return fetch(input, fetchInit)
   }
 
@@ -223,18 +226,18 @@ export function fetchWithProxy(
       loggedHeaders[k] = k.toLowerCase() === 'authorization' ? '[redacted]' : v
     })
   }
-  console.error(`[http ${reqId}] → ${method} ${String(input)}`, {
-    headers: loggedHeaders,
-    ...(init.body != null ? { body: String(init.body) } : {}),
-  })
+  logger.trace(
+    { headers: loggedHeaders, ...(init.body != null ? { body: String(init.body) } : {}) },
+    `[http ${reqId}] → ${method} ${String(input)}`
+  )
 
   return fetch(input, fetchInit).then((res) => {
     const resClone = res.clone()
-    console.error(`[http ${reqId}] ← ${method} ${String(input)} ${res.status} (${Date.now() - start}ms)`)
+    logger.trace(`[http ${reqId}] ← ${method} ${String(input)} ${res.status} (${Date.now() - start}ms)`)
     resClone
       .text()
       .then((body) => {
-        console.error(`[http ${reqId}] ← body: ${body.slice(0, 4096)}`)
+        logger.trace(`[http ${reqId}] ← body: ${body.slice(0, 4096)}`)
       })
       .catch(() => {})
     return res

--- a/packages/util-postgres/package.json
+++ b/packages/util-postgres/package.json
@@ -15,7 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "pg": "^8.16.3"
+    "pg": "^8.16.3",
+    "pino": "^10"
   },
   "devDependencies": {
     "@types/pg": "^8.15.5",

--- a/packages/util-postgres/src/queryLogging.ts
+++ b/packages/util-postgres/src/queryLogging.ts
@@ -1,5 +1,7 @@
 import type pg from 'pg'
+import pino from 'pino'
 
+const logger = pino({ level: process.env.LOG_LEVEL ?? 'info' })
 const verbose = !!process.env.DANGEROUSLY_VERBOSE_LOGGING
 
 /**
@@ -8,7 +10,7 @@ const verbose = !!process.env.DANGEROUSLY_VERBOSE_LOGGING
  * Format: [pg] <ms>ms | rows=<n> | <sql (truncated)>
  */
 export function withQueryLogging<T extends pg.Pool>(pool: T): T {
-  if (!verbose) return pool
+  if (!verbose || !logger.isLevelEnabled('trace')) return pool
 
   const origQuery = pool.query.bind(pool) as typeof pool.query
 
@@ -27,11 +29,11 @@ export function withQueryLogging<T extends pg.Pool>(pool: T): T {
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await (origQuery as any)(...args)
-      console.error(`[pg] ${Date.now() - start}ms | rows=${result?.rowCount ?? 0} | ${label}`)
+      logger.trace(`[pg] ${Date.now() - start}ms | rows=${result?.rowCount ?? 0} | ${label}`)
       return result
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      console.error(`[pg] ${Date.now() - start}ms | ERROR ${msg} | ${label}`)
+      logger.trace(`[pg] ${Date.now() - start}ms | ERROR ${msg} | ${label}`)
       throw err
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -570,6 +570,9 @@ importers:
       https-proxy-agent:
         specifier: ^7.0.6
         version: 7.0.6(supports-color@10.2.2)
+      pino:
+        specifier: ^10
+        version: 10.1.0
       undici:
         specifier: ^7.16.0
         version: 7.24.6
@@ -661,6 +664,9 @@ importers:
       pg:
         specifier: ^8.16.3
         version: 8.16.3
+      pino:
+        specifier: ^10
+        version: 10.1.0
     devDependencies:
       '@types/pg':
         specifier: ^8.15.5
@@ -7320,6 +7326,7 @@ snapshots:
       '@stripe/sync-openapi': file:packages/openapi
       '@stripe/sync-protocol': file:packages/protocol
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      pino: 10.1.0
       undici: 7.24.6
       ws: 8.18.3
       zod: 4.3.6
@@ -7343,6 +7350,7 @@ snapshots:
   '@stripe/sync-util-postgres@file:packages/util-postgres':
     dependencies:
       pg: 8.16.3
+      pino: 10.1.0
     transitivePeerDependencies:
       - pg-native
 

--- a/scripts/drop-all-tables.sh
+++ b/scripts/drop-all-tables.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Drop all tables and functions in the public schema of a given Postgres database.
+# Preserves the schema itself, its permissions, and any installed extensions.
 # Idempotent — safe to run multiple times.
 # Usage: ./scripts/drop-all-tables.sh <database_url>
 
@@ -7,12 +8,29 @@ set -euo pipefail
 
 DB_URL="${1:?Usage: $0 <database_url>}"
 
-psql "$DB_URL" -t -A -c "
-  SELECT 'DROP TABLE IF EXISTS \"' || tablename || '\" CASCADE;'
+SQL=$(psql "$DB_URL" -t -A -c "
+  SELECT string_agg('DROP TABLE IF EXISTS public.\"' || tablename || '\" CASCADE', ';')
   FROM pg_tables WHERE schemaname = 'public';
+")
 
-  SELECT 'DROP FUNCTION IF EXISTS \"' || routine_name || '\" CASCADE;'
-  FROM information_schema.routines WHERE routine_schema = 'public';
-" | psql "$DB_URL"
+if [ -n "$SQL" ] && [ "$SQL" != "" ]; then
+  psql "$DB_URL" -c "$SQL;"
+  echo "Dropped all tables in public schema."
+else
+  echo "No tables to drop."
+fi
+
+# Drop functions
+FSQL=$(psql "$DB_URL" -t -A -c "
+  SELECT string_agg('DROP FUNCTION IF EXISTS public.\"' || p.proname || '\"(' || pg_get_function_identity_arguments(p.oid) || ') CASCADE', ';')
+  FROM pg_proc p
+  JOIN pg_namespace n ON p.pronamespace = n.oid
+  WHERE n.nspname = 'public';
+")
+
+if [ -n "$FSQL" ] && [ "$FSQL" != "" ]; then
+  psql "$DB_URL" -c "$FSQL;"
+  echo "Dropped all functions in public schema."
+fi
 
 echo "Done. Public schema is clean."


### PR DESCRIPTION
## Summary
- Move Postgres query and Stripe HTTP logging to trace level (reduces noise at debug level)
- Add per-stream `record_count` to EOF messages for observability
- Fix debug idle timeout and improve the drop-all-tables script

## Commits
- `88ba4196` Move Postgres query and Stripe HTTP logging to trace level
- `c90d0d67` Fix debug idle timeout and drop table script
- `c3ea8f35` Add per-stream record_count to EOF message

## Test plan
- [x] Unit tests updated for record_count in EOF
- [ ] Manual verification of trace-level logging output
- [ ] Verify drop-all-tables script works against a test database

🤖 Generated with [Claude Code](https://claude.com/claude-code)