### PR TITLE
 Fix async iterable memory leak in engine process

### DIFF
--- a/apps/engine/src/lib/ndjson.ts
+++ b/apps/engine/src/lib/ndjson.ts
@@ -11,16 +11,24 @@ export async function* parseNdjson<T = unknown>(text: string): AsyncIterable<T> 
 /** Serialize an AsyncIterable as a streaming NDJSON ReadableStream. */
 export function toNdjsonStream(iter: AsyncIterable<unknown>): ReadableStream<Uint8Array> {
   const enc = new TextEncoder()
+  const iterator = iter[Symbol.asyncIterator]()
   return new ReadableStream({
     async start(controller) {
       try {
-        for await (const item of iter) {
-          controller.enqueue(enc.encode(JSON.stringify(item) + '\n'))
+        while (true) {
+          const result = await iterator.next()
+          if (result.done) break
+          controller.enqueue(enc.encode(JSON.stringify(result.value) + '\n'))
         }
         controller.close()
       } catch (err) {
         controller.error(err)
+      } finally {
+        iterator.return?.()
       }
+    },
+    cancel() {
+      iterator.return?.()
     },
   })
 }

--- a/apps/engine/src/lib/remote-engine.ts
+++ b/apps/engine/src/lib/remote-engine.ts
@@ -139,22 +139,38 @@ export function createRemoteEngine(engineUrl: string): Engine {
         params: { header: { 'x-source': JSON.stringify(source) } },
       })
       if (!response.ok) throw new Error(`source_discover failed: ${response.status}`)
-      yield* parseNdjsonStream<DiscoverOutput>(response.body!)
+      try {
+        yield* parseNdjsonStream<DiscoverOutput>(response.body!)
+      } finally {
+        await response.body?.cancel().catch(() => {})
+      }
     },
 
     async *pipeline_check(pipeline: PipelineConfig): AsyncIterable<CheckOutput> {
       const res = await post('/pipeline_check', pipeline)
-      yield* parseNdjsonStream<CheckOutput>(res.body!)
+      try {
+        yield* parseNdjsonStream<CheckOutput>(res.body!)
+      } finally {
+        await res.body?.cancel().catch(() => {})
+      }
     },
 
     async *pipeline_setup(pipeline: PipelineConfig): AsyncIterable<SetupOutput> {
       const res = await post('/pipeline_setup', pipeline)
-      yield* parseNdjsonStream<SetupOutput>(res.body!)
+      try {
+        yield* parseNdjsonStream<SetupOutput>(res.body!)
+      } finally {
+        await res.body?.cancel().catch(() => {})
+      }
     },
 
     async *pipeline_teardown(pipeline: PipelineConfig): AsyncIterable<TeardownOutput> {
       const res = await post('/pipeline_teardown', pipeline)
-      yield* parseNdjsonStream<TeardownOutput>(res.body!)
+      try {
+        yield* parseNdjsonStream<TeardownOutput>(res.body!)
+      } finally {
+        await res.body?.cancel().catch(() => {})
+      }
     },
 
     async *pipeline_read(
@@ -164,7 +180,11 @@ export function createRemoteEngine(engineUrl: string): Engine {
     ): AsyncIterable<Message> {
       const body = input ? toNdjsonStream(input) : undefined
       const res = await post('/pipeline_read', pipeline, opts, body)
-      yield* parseNdjsonStream<Message>(res.body!)
+      try {
+        yield* parseNdjsonStream<Message>(res.body!)
+      } finally {
+        await res.body?.cancel().catch(() => {})
+      }
     },
 
     async *pipeline_write(
@@ -172,7 +192,11 @@ export function createRemoteEngine(engineUrl: string): Engine {
       messages: AsyncIterable<Message>
     ): AsyncIterable<DestinationOutput> {
       const res = await post('/pipeline_write', pipeline, undefined, toNdjsonStream(messages))
-      yield* parseNdjsonStream<DestinationOutput>(res.body!)
+      try {
+        yield* parseNdjsonStream<DestinationOutput>(res.body!)
+      } finally {
+        await res.body?.cancel().catch(() => {})
+      }
     },
 
     async *pipeline_sync(
@@ -182,7 +206,11 @@ export function createRemoteEngine(engineUrl: string): Engine {
     ): AsyncIterable<SyncOutput> {
       const body = input ? toNdjsonStream(input) : undefined
       const res = await post('/pipeline_sync', pipeline, opts, body)
-      yield* parseNdjsonStream<SyncOutput>(res.body!)
+      try {
+        yield* parseNdjsonStream<SyncOutput>(res.body!)
+      } finally {
+        await res.body?.cancel().catch(() => {})
+      }
     },
   }
 }

--- a/apps/service/src/temporal/activities/_shared.ts
+++ b/apps/service/src/temporal/activities/_shared.ts
@@ -62,14 +62,12 @@ export async function drainMessages(
 ): Promise<{
   errors: RunResult['errors']
   state: SourceState
-  records: Message[]
   sourceConfig?: Record<string, unknown>
   destConfig?: Record<string, unknown>
   eof?: EofPayload
 }> {
   const errors: RunResult['errors'] = []
   let state: SourceState = initialState ?? { streams: {}, global: {} }
-  const records: Message[] = []
   let sourceConfig: Record<string, unknown> | undefined
   let destConfig: Record<string, unknown> | undefined
   let eof: EofPayload | undefined
@@ -91,13 +89,11 @@ export async function drainMessages(
         errors.push(error)
       } else if (message.type === 'source_state') {
         state = mergeStateMessage(state, message)
-      } else if (message.type === 'record') {
-        records.push(message)
       }
     }
     if (count % 50 === 0) heartbeat({ messages: count })
   }
   if (count % 50 !== 0) heartbeat({ messages: count })
 
-  return { errors, state, records, sourceConfig, destConfig, eof }
+  return { errors, state, sourceConfig, destConfig, eof }
 }

--- a/apps/service/src/temporal/workflows/pipeline-workflow.ts
+++ b/apps/service/src/temporal/workflows/pipeline-workflow.ts
@@ -150,8 +150,8 @@ export async function pipelineWorkflow(
 
       const result = await pipelineSync(pipelineId, {
         state: sourceState,
-        state_limit: 100,
-        time_limit: 10,
+        state_limit: 1000,
+        time_limit: 30,
       })
       operationCount++
       sourceState = result.state

--- a/packages/protocol/src/async-iterable-utils.test.ts
+++ b/packages/protocol/src/async-iterable-utils.test.ts
@@ -127,6 +127,60 @@ describe('split', () => {
     expect(evenResult).toEqual([])
     expect(oddResult).toEqual([1, 3, 5])
   })
+
+  it('propagates return() to source when consumer breaks early', async () => {
+    let sourceReturned = false
+    async function* source() {
+      try {
+        yield 1
+        yield 2
+        yield 3
+      } finally {
+        sourceReturned = true
+      }
+    }
+    const isEven = (n: number): n is number => n % 2 === 0
+    const [, odds] = split(source(), isEven)
+    const it = odds[Symbol.asyncIterator]()
+    await it.next()
+    await it.return!()
+    expect(sourceReturned).toBe(true)
+  })
+
+  it('propagates return() to source from the matches branch', async () => {
+    let sourceReturned = false
+    async function* source() {
+      try {
+        yield 2
+        yield 4
+        yield 6
+      } finally {
+        sourceReturned = true
+      }
+    }
+    const isEven = (n: number): n is number => n % 2 === 0
+    const [evens] = split(source(), isEven)
+    const it = evens[Symbol.asyncIterator]()
+    await it.next()
+    await it.return!()
+    expect(sourceReturned).toBe(true)
+  })
+
+  it('closes sibling branch when one branch returns early', async () => {
+    async function* source() {
+      yield 1
+      yield 2
+      yield 3
+      yield 4
+    }
+    const isEven = (n: number): n is number => n % 2 === 0
+    const [evens, odds] = split(source(), isEven)
+    const oddIt = odds[Symbol.asyncIterator]()
+    await oddIt.next()
+    await oddIt.return!()
+    const remaining = await collect(evens)
+    expect(remaining).toEqual([])
+  })
 })
 
 describe('map', () => {

--- a/packages/protocol/src/async-iterable-utils.ts
+++ b/packages/protocol/src/async-iterable-utils.ts
@@ -2,7 +2,7 @@
 // Pure primitives — no external deps, no engine-specific imports.
 
 /**
- * Async push/pull channel. No array buffering — uses linked promise pairs.
+ * Async push/pull channel with unbounded buffer when push outpaces pull.
  *
  * **Error handling:** The channel itself never throws — it is a passive data
  * structure. Producers call `push()` and `close()`; neither can fail.
@@ -12,10 +12,12 @@
 export function channel<T>(): AsyncIterable<T> & {
   push(value: T): void
   close(): void
+  onReturn?: () => void | Promise<unknown>
 } {
   let resolve: ((result: IteratorResult<T>) => void) | null = null
   let done = false
   const pending: T[] = [] // only used when push() is called before next()
+  let onReturn: (() => void | Promise<unknown>) | undefined
 
   const iter: AsyncIterableIterator<T> = {
     [Symbol.asyncIterator]() {
@@ -30,9 +32,20 @@ export function channel<T>(): AsyncIterable<T> & {
         resolve = r
       })
     },
+    async return() {
+      done = true
+      pending.length = 0
+      if (resolve) {
+        const r = resolve
+        resolve = null
+        r({ value: undefined as any, done: true })
+      }
+      await onReturn?.()
+      return { value: undefined as any, done: true }
+    },
   }
 
-  return Object.assign(iter, {
+  const result = Object.assign(iter, {
     push(value: T) {
       if (done) return
       if (resolve) {
@@ -52,6 +65,16 @@ export function channel<T>(): AsyncIterable<T> & {
       }
     },
   })
+  Object.defineProperty(result, 'onReturn', {
+    set(fn: (() => void | Promise<unknown>) | undefined) {
+      onReturn = fn
+    },
+    get() {
+      return onReturn
+    },
+    configurable: true,
+  })
+  return result as typeof result & { onReturn?: () => void | Promise<unknown> }
 }
 
 /**
@@ -87,13 +110,19 @@ export async function* merge<T>(
     enqueue(i)
   }
 
-  while (pending.size > 0) {
-    const { index, result } = await Promise.race(pending.values())
-    if (result.done) {
-      pending.delete(index)
-    } else {
-      yield result.value
-      enqueue(index)
+  try {
+    while (pending.size > 0) {
+      const { index, result } = await Promise.race(pending.values())
+      if (result.done) {
+        pending.delete(index)
+      } else {
+        yield result.value
+        enqueue(index)
+      }
+    }
+  } finally {
+    for (const it of iterators) {
+      it.return?.()
     }
   }
 }
@@ -115,16 +144,29 @@ export function split<T, U extends T>(
   iterable: AsyncIterable<T>,
   predicate: (item: T) => item is U
 ): [AsyncIterable<U>, AsyncIterable<Exclude<T, U>>] {
+  const sourceIterator = iterable[Symbol.asyncIterator]()
   const matches = channel<U>()
   const rest = channel<Exclude<T, U>>()
 
+  let aborted = false
+  const abort = () => {
+    if (aborted) return
+    aborted = true
+    matches.close()
+    rest.close()
+    return sourceIterator.return?.()
+  }
+  matches.onReturn = abort
+  rest.onReturn = abort
   ;(async () => {
     try {
-      for await (const item of iterable) {
-        if (predicate(item)) {
-          matches.push(item)
+      while (true) {
+        const result = await sourceIterator.next()
+        if (result.done) break
+        if (predicate(result.value)) {
+          matches.push(result.value)
         } else {
-          rest.push(item as Exclude<T, U>)
+          rest.push(result.value as Exclude<T, U>)
         }
       }
     } finally {

--- a/packages/ts-cli/src/ndjson.ts
+++ b/packages/ts-cli/src/ndjson.ts
@@ -23,20 +23,27 @@ export function ndjsonResponse<T>(
   onError?: (err: unknown) => T
 ): Response {
   const encoder = new TextEncoder()
+  const iterator = iterable[Symbol.asyncIterator]()
 
   const stream = new ReadableStream({
     async start(controller) {
       try {
-        for await (const item of iterable) {
-          controller.enqueue(encoder.encode(JSON.stringify(item) + '\n'))
+        while (true) {
+          const result = await iterator.next()
+          if (result.done) break
+          controller.enqueue(encoder.encode(JSON.stringify(result.value) + '\n'))
         }
       } catch (err) {
         if (onError) {
           controller.enqueue(encoder.encode(JSON.stringify(onError(err)) + '\n'))
         }
       } finally {
+        iterator.return?.()
         controller.close()
       }
+    },
+    cancel() {
+      iterator.return?.()
     },
   })
 


### PR DESCRIPTION
## Summary

The engine process leaked memory unboundedly (258MB → 4GB+) during sustained sync operations. The root cause was a missing teardown chain across the async iterable pipeline: when takeLimits ended a 60-second sync window, nothing told the upstream split/channel/source generators to stop. They kept running in the background, accumulating records in unbounded pending arrays that were never GC'd.


## How to test (optional)

Docker compose with a live Stripe account — engine RSS should stay stable (~300-400MB) across successive 60s sync windows instead of growing unboundedly


