### PR TITLE
CI: copy OpenAPI specs into docs/ before Vercel build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -734,6 +734,12 @@ jobs:
           key: stripe-openapi-${{ env.STRIPE_OPENAPI_WEEK }}
           restore-keys: stripe-openapi-
 
+      - name: Copy Sync Engine OpenAPI specs
+        run: |
+          mkdir -p docs/openapi
+          cp apps/engine/src/__generated__/openapi.json docs/openapi/engine.json
+          cp apps/service/src/__generated__/openapi.json docs/openapi/service.json
+
       - name: Build
         run: |
           PROD=${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v2') && '--prod' || '' }}


### PR DESCRIPTION
## Summary
- `docs/openapi/` is gitignored (generated by `scripts/generate-openapi.sh`), so the Vercel docs build never had the engine/service specs available
- Copy them from the committed `apps/*/src/__generated__/openapi.json` before building
- Fixes the "Document 'api-1' could not be loaded" error on `stripe-sync.dev/engine.html`

## Test plan
- [x] Local `SKIP_STRIPE_SPECS=1 node docs/build.mjs` produces `out/openapi/engine.json`
- [ ] Verify `stripe-sync.dev/engine.html` loads the API reference after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)