### PR TITLE
Add `--live` CLI flag and `?only` setup/teardown filter

### DIFF
--- a/apps/engine/src/__generated__/openapi.d.ts
+++ b/apps/engine/src/__generated__/openapi.d.ts
@@ -52,7 +52,7 @@ export interface paths {
         put?: never;
         /**
          * Set up destination schema
-         * @description Creates destination tables and applies migrations. Streams NDJSON messages (control, log, trace) tagged with _emitted_by.
+         * @description Creates destination tables and applies migrations. Streams NDJSON messages (control, log, trace) tagged with _emitted_by. Pass ?only=destination to run destination setup alone (e.g. optimistic table creation) or ?only=source to isolate the source.
          */
         post: operations["pipeline_setup"];
         delete?: never;
@@ -72,7 +72,7 @@ export interface paths {
         put?: never;
         /**
          * Tear down destination schema
-         * @description Drops destination tables. Streams NDJSON messages (log, trace) tagged with _emitted_by.
+         * @description Drops destination tables. Streams NDJSON messages (log, trace) tagged with _emitted_by. Pass ?only=destination or ?only=source to run a single side.
          */
         post: operations["pipeline_teardown"];
         delete?: never;
@@ -755,7 +755,10 @@ export interface operations {
     };
     pipeline_setup: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Run only the source or destination side. Useful for optimistic destination setup (e.g. creating tables early in a UI) or isolating a connector when debugging. */
+                only?: "source" | "destination";
+            };
             header: {
                 /** @description JSON-encoded PipelineConfig */
                 "x-pipeline": string;
@@ -789,7 +792,10 @@ export interface operations {
     };
     pipeline_teardown: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Run only the source or destination side. Useful for optimistic destination setup (e.g. creating tables early in a UI) or isolating a connector when debugging. */
+                only?: "source" | "destination";
+            };
             header: {
                 /** @description JSON-encoded PipelineConfig */
                 "x-pipeline": string;

--- a/apps/engine/src/__generated__/openapi.json
+++ b/apps/engine/src/__generated__/openapi.json
@@ -111,8 +111,22 @@
           "Stateless Sync API"
         ],
         "summary": "Set up destination schema",
-        "description": "Creates destination tables and applies migrations. Streams NDJSON messages (control, log, trace) tagged with _emitted_by.",
+        "description": "Creates destination tables and applies migrations. Streams NDJSON messages (control, log, trace) tagged with _emitted_by. Pass ?only=destination to run destination setup alone (e.g. optimistic table creation) or ?only=source to isolate the source.",
         "parameters": [
+          {
+            "in": "query",
+            "name": "only",
+            "schema": {
+              "description": "Run only the source or destination side. Useful for optimistic destination setup (e.g. creating tables early in a UI) or isolating a connector when debugging.",
+              "example": "destination",
+              "type": "string",
+              "enum": [
+                "source",
+                "destination"
+              ]
+            },
+            "description": "Run only the source or destination side. Useful for optimistic destination setup (e.g. creating tables early in a UI) or isolating a connector when debugging."
+          },
           {
             "in": "header",
             "name": "x-pipeline",
@@ -165,8 +179,22 @@
           "Stateless Sync API"
         ],
         "summary": "Tear down destination schema",
-        "description": "Drops destination tables. Streams NDJSON messages (log, trace) tagged with _emitted_by.",
+        "description": "Drops destination tables. Streams NDJSON messages (log, trace) tagged with _emitted_by. Pass ?only=destination or ?only=source to run a single side.",
         "parameters": [
+          {
+            "in": "query",
+            "name": "only",
+            "schema": {
+              "description": "Run only the source or destination side. Useful for optimistic destination setup (e.g. creating tables early in a UI) or isolating a connector when debugging.",
+              "example": "destination",
+              "type": "string",
+              "enum": [
+                "source",
+                "destination"
+              ]
+            },
+            "description": "Run only the source or destination side. Useful for optimistic destination setup (e.g. creating tables early in a UI) or isolating a connector when debugging."
+          },
           {
             "in": "header",
             "name": "x-pipeline",

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -352,6 +352,17 @@ export async function createApp(resolver: ConnectorResolver) {
     )
   })
 
+  const onlyQueryParam = z.object({
+    only: z
+      .enum(['source', 'destination'])
+      .optional()
+      .meta({
+        description:
+          'Run only the source or destination side. Useful for optimistic destination setup (e.g. creating tables early in a UI) or isolating a connector when debugging.',
+        example: 'destination',
+      }),
+  })
+
   const pipelineSetupRoute = createRoute({
     operationId: 'pipeline_setup',
     method: 'post',
@@ -359,8 +370,9 @@ export async function createApp(resolver: ConnectorResolver) {
     tags: ['Stateless Sync API'],
     summary: 'Set up destination schema',
     description:
-      'Creates destination tables and applies migrations. Streams NDJSON messages (control, log, trace) tagged with _emitted_by.',
-    requestParams: { header: pipelineHeaders },
+      'Creates destination tables and applies migrations. Streams NDJSON messages (control, log, trace) tagged with _emitted_by. ' +
+      'Pass ?only=destination to run destination setup alone (e.g. optimistic table creation) or ?only=source to isolate the source.',
+    requestParams: { header: pipelineHeaders, query: onlyQueryParam },
     responses: {
       200: {
         description: 'NDJSON stream of setup messages',
@@ -371,9 +383,14 @@ export async function createApp(resolver: ConnectorResolver) {
   })
   app.openapi(pipelineSetupRoute, (c) => {
     const pipeline = c.req.valid('header')['x-pipeline']
+    const only = c.req.valid('query').only
     const context = { path: '/pipeline_setup', ...syncRequestContext(pipeline) }
     return ndjsonResponse(
-      logApiStream('Engine API /pipeline_setup', engine.pipeline_setup(pipeline), context)
+      logApiStream(
+        'Engine API /pipeline_setup',
+        engine.pipeline_setup(pipeline, only ? { only } : undefined),
+        context
+      )
     )
   })
 
@@ -384,8 +401,9 @@ export async function createApp(resolver: ConnectorResolver) {
     tags: ['Stateless Sync API'],
     summary: 'Tear down destination schema',
     description:
-      'Drops destination tables. Streams NDJSON messages (log, trace) tagged with _emitted_by.',
-    requestParams: { header: pipelineHeaders },
+      'Drops destination tables. Streams NDJSON messages (log, trace) tagged with _emitted_by. ' +
+      'Pass ?only=destination or ?only=source to run a single side.',
+    requestParams: { header: pipelineHeaders, query: onlyQueryParam },
     responses: {
       200: {
         description: 'NDJSON stream of teardown messages',
@@ -396,9 +414,14 @@ export async function createApp(resolver: ConnectorResolver) {
   })
   app.openapi(pipelineTeardownRoute, (c) => {
     const pipeline = c.req.valid('header')['x-pipeline']
+    const only = c.req.valid('query').only
     const context = { path: '/pipeline_teardown', ...syncRequestContext(pipeline) }
     return ndjsonResponse(
-      logApiStream('Engine API /pipeline_teardown', engine.pipeline_teardown(pipeline), context)
+      logApiStream(
+        'Engine API /pipeline_teardown',
+        engine.pipeline_teardown(pipeline, only ? { only } : undefined),
+        context
+      )
     )
   })
 

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -353,14 +353,11 @@ export async function createApp(resolver: ConnectorResolver) {
   })
 
   const onlyQueryParam = z.object({
-    only: z
-      .enum(['source', 'destination'])
-      .optional()
-      .meta({
-        description:
-          'Run only the source or destination side. Useful for optimistic destination setup (e.g. creating tables early in a UI) or isolating a connector when debugging.',
-        example: 'destination',
-      }),
+    only: z.enum(['source', 'destination']).optional().meta({
+      description:
+        'Run only the source or destination side. Useful for optimistic destination setup (e.g. creating tables early in a UI) or isolating a connector when debugging.',
+      example: 'destination',
+    }),
   })
 
   const pipelineSetupRoute = createRoute({

--- a/apps/engine/src/api/header-size.test.ts
+++ b/apps/engine/src/api/header-size.test.ts
@@ -72,10 +72,7 @@ function makePipelineHeader(sizeBytes: number): string {
   return JSON.stringify(base)
 }
 
-async function probeHeaderSize(
-  baseUrl: string,
-  bytes: number
-): Promise<number | string> {
+async function probeHeaderSize(baseUrl: string, bytes: number): Promise<number | string> {
   const header = makePipelineHeader(bytes)
   try {
     const res = await fetch(`${baseUrl}/pipeline_check`, {

--- a/apps/engine/src/api/index.ts
+++ b/apps/engine/src/api/index.ts
@@ -46,7 +46,10 @@ async function main() {
         serverOptions: { maxHeaderSize: 50 * 1024 * 1024 },
       },
       (info) => {
-        logger.info({ port: info.port }, `Sync Engine API listening on http://localhost:${info.port}`)
+        logger.info(
+          { port: info.port },
+          `Sync Engine API listening on http://localhost:${info.port}`
+        )
       }
     )
   }

--- a/apps/engine/src/cli/sync.ts
+++ b/apps/engine/src/cli/sync.ts
@@ -46,6 +46,11 @@ export function createSyncCmd(engine: Engine, _resolver: ConnectorResolver) {
         type: 'string',
         description: 'Stop after N seconds',
       },
+      live: {
+        type: 'boolean',
+        default: false,
+        description: 'Keep running after backfill and stream live events via WebSocket',
+      },
     },
     async run({ args }) {
       const stripeApiKey = args.stripeApiKey || process.env.STRIPE_API_KEY
@@ -77,9 +82,13 @@ export function createSyncCmd(engine: Engine, _resolver: ConnectorResolver) {
       const timeLimit = args.timeLimit ? parseInt(args.timeLimit) : undefined
       const backfillLimit = args.backfillLimit ? parseInt(args.backfillLimit) : undefined
 
-      // Inject backfill_limit into source config if provided
+      // Inject optional source config overrides
+      const stripeConfig = pipeline.source.stripe as Record<string, unknown>
       if (backfillLimit) {
-        ;(pipeline.source.stripe as Record<string, unknown>).backfill_limit = backfillLimit
+        stripeConfig.backfill_limit = backfillLimit
+      }
+      if (args.live) {
+        stripeConfig.websocket = true
       }
 
       // Create tables before syncing (must drain — await alone no-ops on AsyncIterable)

--- a/apps/engine/src/lib/engine.ts
+++ b/apps/engine/src/lib/engine.ts
@@ -73,17 +73,28 @@ export interface Engine {
   pipeline_check(pipeline: PipelineConfig): AsyncIterable<CheckOutput>
 
   /**
-   * Run connector `setup()` hooks for both source and destination.
+   * Run connector `setup()` hooks for source and/or destination.
    * Yields {@link SetupOutput} messages (control, log, trace) tagged with `_emitted_by`.
    * Use `collectMessages(stream, 'control')` to extract config updates.
+   *
+   * Pass `only` to run a single side — useful for optimistic destination setup
+   * (e.g. creating tables early in a UI flow) or isolating connectors when debugging.
    */
-  pipeline_setup(pipeline: PipelineConfig): AsyncIterable<SetupOutput>
+  pipeline_setup(
+    pipeline: PipelineConfig,
+    opts?: { only?: 'source' | 'destination' }
+  ): AsyncIterable<SetupOutput>
 
   /**
-   * Run connector `teardown()` hooks for both source and destination.
+   * Run connector `teardown()` hooks for source and/or destination.
    * Yields {@link TeardownOutput} messages (log, trace) tagged with `_emitted_by`.
+   *
+   * Pass `only` to run a single side — useful for isolating connectors when debugging.
    */
-  pipeline_teardown(pipeline: PipelineConfig): AsyncIterable<TeardownOutput>
+  pipeline_teardown(
+    pipeline: PipelineConfig,
+    opts?: { only?: 'source' | 'destination' }
+  ): AsyncIterable<TeardownOutput>
 
   /**
    * Discover the streams available from a source.
@@ -316,17 +327,18 @@ export async function createEngine(resolver: ConnectorResolver): Promise<Engine>
       )
     },
 
-    async *pipeline_setup(pipeline) {
+    async *pipeline_setup(pipeline, opts?) {
       const baseContext = engineLogContext(pipeline)
+      const runSource = opts?.only !== 'destination'
+      const runDest = opts?.only !== 'source'
+
       const [srcConnector, destConnector] = await Promise.all([
-        resolver.resolveSource(pipeline.source.type),
-        resolver.resolveDestination(pipeline.destination.type),
+        runSource ? resolver.resolveSource(pipeline.source.type) : null,
+        runDest ? resolver.resolveDestination(pipeline.destination.type) : null,
       ])
-      const rawSrc = configPayload(pipeline.source)
-      const rawDest = configPayload(pipeline.destination)
       const [sourceConfig, destConfig] = await Promise.all([
-        getSpecConfig(srcConnector, rawSrc),
-        getSpecConfig(destConnector, rawDest),
+        srcConnector ? getSpecConfig(srcConnector, configPayload(pipeline.source)) : null,
+        destConnector ? getSpecConfig(destConnector, configPayload(pipeline.destination)) : null,
       ])
 
       const { catalog, filteredCatalog } = await discoverCatalog(engine, pipeline)
@@ -335,49 +347,57 @@ export async function createEngine(resolver: ConnectorResolver): Promise<Engine>
       const destTag = `destination/${pipeline.destination.type}`
 
       yield* merge(
-        srcConnector.setup &&
+        runSource &&
+          srcConnector?.setup &&
           withLoggedStream(
             'Engine source setup',
             baseContext,
-            map(srcConnector.setup({ config: sourceConfig, catalog }), tag(sourceTag))
+            map(srcConnector.setup({ config: sourceConfig!, catalog }), tag(sourceTag))
           ),
-        destConnector.setup &&
+        runDest &&
+          destConnector?.setup &&
           withLoggedStream(
             'Engine destination setup',
             baseContext,
-            map(destConnector.setup({ config: destConfig, catalog: filteredCatalog }), tag(destTag))
+            map(
+              destConnector.setup({ config: destConfig!, catalog: filteredCatalog }),
+              tag(destTag)
+            )
           )
       )
     },
 
-    async *pipeline_teardown(pipeline) {
+    async *pipeline_teardown(pipeline, opts?) {
       const baseContext = engineLogContext(pipeline)
+      const runSource = opts?.only !== 'destination'
+      const runDest = opts?.only !== 'source'
+
       const [srcConnector, destConnector] = await Promise.all([
-        resolver.resolveSource(pipeline.source.type),
-        resolver.resolveDestination(pipeline.destination.type),
+        runSource ? resolver.resolveSource(pipeline.source.type) : null,
+        runDest ? resolver.resolveDestination(pipeline.destination.type) : null,
       ])
-      const rawSrc = configPayload(pipeline.source)
-      const rawDest = configPayload(pipeline.destination)
       const [sourceConfig, destConfig] = await Promise.all([
-        getSpecConfig(srcConnector, rawSrc),
-        getSpecConfig(destConnector, rawDest),
+        srcConnector ? getSpecConfig(srcConnector, configPayload(pipeline.source)) : null,
+        destConnector ? getSpecConfig(destConnector, configPayload(pipeline.destination)) : null,
       ])
 
       const sourceTag = `source/${pipeline.source.type}`
       const destTag = `destination/${pipeline.destination.type}`
 
       yield* merge(
-        srcConnector.teardown &&
+        runSource &&
+          srcConnector?.teardown &&
           withLoggedStream(
             'Engine source teardown',
             baseContext,
-            map(srcConnector.teardown({ config: sourceConfig }), tag(sourceTag))
+            map(srcConnector.teardown({ config: sourceConfig! }), tag(sourceTag))
           ),
-        destConnector.teardown &&
+        runDest &&
+          destConnector?.teardown &&
           withLoggedStream(
             'Engine destination teardown',
             baseContext,
-            map(destConnector.teardown({ config: destConfig }), tag(destTag))
+            map(destConnector.teardown({ config: destConfig! }), tag(destTag))
           )
       )
     },

--- a/apps/engine/src/lib/pipeline.test.ts
+++ b/apps/engine/src/lib/pipeline.test.ts
@@ -708,9 +708,7 @@ describe('takeLimits()', () => {
       },
     ]
     // State limit of 1 fires before any time limit
-    const result = await drain(
-      takeLimits({ state_limit: 1, time_limit: 60 })(toAsync(msgs))
-    )
+    const result = await drain(takeLimits({ state_limit: 1, time_limit: 60 })(toAsync(msgs)))
     expect(result.at(-1)).toMatchObject({ type: 'eof', eof: { reason: 'state_limit' } })
   })
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -94,6 +94,43 @@ export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
 
 This syncs `products`, `prices`, and `customers` into Postgres with full schema management.
 
+## Step 5: Live mode (WebSocket streaming)
+
+The engine can keep running after the initial backfill and stream live events
+via Stripe's WebSocket API (the same mechanism behind `stripe listen`). Any
+object you create, update, or delete in the Stripe Dashboard (or via the API)
+is written to Postgres within seconds.
+
+```sh
+export STRIPE_API_KEY=sk_test_...
+export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
+
+./demo/stripe-to-postgres-live.sh
+```
+
+The script backfills the latest 10 objects per stream, then blocks and waits
+for live events. Open a second terminal to trigger some:
+
+```sh
+# Using the Stripe CLI (https://docs.stripe.com/stripe-cli)
+stripe trigger customer.created
+stripe trigger product.created
+stripe trigger price.created
+```
+
+You'll see the new records appear in Postgres immediately.
+Press **Ctrl+C** to stop.
+
+### How it works
+
+Setting `websocket: true` in the source config tells the Stripe source to open
+a WebSocket session to Stripe (via the same `/v1/stripecli/sessions` API the
+Stripe CLI uses). During backfill, incoming events are queued; once backfill
+completes the engine drains the queue and then blocks on new events indefinitely.
+
+No webhook endpoint, tunnel, or public URL is needed — everything runs over an
+outbound WebSocket connection.
+
 ## All demos
 
 | Script | What it does | Required env vars |
@@ -103,6 +140,7 @@ This syncs `products`, `prices`, and `customers` into Postgres with full schema 
 | `write-to-sheets.sh` | Write NDJSON (stdin or sample data) to Google Sheets | `GOOGLE_*` |
 | `stripe-to-postgres.sh` | Stripe → Postgres via the engine | `STRIPE_API_KEY`, `DATABASE_URL` |
 | `stripe-to-google-sheets.sh` | Stripe → Google Sheets via the engine | `STRIPE_API_KEY`, `GOOGLE_*` |
+| `stripe-to-postgres-live.sh` | Stripe → Postgres with live WebSocket streaming | `STRIPE_API_KEY`, `DATABASE_URL` |
 
 ### TypeScript API
 
@@ -111,6 +149,7 @@ The `.ts` files do the same thing using the engine as a library / during develop
 ```sh
 node --import tsx demo/stripe-to-postgres.ts
 node --import tsx demo/stripe-to-google-sheets.ts
+node --import tsx demo/stripe-to-postgres-live.ts   # live WebSocket mode
 ```
 
 ## Utilities

--- a/demo/README.md
+++ b/demo/README.md
@@ -133,14 +133,14 @@ outbound WebSocket connection.
 
 ## All demos
 
-| Script | What it does | Required env vars |
-|--------|-------------|-------------------|
-| `read-from-stripe.sh` | Read from Stripe, output NDJSON to stdout | `STRIPE_API_KEY` |
-| `write-to-postgres.sh` | Write NDJSON (stdin or sample data) to Postgres | `DATABASE_URL` |
-| `write-to-sheets.sh` | Write NDJSON (stdin or sample data) to Google Sheets | `GOOGLE_*` |
-| `stripe-to-postgres.sh` | Stripe → Postgres via the engine | `STRIPE_API_KEY`, `DATABASE_URL` |
-| `stripe-to-google-sheets.sh` | Stripe → Google Sheets via the engine | `STRIPE_API_KEY`, `GOOGLE_*` |
-| `stripe-to-postgres-live.sh` | Stripe → Postgres with live WebSocket streaming | `STRIPE_API_KEY`, `DATABASE_URL` |
+| Script                       | What it does                                         | Required env vars                |
+| ---------------------------- | ---------------------------------------------------- | -------------------------------- |
+| `read-from-stripe.sh`        | Read from Stripe, output NDJSON to stdout            | `STRIPE_API_KEY`                 |
+| `write-to-postgres.sh`       | Write NDJSON (stdin or sample data) to Postgres      | `DATABASE_URL`                   |
+| `write-to-sheets.sh`         | Write NDJSON (stdin or sample data) to Google Sheets | `GOOGLE_*`                       |
+| `stripe-to-postgres.sh`      | Stripe → Postgres via the engine                     | `STRIPE_API_KEY`, `DATABASE_URL` |
+| `stripe-to-google-sheets.sh` | Stripe → Google Sheets via the engine                | `STRIPE_API_KEY`, `GOOGLE_*`     |
+| `stripe-to-postgres-live.sh` | Stripe → Postgres with live WebSocket streaming      | `STRIPE_API_KEY`, `DATABASE_URL` |
 
 ### TypeScript API
 
@@ -154,7 +154,7 @@ node --import tsx demo/stripe-to-postgres-live.ts   # live WebSocket mode
 
 ## Utilities
 
-| Script | What it does |
-|--------|-------------|
-| `reset-postgres.sh` | Drop all tables and non-system schemas |
-| `webhooksite.sh` | Set up webhook forwarding for live Stripe events |
+| Script              | What it does                                     |
+| ------------------- | ------------------------------------------------ |
+| `reset-postgres.sh` | Drop all tables and non-system schemas           |
+| `webhooksite.sh`    | Set up webhook forwarding for live Stripe events |

--- a/demo/stripe-to-google-sheets.ts
+++ b/demo/stripe-to-google-sheets.ts
@@ -37,7 +37,8 @@ const resolver = await createConnectorResolver(defaultConnectors, { path: true }
 const engine = await createEngine(resolver)
 
 // Setup (creates spreadsheet/sheets if needed)
-for await (const _msg of engine.pipeline_setup(pipeline)) {}
+for await (const _msg of engine.pipeline_setup(pipeline)) {
+}
 
 // State: file-backed, resumable across runs
 const store = fileStateStore('.sync-state-sheets.json')

--- a/demo/stripe-to-postgres-live.sh
+++ b/demo/stripe-to-postgres-live.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Sync Stripe → Postgres with live WebSocket streaming.
+#
+# After the initial backfill, the engine keeps running and streams live events
+# via Stripe's WebSocket API (same mechanism as `stripe listen`). Any changes
+# you make in the Stripe Dashboard (or via the API) appear in Postgres within
+# seconds.
+#
+# Usage:
+#   ./demo/stripe-to-postgres-live.sh
+#
+# Trigger test events (in another terminal):
+#   stripe trigger customer.created
+#   stripe trigger product.created
+#   stripe trigger price.created
+#
+# Env: STRIPE_API_KEY, DATABASE_URL (or POSTGRES_URL)
+# Override TypeScript runner: TS_RUNNER="bun" or TS_RUNNER="npx tsx"
+set -euo pipefail
+cd "$(dirname "$0")/.."
+RUN="${TS_RUNNER:-node --import tsx}"
+POSTGRES_URL="${DATABASE_URL:-${POSTGRES_URL:?Set DATABASE_URL or POSTGRES_URL}}"
+
+echo "=== Stripe → Postgres (live WebSocket mode) ===" >&2
+echo "Postgres: $POSTGRES_URL" >&2
+echo "" >&2
+echo "After backfill completes, the engine will keep running and stream" >&2
+echo "live events. Press Ctrl+C to stop." >&2
+echo "" >&2
+
+$RUN apps/engine/src/cli/index.ts sync \
+  --stripe-api-key "$STRIPE_API_KEY" \
+  --postgres-url "$POSTGRES_URL" \
+  --streams products,prices,customers \
+  --backfill-limit 10 \
+  --live

--- a/demo/stripe-to-postgres-live.ts
+++ b/demo/stripe-to-postgres-live.ts
@@ -44,7 +44,8 @@ const resolver = await createConnectorResolver(defaultConnectors, { path: true }
 const engine = await createEngine(resolver)
 
 // Create tables
-for await (const _msg of engine.pipeline_setup(pipeline)) {}
+for await (const _msg of engine.pipeline_setup(pipeline)) {
+}
 
 // State: file-backed, resumable across runs
 const store = fileStateStore('.sync-state.json')

--- a/demo/stripe-to-postgres-live.ts
+++ b/demo/stripe-to-postgres-live.ts
@@ -1,0 +1,63 @@
+/**
+ * Sync Stripe → Postgres with live WebSocket streaming (TypeScript).
+ *
+ * After the initial backfill, the engine keeps running and streams live events
+ * via Stripe's WebSocket API. Any changes in the Stripe Dashboard (or API)
+ * appear in Postgres within seconds.
+ *
+ * Usage:
+ *   node --import tsx demo/stripe-to-postgres-live.ts
+ *
+ * Trigger test events (in another terminal):
+ *   stripe trigger customer.created
+ *   stripe trigger product.created
+ *
+ * Env: STRIPE_API_KEY, DATABASE_URL (or POSTGRES_URL)
+ */
+import { createConnectorResolver, createEngine } from '../apps/engine/src/lib/index.js'
+import { defaultConnectors } from '../apps/engine/src/lib/default-connectors.js'
+import { fileStateStore } from '../apps/engine/src/lib/state-store.js'
+import type { PipelineConfig } from '../packages/protocol/src/index.js'
+
+const stripeApiKey = process.env.STRIPE_API_KEY
+const postgresUrl = process.env.DATABASE_URL ?? process.env.POSTGRES_URL
+if (!stripeApiKey) throw new Error('Set STRIPE_API_KEY')
+if (!postgresUrl) throw new Error('Set DATABASE_URL or POSTGRES_URL')
+
+const pipeline: PipelineConfig = {
+  source: {
+    type: 'stripe',
+    stripe: {
+      api_key: stripeApiKey,
+      backfill_limit: 10,
+      websocket: true,
+    },
+  },
+  destination: {
+    type: 'postgres',
+    postgres: { url: postgresUrl, schema: 'public', port: 5432, batch_size: 100 },
+  },
+  streams: [{ name: 'products' }, { name: 'prices' }, { name: 'customers' }],
+}
+
+const resolver = await createConnectorResolver(defaultConnectors, { path: true })
+const engine = await createEngine(resolver)
+
+// Create tables
+for await (const _msg of engine.pipeline_setup(pipeline)) {}
+
+// State: file-backed, resumable across runs
+const store = fileStateStore('.sync-state.json')
+const state = await store.get()
+
+console.error('=== Stripe → Postgres (live WebSocket mode) ===')
+console.error('After backfill, the engine will stream live events. Press Ctrl+C to stop.\n')
+
+// Sync — with websocket: true this blocks indefinitely, streaming live events
+for await (const msg of engine.pipeline_sync(pipeline, { state })) {
+  if (msg.type === 'source_state') {
+    if (msg.source_state.state_type === 'global') await store.setGlobal(msg.source_state.data)
+    else await store.set(msg.source_state.stream, msg.source_state.data)
+  }
+  console.log(JSON.stringify(msg))
+}

--- a/demo/stripe-to-postgres.ts
+++ b/demo/stripe-to-postgres.ts
@@ -30,7 +30,8 @@ const resolver = await createConnectorResolver(defaultConnectors, { path: true }
 const engine = await createEngine(resolver)
 
 // Create tables
-for await (const _msg of engine.pipeline_setup(pipeline)) {}
+for await (const _msg of engine.pipeline_setup(pipeline)) {
+}
 
 // State: file-backed, resumable across runs
 const store = fileStateStore('.sync-state.json')

--- a/docs/engine/header-size-limits.md
+++ b/docs/engine/header-size-limits.md
@@ -27,11 +27,11 @@ Bun's `Bun.serve()` does not use Node's HTTP parser and has a much higher defaul
 
 Each `{ "obj_id": row_number }` entry is ~30 bytes. With Google Sheets' 10M cell limit:
 
-| Columns/row | Max rows | Mapping size (JSON object) |
-|---|---|---|
-| 10 | 1,000,000 | ~30 MB |
-| 20 | 500,000 | ~15 MB |
-| 50 | 200,000 | ~6 MB |
+| Columns/row | Max rows  | Mapping size (JSON object) |
+| ----------- | --------- | -------------------------- |
+| 10          | 1,000,000 | ~30 MB                     |
+| 20          | 500,000   | ~15 MB                     |
+| 50          | 200,000   | ~6 MB                      |
 
 More efficient encodings (sorted array, prefix compression) reduce this by ~30-50% but
 don't change the order of magnitude.
@@ -42,11 +42,11 @@ Instead of storing the row map in state, read the ID column from the sheet at th
 each write batch and build the map in memory:
 
 | Sheet rows | API call time | Response size |
-|---|---|---|
-| 1K | ~100ms | ~25 KB |
-| 10K | ~200ms | ~250 KB |
-| 100K | ~1-2s | ~2.5 MB |
-| 1M | ~5-15s | ~25 MB |
+| ---------- | ------------- | ------------- |
+| 1K         | ~100ms        | ~25 KB        |
+| 10K        | ~200ms        | ~250 KB       |
+| 100K       | ~1-2s         | ~2.5 MB       |
+| 1M         | ~5-15s        | ~25 MB        |
 
 This eliminates the mapping from state entirely. Tradeoff: one extra Sheets API read per
 batch. At large row counts the batch write itself takes longer than the lookup.


### PR DESCRIPTION
## Summary

- **`--live` flag for CLI `sync` command**: Sets `websocket: true` on the source config, enabling real-time event-driven sync via WebSocket. Includes demo scripts (`stripe-to-postgres-live.sh` / `.ts`) and a getting-started guide in `demo/README.md`.
- **`?only=source|destination` query param for `pipeline_setup` / `pipeline_teardown`**: Allows running setup or teardown for a single connector side. Useful for optimistic destination setup (e.g. creating tables early in a UI flow) or isolating a connector when debugging.

## Test plan

- [ ] `npx @stripe/sync-engine sync --src stripe --dst postgres --live` starts a live WebSocket sync
- [ ] `POST /pipeline_setup?only=destination` creates tables without invoking source setup
- [ ] `POST /pipeline_teardown?only=source` tears down source without touching destination
- [ ] Omitting `?only` runs both sides (existing behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)