### PR TITLE
Demo: node --import tsx, getting started guide, fix docs OpenAPI

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,121 @@
+# Demo Scripts
+
+Sync Stripe data to Postgres (or Google Sheets) from source in under 5 minutes.
+
+## Setup
+
+```sh
+git clone git@github.com:stripe/sync-engine.git
+cd sync-engine
+
+# nvm (Node version manager) — skip if you already have it
+# see https://github.com/nvm-sh/nvm?tab=readme-ov-file#installing-and-updating
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+
+# Node 24+
+nvm install 24
+nvm use 24
+
+# pnpm (auto-provided via corepack)
+corepack enable
+pnpm install
+```
+
+## Environment variables
+
+Create a `.env` file (or export directly):
+
+```sh
+# Required for most demos
+STRIPE_API_KEY=sk_test_...        # Stripe Dashboard → Developers → API keys (test mode)
+DATABASE_URL=postgresql://...      # Any Postgres connection string
+
+# Google Sheets demos only
+GOOGLE_CLIENT_ID=...
+GOOGLE_CLIENT_SECRET=...
+GOOGLE_REFRESH_TOKEN=...
+GOOGLE_SPREADSHEET_ID=...         # optional — creates a new spreadsheet if omitted
+```
+
+## Get a Postgres database
+
+Any of these work:
+
+- **Docker:** `docker run -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:17`
+  → `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres`
+- **Supabase / Neon / etc.** — any hosted Postgres
+- **Stripe Projects:** [projects.dev](https://projects.dev)
+
+## Step 1: Read from Stripe
+
+The source connector reads from the Stripe API and outputs NDJSON to stdout:
+
+```sh
+export STRIPE_API_KEY=sk_test_...
+
+./demo/read-from-stripe.sh
+```
+
+You'll see a stream of JSON records — one per line — for each Stripe object.
+
+## Step 2: Write to Postgres
+
+The destination connector reads NDJSON from stdin and writes to Postgres:
+
+```sh
+export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
+
+./demo/write-to-postgres.sh
+```
+
+Without piped input, this uses built-in sample data to create a `demo` table.
+
+## Step 3: Pipe them together
+
+Source and destination are independent processes that communicate via NDJSON.
+Pipe one into the other:
+
+```sh
+./demo/read-from-stripe.sh | ./demo/write-to-postgres.sh
+```
+
+This reads products from Stripe and writes them directly into Postgres.
+
+## Step 4: Use the sync engine
+
+The above pipes work, but the engine sits between source and destination to handle state management, validation, and resumability.
+
+```sh
+export STRIPE_API_KEY=sk_test_...
+export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
+
+./demo/stripe-to-postgres.sh
+```
+
+This syncs `products`, `prices`, and `customers` into Postgres with full schema management.
+
+## All demos
+
+| Script | What it does | Required env vars |
+|--------|-------------|-------------------|
+| `read-from-stripe.sh` | Read from Stripe, output NDJSON to stdout | `STRIPE_API_KEY` |
+| `write-to-postgres.sh` | Write NDJSON (stdin or sample data) to Postgres | `DATABASE_URL` |
+| `write-to-sheets.sh` | Write NDJSON (stdin or sample data) to Google Sheets | `GOOGLE_*` |
+| `stripe-to-postgres.sh` | Stripe → Postgres via the engine | `STRIPE_API_KEY`, `DATABASE_URL` |
+| `stripe-to-google-sheets.sh` | Stripe → Google Sheets via the engine | `STRIPE_API_KEY`, `GOOGLE_*` |
+
+### TypeScript API
+
+The `.ts` files do the same thing using the engine as a library / during development.
+
+```sh
+node --import tsx demo/stripe-to-postgres.ts
+node --import tsx demo/stripe-to-google-sheets.ts
+```
+
+## Utilities
+
+| Script | What it does |
+|--------|-------------|
+| `reset-postgres.sh` | Drop all tables and non-system schemas |
+| `webhooksite.sh` | Set up webhook forwarding for live Stripe events |

--- a/demo/read-from-stripe.sh
+++ b/demo/read-from-stripe.sh
@@ -6,10 +6,10 @@
 #   ./demo/read-from-stripe.sh | ./demo/write-to-sheets.sh
 #
 # Env: STRIPE_API_KEY
-# Override TypeScript runner: TS_RUNNER="bun" or TS_RUNNER="node --import tsx"
+# Override TypeScript runner: TS_RUNNER="bun" or TS_RUNNER="npx tsx"
 set -euo pipefail
 cd "$(dirname "$0")/.."
-RUN="${TS_RUNNER:-$(dirname "$0")/../scripts/ts-run}"
+RUN="${TS_RUNNER:-node --import tsx}"
 
 ACCT=$(curl -su "$STRIPE_API_KEY:" https://api.stripe.com/v1/account 2>/dev/null \
   | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).id))")

--- a/demo/read-from-stripe.sh
+++ b/demo/read-from-stripe.sh
@@ -2,8 +2,8 @@
 # Read from Stripe via the connector CLI — outputs NDJSON to stdout.
 #
 # Usage:
-#   ./scripts/read-from-stripe.sh
-#   ./scripts/read-from-stripe.sh | ./scripts/write-to-sheets.sh
+#   ./demo/read-from-stripe.sh
+#   ./demo/read-from-stripe.sh | ./demo/write-to-sheets.sh
 #
 # Env: STRIPE_API_KEY
 # Override TypeScript runner: TS_RUNNER="bun" or TS_RUNNER="node --import tsx"

--- a/demo/stripe-to-google-sheets.sh
+++ b/demo/stripe-to-google-sheets.sh
@@ -9,7 +9,7 @@
 # Override TypeScript runner: TS_RUNNER="bun" or TS_RUNNER="npx tsx"
 set -euo pipefail
 cd "$(dirname "$0")/.."
-RUN="${TS_RUNNER:-bun}"
+RUN="${TS_RUNNER:-node --import tsx}"
 
 echo "=== Stripe → Google Sheets ===" >&2
 [ -n "${GOOGLE_SPREADSHEET_ID:-}" ] && echo "Sheet: https://docs.google.com/spreadsheets/d/$GOOGLE_SPREADSHEET_ID" >&2

--- a/demo/stripe-to-postgres.sh
+++ b/demo/stripe-to-postgres.sh
@@ -9,7 +9,7 @@
 # Override TypeScript runner: TS_RUNNER="bun" or TS_RUNNER="npx tsx"
 set -euo pipefail
 cd "$(dirname "$0")/.."
-RUN="${TS_RUNNER:-bun}"
+RUN="${TS_RUNNER:-node --import tsx}"
 POSTGRES_URL="${DATABASE_URL:-${POSTGRES_URL:?Set DATABASE_URL or POSTGRES_URL}}"
 
 if [[ "${1:-}" == "verbose" ]]; then
@@ -19,10 +19,6 @@ fi
 
 echo "=== Stripe → Postgres ===" >&2
 echo "Postgres: $POSTGRES_URL" >&2
-
-# npx @stripe/sync-engine --stripe-api-key $API_KEY --postgres-url $PG_URL
-# bun 
-
 
 
 # ── Option A: Simple shorthand (new sync command) ────────────────────────────

--- a/demo/stripe-to-postgres.sh
+++ b/demo/stripe-to-postgres.sh
@@ -20,6 +20,11 @@ fi
 echo "=== Stripe → Postgres ===" >&2
 echo "Postgres: $POSTGRES_URL" >&2
 
+# npx @stripe/sync-engine --stripe-api-key $API_KEY --postgres-url $PG_URL
+# bun 
+
+
+
 # ── Option A: Simple shorthand (new sync command) ────────────────────────────
 $RUN apps/engine/src/cli/index.ts sync \
   --stripe-api-key "$STRIPE_API_KEY" \

--- a/demo/write-to-postgres.sh
+++ b/demo/write-to-postgres.sh
@@ -7,10 +7,10 @@
 #   ./scripts/read-from-stripe.sh | ./scripts/write-to-postgres.sh    # piped
 #
 # Env: DATABASE_URL
-# Override TypeScript runner: TS_RUNNER="bun" or TS_RUNNER="node --import tsx"
+# Override TypeScript runner: TS_RUNNER="bun" or TS_RUNNER="npx tsx"
 set -euo pipefail
 cd "$(dirname "$0")/.."
-RUN="${TS_RUNNER:-$(dirname "$0")/../scripts/ts-run}"
+RUN="${TS_RUNNER:-node --import tsx}"
 
 echo "Postgres: $DATABASE_URL" >&2
 

--- a/demo/write-to-sheets.sh
+++ b/demo/write-to-sheets.sh
@@ -7,10 +7,10 @@
 #   ./demo/read-from-stripe.sh | ./demo/write-to-sheets.sh  # piped
 #
 # Env: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REFRESH_TOKEN, GOOGLE_SPREADSHEET_ID
-# Override TypeScript runner: TS_RUNNER="bun" or TS_RUNNER="node --import tsx"
+# Override TypeScript runner: TS_RUNNER="bun" or TS_RUNNER="npx tsx"
 set -euo pipefail
 cd "$(dirname "$0")/.."
-RUN="${TS_RUNNER:-$(dirname "$0")/../scripts/ts-run}"
+RUN="${TS_RUNNER:-node --import tsx}"
 
 echo "Sheet: https://docs.google.com/spreadsheets/d/$GOOGLE_SPREADSHEET_ID" >&2
 

--- a/demo/write-to-sheets.sh
+++ b/demo/write-to-sheets.sh
@@ -3,8 +3,8 @@
 # Reads from stdin, or uses sample data if stdin is a terminal.
 #
 # Usage:
-#   ./scripts/write-to-sheets.sh                              # sample data
-#   ./scripts/read-from-stripe.sh | ./scripts/write-to-sheets.sh  # piped
+#   ./demo/write-to-sheets.sh                              # sample data
+#   ./demo/read-from-stripe.sh | ./demo/write-to-sheets.sh  # piped
 #
 # Env: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REFRESH_TOKEN, GOOGLE_SPREADSHEET_ID
 # Override TypeScript runner: TS_RUNNER="bun" or TS_RUNNER="node --import tsx"
@@ -25,8 +25,8 @@ CONFIG="{
 if [ -t 0 ]; then
   # No pipe — use sample data
   printf '%s\n' \
-    '{"type":"record","stream":"demo","data":{"id":"1","name":"Alice","email":"alice@example.com"},"emitted_at":"2024-01-01T00:00:00.000Z"}' \
-    '{"type":"record","stream":"demo","data":{"id":"2","name":"Bob","email":"bob@example.com"},"emitted_at":"2024-01-01T00:00:00.000Z"}' \
+    '{"type":"record","record":{"stream":"demo","data":{"id":"1","name":"Alice","email":"alice@example.com"},"emitted_at":"2024-01-01T00:00:00.000Z"}}' \
+    '{"type":"record","record":{"stream":"demo","data":{"id":"2","name":"Bob","email":"bob@example.com"},"emitted_at":"2024-01-01T00:00:00.000Z"}}' \
   | $RUN packages/destination-google-sheets/src/bin.ts write \
     --config "$CONFIG" --catalog '{"streams":[]}'
 else


### PR DESCRIPTION
## Summary
- Replace `bun` and `scripts/ts-run` with `node --import tsx` as the default TypeScript runner in all demo scripts
- Add `demo/README.md` — step-by-step getting started guide from `git clone` to running demos
- Fix `stripe-sync.dev/engine.html` — copy committed OpenAPI specs into `docs/openapi/` before Vercel build (they were gitignored and missing in CI)

## Test plan
- [x] Verified `node --import tsx apps/engine/src/cli/index.ts --help` works
- [x] Local `SKIP_STRIPE_SPECS=1 node docs/build.mjs` produces `out/openapi/engine.json`
- [ ] Verify `stripe-sync.dev/engine.html` loads after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)