### PR TITLE
feat(service): Temporal visibility for pipeline workflows

### DIFF
--- a/apps/service/package.json
+++ b/apps/service/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@hyperjump/json-schema": "^1.17.5",
+    "@temporalio/common": "^1",
     "@temporalio/testing": "^1",
     "@types/node": "^24.10.1",
     "openapi-typescript": "^7",

--- a/apps/service/src/__tests__/temporal-test-env.ts
+++ b/apps/service/src/__tests__/temporal-test-env.ts
@@ -1,0 +1,24 @@
+import { SearchAttributeType, defineSearchAttributeKey } from '@temporalio/common'
+import { TestWorkflowEnvironment } from '@temporalio/testing'
+import {
+  SYNC_ENGINE_PIPELINE_DESIRED_STATUS_SEARCH_ATTRIBUTE,
+  SYNC_ENGINE_PIPELINE_STATUS_SEARCH_ATTRIBUTE,
+} from '../temporal/pipeline-search-attributes.js'
+
+/** Local dev server with the custom search attributes used by `pipelineWorkflow`. */
+export function createPipelineTestWorkflowEnvironment() {
+  return TestWorkflowEnvironment.createLocal({
+    server: {
+      searchAttributes: [
+        defineSearchAttributeKey(
+          SYNC_ENGINE_PIPELINE_STATUS_SEARCH_ATTRIBUTE,
+          SearchAttributeType.KEYWORD
+        ),
+        defineSearchAttributeKey(
+          SYNC_ENGINE_PIPELINE_DESIRED_STATUS_SEARCH_ATTRIBUTE,
+          SearchAttributeType.KEYWORD
+        ),
+      ],
+    },
+  })
+}

--- a/apps/service/src/__tests__/workflow.test.ts
+++ b/apps/service/src/__tests__/workflow.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import type { SyncActivities } from '../temporal/activities/index.js'
 import type { RunResult } from '../temporal/activities/index.js'
 import { CONTINUE_AS_NEW_THRESHOLD } from '../lib/utils.js'
+import { createPipelineTestWorkflowEnvironment } from './temporal-test-env.js'
 
 type SourceInput = unknown
 
@@ -54,7 +55,7 @@ async function signalSourceInput(
 let testEnv: TestWorkflowEnvironment
 
 beforeAll(async () => {
-  testEnv = await TestWorkflowEnvironment.createLocal()
+  testEnv = await createPipelineTestWorkflowEnvironment()
 }, 120_000)
 
 afterAll(async () => {
@@ -126,6 +127,16 @@ describe('pipelineWorkflow (unit — stubbed activities)', () => {
 
       // Let reconciliation start
       await new Promise((r) => setTimeout(r, 1500))
+
+      const statusSnap = (await handle.query('status')) as {
+        pipeline_id: string
+        status: string
+        desired_status: string
+        iteration: number
+      }
+      expect(statusSnap.pipeline_id).toBe(testPipelineId)
+      expect(statusSnap.desired_status).toBe('active')
+      expect(['setup', 'backfill', 'ready']).toContain(statusSnap.status)
 
       // Send events
       await signalSourceInput(handle, {

--- a/apps/service/src/api/app.test.ts
+++ b/apps/service/src/api/app.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@stripe/sync-engine'
 import destinationGoogleSheets from '@stripe/sync-destination-google-sheets'
 import type { SyncActivities, RunResult } from '../temporal/activities/index.js'
+import { createPipelineTestWorkflowEnvironment } from '../__tests__/temporal-test-env.js'
 import { createApp } from './app.js'
 import { memoryPipelineStore } from '../lib/stores-memory.js'
 import type { PipelineStore } from '../lib/stores.js'
@@ -103,7 +104,7 @@ let workerRunning: Promise<void>
 let sharedStore: PipelineStore
 
 beforeAll(async () => {
-  testEnv = await TestWorkflowEnvironment.createLocal()
+  testEnv = await createPipelineTestWorkflowEnvironment()
   sharedStore = memoryPipelineStore()
   worker = await Worker.create({
     connection: testEnv.nativeConnection,

--- a/apps/service/src/temporal/pipeline-search-attributes.ts
+++ b/apps/service/src/temporal/pipeline-search-attributes.ts
@@ -1,0 +1,8 @@
+/**
+ * Keyword search attribute names for `pipelineWorkflow`. Register these on the
+ * Temporal namespace before using them in list filters or as UI table columns.
+ */
+export const SYNC_ENGINE_PIPELINE_STATUS_SEARCH_ATTRIBUTE = 'SyncEnginePipelineStatus'
+
+export const SYNC_ENGINE_PIPELINE_DESIRED_STATUS_SEARCH_ATTRIBUTE =
+  'SyncEnginePipelineDesiredStatus'

--- a/apps/service/src/temporal/workflows/pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/pipeline-workflow.ts
@@ -1,7 +1,18 @@
-import { condition, continueAsNew, setHandler } from '@temporalio/workflow'
+import {
+  condition,
+  continueAsNew,
+  defineQuery,
+  setHandler,
+  type SearchAttributes,
+  upsertSearchAttributes,
+} from '@temporalio/workflow'
 
 import type { SourceInputMessage, SourceState } from '@stripe/sync-protocol'
 import type { DesiredStatus, PipelineStatus } from '../../lib/createSchemas.js'
+import {
+  SYNC_ENGINE_PIPELINE_DESIRED_STATUS_SEARCH_ATTRIBUTE,
+  SYNC_ENGINE_PIPELINE_STATUS_SEARCH_ATTRIBUTE,
+} from '../pipeline-search-attributes.js'
 import { CONTINUE_AS_NEW_THRESHOLD } from '../../lib/utils.js'
 import { classifySyncErrors } from '../sync-errors.js'
 import {
@@ -36,6 +47,21 @@ export interface PipelineWorkflowOpts {
   errorRecoveryRequested?: boolean
 }
 
+/** Snapshot returned by the `status` workflow query (Temporal UI / QA). */
+export interface PipelineWorkflowStatusSnapshot {
+  pipeline_id: string
+  status: PipelineStatus
+  desired_status: DesiredStatus
+  state: PipelineWorkflowState
+  /** Sync operations completed in this run (resets on continue-as-new). */
+  operation_count: number
+  /** Alias for `operation_count` (legacy tests / tooling). */
+  iteration: number
+  input_queue_length: number
+}
+
+const pipelineStatusQuery = defineQuery<PipelineWorkflowStatusSnapshot>('status')
+
 export async function pipelineWorkflow(
   pipelineId: string,
   opts?: PipelineWorkflowOpts
@@ -58,7 +84,18 @@ export async function pipelineWorkflow(
     if (state.errored && status === 'active') {
       errorRecoveryRequested = true
     }
+    syncPipelineSearchAttributes()
   })
+
+  setHandler(pipelineStatusQuery, () => ({
+    pipeline_id: pipelineId,
+    status: derivePipelineStatus(),
+    desired_status: desiredStatus,
+    state: { ...state },
+    operation_count: operationCount,
+    iteration: operationCount,
+    input_queue_length: inputQueue.length,
+  }))
 
   // MARK: - State
 
@@ -70,6 +107,14 @@ export async function pipelineWorkflow(
     return state.phase === 'ready' ? 'ready' : 'backfill'
   }
 
+  function syncPipelineSearchAttributes(): void {
+    const attrs: SearchAttributes = {
+      [SYNC_ENGINE_PIPELINE_STATUS_SEARCH_ATTRIBUTE]: [derivePipelineStatus()],
+      [SYNC_ENGINE_PIPELINE_DESIRED_STATUS_SEARCH_ATTRIBUTE]: [desiredStatus],
+    }
+    upsertSearchAttributes(attrs)
+  }
+
   async function setState(next: Partial<PipelineWorkflowState>) {
     const previousStatus = derivePipelineStatus()
     state = { ...state, ...next }
@@ -77,6 +122,7 @@ export async function pipelineWorkflow(
 
     if (previousStatus !== nextStatus) {
       await updatePipelineStatus(pipelineId, nextStatus)
+      syncPipelineSearchAttributes()
     }
   }
 
@@ -164,6 +210,8 @@ export async function pipelineWorkflow(
       }
     }
   }
+
+  syncPipelineSearchAttributes()
 
   // MARK: - Main logic
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,6 +292,9 @@ importers:
       '@hyperjump/json-schema':
         specifier: ^1.17.5
         version: 1.17.5(@hyperjump/browser@1.3.1)
+      '@temporalio/common':
+        specifier: ^1
+        version: 1.15.0
       '@temporalio/testing':
         specifier: ^1
         version: 1.15.0(tslib@2.8.1)


### PR DESCRIPTION
## Summary
Expose pipeline execution state in Temporal visibility (list filters / UI columns) and keep the `status` workflow query for per-run detail.

## Changes
- **Search attributes** (Keyword): `SyncEnginePipelineStatus`, `SyncEnginePipelineDesiredStatus` — upserted on startup, when derived status changes, and on `desired_status` signal.
- **Query** `status`: JSON snapshot.
- **Tests**: `createPipelineTestWorkflowEnvironment()` registers those attributes on the embedded dev server; `@temporalio/common` devDependency.

## Ops
Register both attributes as **Keyword** on each Temporal namespace before deploy.

Base: `v2`. (Earlier PR mistakenly targeted another fork parent.)

Made with [Cursor](https://cursor.com)