### PR TITLE
auto-detect backfill segment count, remove backfill_concurrency config

### DIFF
--- a/apps/engine/src/__generated__/openapi.d.ts
+++ b/apps/engine/src/__generated__/openapi.d.ts
@@ -575,8 +575,6 @@ export interface components {
             backfill_limit?: number;
             /** @description Max Stripe API requests per second (default: 25) */
             rate_limit?: number;
-            /** @description Number of time-range segments for parallel backfill (default: 10) */
-            backfill_concurrency?: number;
         };
         DestinationConfig: {
             /** @constant */

--- a/apps/engine/src/__generated__/openapi.json
+++ b/apps/engine/src/__generated__/openapi.json
@@ -1636,12 +1636,6 @@
             "exclusiveMinimum": 0,
             "maximum": 9007199254740991,
             "description": "Max Stripe API requests per second (default: 25)"
-          },
-          "backfill_concurrency": {
-            "type": "integer",
-            "exclusiveMinimum": 0,
-            "maximum": 9007199254740991,
-            "description": "Number of time-range segments for parallel backfill (default: 10)"
           }
         },
         "required": [

--- a/apps/service/src/__generated__/openapi.d.ts
+++ b/apps/service/src/__generated__/openapi.d.ts
@@ -120,8 +120,6 @@ export interface components {
             backfill_limit?: number;
             /** @description Max Stripe API requests per second (default: 25) */
             rate_limit?: number;
-            /** @description Number of time-range segments for parallel backfill (default: 10) */
-            backfill_concurrency?: number;
         };
         DestinationConfig: {
             /** @constant */

--- a/apps/service/src/__generated__/openapi.json
+++ b/apps/service/src/__generated__/openapi.json
@@ -886,12 +886,6 @@
             "exclusiveMinimum": 0,
             "maximum": 9007199254740991,
             "description": "Max Stripe API requests per second (default: 25)"
-          },
-          "backfill_concurrency": {
-            "type": "integer",
-            "exclusiveMinimum": 0,
-            "maximum": 9007199254740991,
-            "description": "Number of time-range segments for parallel backfill (default: 10)"
           }
         },
         "required": [

--- a/e2e/stripe-to-postgres.test.ts
+++ b/e2e/stripe-to-postgres.test.ts
@@ -65,7 +65,6 @@ describeWithEnv('stripe → postgres e2e', ['STRIPE_API_KEY'], ({ STRIPE_API_KEY
         stripe: {
           api_key: STRIPE_API_KEY,
           backfill_limit: BACKFILL_LIMIT,
-          backfill_concurrency: 1,
           ...(opts.websocket && { websocket: true }),
         },
       },

--- a/e2e/test-e2e-network.test.ts
+++ b/e2e/test-e2e-network.test.ts
@@ -217,7 +217,6 @@ describe('network interruption e2e via Docker service', () => {
       })
 
       pipelineId = await createCustomersPipeline(harness, schema, {
-        backfill_concurrency: 1,
         rate_limit: 1000,
       })
 
@@ -245,7 +244,6 @@ describe('network interruption e2e via Docker service', () => {
     try {
       harness = await startServiceHarness({ customerCount: 400 })
       pipelineId = await createCustomersPipeline(harness, schema, {
-        backfill_concurrency: 1,
         rate_limit: 1,
       })
 
@@ -274,7 +272,6 @@ describe('network interruption e2e via Docker service', () => {
     try {
       harness = await startServiceHarness({ customerCount: 400 })
       pipelineId = await createCustomersPipeline(harness, schema, {
-        backfill_concurrency: 1,
         rate_limit: 1,
       })
 
@@ -309,7 +306,6 @@ describe('network interruption e2e via Docker service', () => {
     try {
       harness = await startServiceHarness({ customerCount: 400 })
       pipelineId = await createCustomersPipeline(harness, schema, {
-        backfill_concurrency: 1,
         rate_limit: 1,
       })
 

--- a/e2e/test-server-all-api.test.ts
+++ b/e2e/test-server-all-api.test.ts
@@ -195,7 +195,6 @@ async function syncAllEndpointsForVersion(apiVersion: string): Promise<void> {
           api_version: endpointSet.apiVersion,
           base_url: versionTestServer.url,
           rate_limit: RATE_LIMIT,
-          backfill_concurrency: 12,
         },
       },
       destination: {

--- a/e2e/test-server-sync.test.ts
+++ b/e2e/test-server-sync.test.ts
@@ -284,7 +284,6 @@ describe('test-server sync via Docker engine', () => {
 
     const { state } = await runSync({
       destSchema,
-      sourceOverrides: { backfill_concurrency: CONC },
       state: sourceState({ customers: pendingState({ num_segments: CONC }) }),
     })
 
@@ -320,7 +319,6 @@ describe('test-server sync via Docker engine', () => {
     await seedCustomers([...inRange, ...outOfRange])
     await runSync({
       destSchema,
-      sourceOverrides: { backfill_concurrency: 1 },
       state: sourceState({ customers: pendingState({ num_segments: 1 }) }),
     })
 
@@ -342,7 +340,6 @@ describe('test-server sync via Docker engine', () => {
 
     const { messages } = await runSync({
       destSchema,
-      sourceOverrides: { backfill_concurrency: 1 },
     })
 
     expect(await countRows(destSchema, 'customers')).toBe(COUNT)
@@ -372,7 +369,6 @@ describe('test-server sync via Docker engine', () => {
 
     const { messages } = await runRead({
       destSchema,
-      sourceOverrides: { backfill_concurrency: CONC },
       state: sourceState({ customers: pendingState({ num_segments: CONC }) }),
     })
 
@@ -403,7 +399,6 @@ describe('test-server sync via Docker engine', () => {
     const completedRange = { gte: segments[0].gte, lt: segments[2].lt }
     await runSync({
       destSchema,
-      sourceOverrides: { backfill_concurrency: CONC },
       state: sourceState({
         customers: pendingState({
           num_segments: CONC,
@@ -444,7 +439,6 @@ describe('test-server sync via Docker engine', () => {
 
     const { state } = await runSync({
       destSchema,
-      sourceOverrides: { backfill_concurrency: CONC },
       state: sourceState({ customers: pendingState({ num_segments: CONC }) }),
     })
 
@@ -474,7 +468,6 @@ describe('test-server sync via Docker engine', () => {
 
     const { messages } = await runSync({
       destSchema,
-      sourceOverrides: { backfill_concurrency: 1 },
       streams: [{ name: 'customers', sync_mode: 'full_refresh', backfill_limit: 5 }],
     })
 
@@ -495,7 +488,6 @@ describe('test-server sync via Docker engine', () => {
     await seedCustomers(objects)
     await runSync({
       destSchema,
-      sourceOverrides: { backfill_concurrency: 1 },
     })
 
     const destIds = new Set(await listIds(destSchema, 'customers'))
@@ -530,7 +522,6 @@ describe('test-server sync via Docker engine', () => {
 
     const { state } = await runSync({
       destSchema,
-      sourceOverrides: { backfill_concurrency: 1 },
       streams: [
         { name: 'customers', sync_mode: 'full_refresh' },
         { name: 'products', sync_mode: 'full_refresh' },
@@ -550,7 +541,6 @@ describe('test-server sync via Docker engine', () => {
 
     const { state } = await runSync({
       destSchema,
-      sourceOverrides: { backfill_concurrency: 1 },
     })
 
     expect(await countRows(destSchema, 'customers')).toBe(0)
@@ -564,7 +554,6 @@ describe('test-server sync via Docker engine', () => {
 
     const { state } = await runSync({
       destSchema,
-      sourceOverrides: { backfill_concurrency: 1 },
     })
 
     const ids = await listIds(destSchema, 'customers')
@@ -579,7 +568,6 @@ describe('test-server sync via Docker engine', () => {
     await seedCustomers(sourceObjects)
     await runSync({
       destSchema,
-      sourceOverrides: { backfill_concurrency: 1 },
     })
 
     expect(await countRows(destSchema, 'customers')).toBe(sourceObjects.length)
@@ -616,7 +604,6 @@ describe('test-server sync via Docker engine', () => {
 
     const { messages, state } = await runSync({
       destSchema,
-      sourceOverrides: { backfill_concurrency: CONC },
       state: sourceState({ customers: pendingState({ num_segments: CONC }) }),
     })
 
@@ -650,7 +637,7 @@ describe('test-server sync via Docker engine', () => {
 
     const { state } = await runSync({
       destSchema,
-      sourceOverrides: { backfill_concurrency: CONC, rate_limit: 1_000 },
+      sourceOverrides: { rate_limit: 1_000 },
       state: sourceState({ customers: pendingState({ num_segments: CONC }) }),
     })
 
@@ -678,7 +665,7 @@ describe('test-server sync via Docker engine', () => {
       const destSchema = uniqueSchema(`multikey_${apiKey.slice(-5)}`)
       const { state } = await runSync({
         destSchema,
-        sourceOverrides: { api_key: apiKey, backfill_concurrency: 3 },
+        sourceOverrides: { api_key: apiKey },
       })
       return { apiKey, destSchema, state }
     })

--- a/e2e/test-sync-engine.test.ts
+++ b/e2e/test-sync-engine.test.ts
@@ -271,7 +271,6 @@ describe('Stripe failure handling via Docker engine', () => {
       baseUrl: server.url,
       sourceOverrides: {
         api_key: 'sk_test_bad',
-        backfill_concurrency: 1,
       },
     })
 
@@ -320,7 +319,6 @@ describe('Stripe failure handling via Docker engine', () => {
         { name: 'customers', sync_mode: 'full_refresh' },
         { name: 'products', sync_mode: 'full_refresh' },
       ],
-      sourceOverrides: { backfill_concurrency: 1 },
     })
 
     const customerError = getErrorTrace(messages, 'customers')
@@ -363,7 +361,6 @@ describe('Stripe failure handling via Docker engine', () => {
     const { messages, state } = await runSync({
       destSchema,
       baseUrl: server.url,
-      sourceOverrides: { backfill_concurrency: 1 },
     })
 
     expect(getErrorTrace(messages, 'customers')).toBeUndefined()

--- a/packages/openapi/index.ts
+++ b/packages/openapi/index.ts
@@ -20,6 +20,7 @@ export type {
   ListEndpoint,
   NestedEndpoint,
   ListFn,
+  ListResult,
   RetrieveFn,
   ListParams,
 } from './listFnResolver.js'

--- a/packages/source-stripe/src/index.test.ts
+++ b/packages/source-stripe/src/index.test.ts
@@ -2122,6 +2122,11 @@ describe('StripeSource', () => {
         })
       )
 
+      // First call is the density probe — verify it includes created filter
+      expect(parallelListFn.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ limit: 100, created: expect.any(Object) })
+      )
+
       for (const call of parallelListFn.mock.calls.slice(1)) {
         expect(call[0]).toHaveProperty('created')
       }

--- a/packages/source-stripe/src/index.test.ts
+++ b/packages/source-stripe/src/index.test.ts
@@ -653,7 +653,6 @@ describe('StripeSource', () => {
           client: mockClient,
           accountId: 'acct_test',
           rateLimiter: async () => 0,
-          backfillConcurrency: 2,
         })
       )
 
@@ -1925,7 +1924,6 @@ describe('StripeSource', () => {
           client: mockClient,
           accountId: 'acct_test',
           rateLimiter,
-          backfillConcurrency: 3,
         })
       )
 
@@ -1980,7 +1978,6 @@ describe('StripeSource', () => {
           client: mockClient,
           accountId: 'acct_test',
           rateLimiter,
-          backfillConcurrency: 3,
         })
       )
 
@@ -2122,11 +2119,10 @@ describe('StripeSource', () => {
           client: mockClient,
           accountId: 'acct_test',
           rateLimiter,
-          backfillConcurrency: 3,
         })
       )
 
-      for (const call of parallelListFn.mock.calls) {
+      for (const call of parallelListFn.mock.calls.slice(1)) {
         expect(call[0]).toHaveProperty('created')
       }
 

--- a/packages/source-stripe/src/index.ts
+++ b/packages/source-stripe/src/index.ts
@@ -387,5 +387,10 @@ export { catalogFromRegistry } from './catalog.js'
 export { SpecParser, OPENAPI_RESOURCE_TABLE_ALIASES } from './openapi/specParser.js'
 export type { ParsedResourceTable, ParsedOpenApiSpec } from './openapi/types.js'
 export type { RateLimiter } from './rate-limiter.js'
-export { createInMemoryRateLimiter, DEFAULT_MAX_RPS } from './rate-limiter.js'
+export {
+  createInMemoryRateLimiter,
+  DEFAULT_MAX_RPS,
+  MAX_SEGMENTS,
+  MAX_CONCURRENCY,
+} from './rate-limiter.js'
 export { verifyWebhookSignature, WebhookSignatureError } from './webhookVerify.js'

--- a/packages/source-stripe/src/index.ts
+++ b/packages/source-stripe/src/index.ts
@@ -307,7 +307,6 @@ export function createStripeSource(
           client,
           accountId,
           backfillLimit: config.backfill_limit,
-          backfillConcurrency: config.backfill_concurrency,
           drainQueue: wsClient
             ? () => inputQueue.drain(config, catalog, registry, streamNames, accountId)
             : undefined,

--- a/packages/source-stripe/src/rate-limiter.ts
+++ b/packages/source-stripe/src/rate-limiter.ts
@@ -5,9 +5,31 @@
  * This contract matches `util-postgres`'s `acquire()` return value so a
  * Postgres-backed implementation can be used as a drop-in replacement.
  */
+export type RateLimiter = (cost?: number) => Promise<number>
+
+// -- Backfill tuning constants ------------------------------------------------
+// All three knobs live here so they're easy to find and reason about together.
+
+/** Token-bucket refill rate. Each list API call costs 1 token. */
 export const DEFAULT_MAX_RPS = 25
 
-export type RateLimiter = (cost?: number) => Promise<number>
+/**
+ * Upper bound on how many time segments a single stream's backfill is split
+ * into. More segments = finer time slices, but each one becomes its own
+ * async generator so the overhead grows. 50 is high enough to saturate the
+ * rate limit on dense streams without excessive per-segment bookkeeping.
+ */
+export const MAX_SEGMENTS = 50
+
+/**
+ * How many segment generators run concurrently inside `mergeAsync`.
+ * Independent of MAX_SEGMENTS — a stream may be split into 50 segments but
+ * only 15 are actively fetching pages at any moment. This bounds memory
+ * pressure (each in-flight generator holds a partial page) and avoids
+ * bursty traffic that the token-bucket would otherwise have to absorb.
+ * 15 × ~2 pages/sec ≈ 30 RPS before the limiter starts throttling.
+ */
+export const MAX_CONCURRENCY = 15
 
 /**
  * In-memory token-bucket rate limiter.

--- a/packages/source-stripe/src/spec.ts
+++ b/packages/source-stripe/src/spec.ts
@@ -50,12 +50,6 @@ export const configSchema = z.object({
     .positive()
     .optional()
     .describe('Max Stripe API requests per second (default: 25)'),
-  backfill_concurrency: z
-    .number()
-    .int()
-    .positive()
-    .optional()
-    .describe('Number of time-range segments for parallel backfill (default: 10)'),
 })
 
 export type Config = z.infer<typeof configSchema>

--- a/packages/source-stripe/src/src-list-api.test.ts
+++ b/packages/source-stripe/src/src-list-api.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { SegmentState, BackfillState } from './index.js'
-import { compactState, expandState, probeSegmentCount } from './src-list-api.js'
+import {
+  compactState,
+  expandState,
+  probeAndBuildSegments,
+  segmentCountFromDensity,
+} from './src-list-api.js'
 
 const seg = (
   index: number,
@@ -151,7 +156,47 @@ describe('compactState → expandState round-trip', () => {
   })
 })
 
-// MARK: - probeSegmentCount
+// MARK: - segmentCountFromDensity
+
+describe('segmentCountFromDensity', () => {
+  it('returns MAX_SEGMENTS (50) for zero or negative timeProgress', () => {
+    expect(segmentCountFromDensity(0)).toBe(50)
+    expect(segmentCountFromDensity(-1)).toBe(50)
+  })
+
+  it('returns 1 for very sparse data (timeProgress >= 1)', () => {
+    expect(segmentCountFromDensity(1)).toBe(1)
+    expect(segmentCountFromDensity(2)).toBe(1)
+  })
+
+  it('returns 2 for timeProgress = 0.5', () => {
+    expect(segmentCountFromDensity(0.5)).toBe(2)
+  })
+
+  it('returns 10 for timeProgress = 0.1', () => {
+    expect(segmentCountFromDensity(0.1)).toBe(10)
+  })
+
+  it('returns 50 for very dense data (timeProgress = 0.02)', () => {
+    expect(segmentCountFromDensity(0.02)).toBe(50)
+  })
+
+  it('caps at 50 for extremely dense data', () => {
+    expect(segmentCountFromDensity(0.001)).toBe(50)
+  })
+
+  it('produces smooth values without cliff edges', () => {
+    const at9 = segmentCountFromDensity(0.09)
+    const at10 = segmentCountFromDensity(0.10)
+    const at11 = segmentCountFromDensity(0.11)
+    expect(at9).toBeGreaterThanOrEqual(at10)
+    expect(at10).toBeGreaterThanOrEqual(at11)
+    // No jump from 10 to 50 at the boundary
+    expect(at9 - at10).toBeLessThanOrEqual(2)
+  })
+})
+
+// MARK: - probeAndBuildSegments
 
 type MockListResult = { data: unknown[]; has_more: boolean }
 
@@ -159,73 +204,102 @@ function mockListFn(response: MockListResult) {
   return async () => response
 }
 
-const noopRateLimiter = async () => 0
-
-describe('probeSegmentCount', () => {
+describe('probeAndBuildSegments', () => {
   const probeRange = { gte: 0, lt: 1000 }
 
-  it('returns 1 for an empty stream', async () => {
-    const result = await probeSegmentCount({
+  it('returns 1 segment for an empty stream', async () => {
+    const result = await probeAndBuildSegments({
       listFn: mockListFn({ data: [], has_more: false }),
       range: probeRange,
-      rateLimiter: noopRateLimiter,
     })
-    expect(result).toBe(1)
+    expect(result.numSegments).toBe(1)
+    expect(result.segments).toHaveLength(1)
+    expect(result.firstPage.data).toEqual([])
   })
 
-  it('returns 1 when all data fits in one page', async () => {
+  it('returns 1 segment when all data fits in one page', async () => {
     const items = Array.from({ length: 50 }, (_, i) => ({ id: `id_${i}`, created: 900 - i }))
-    const result = await probeSegmentCount({
+    const result = await probeAndBuildSegments({
       listFn: mockListFn({ data: items, has_more: false }),
       range: probeRange,
-      rateLimiter: noopRateLimiter,
     })
-    expect(result).toBe(1)
+    expect(result.numSegments).toBe(1)
+    expect(result.firstPage.data).toHaveLength(50)
   })
 
-  it('returns 1 for low density (100 items cover >= 20% of time)', async () => {
-    // 100 items, last item created at 800 → timeProgress = (1000-800)/1000 = 0.2
-    const items = Array.from({ length: 100 }, (_, i) => ({ id: `id_${i}`, created: 1000 - i * 2 }))
-    items[99] = { id: 'id_last', created: 800 }
-    const result = await probeSegmentCount({
+  it('returns few segments for sparse data', async () => {
+    // last item created at 500 → timeProgress = (1000-500)/1000 = 0.5 → ceil(1/0.5) = 2
+    const items = Array.from({ length: 100 }, (_, i) => ({ id: `id_${i}`, created: 999 - i * 5 }))
+    items[99] = { id: 'id_last', created: 500 }
+    const result = await probeAndBuildSegments({
       listFn: mockListFn({ data: items, has_more: true }),
       range: probeRange,
-      rateLimiter: noopRateLimiter,
     })
-    expect(result).toBe(1)
+    expect(result.numSegments).toBe(2)
   })
 
-  it('returns 10 for medium density (100 items cover 10-20% of time)', async () => {
-    // last item created at 850 → timeProgress = (1000-850)/1000 = 0.15
-    const items = Array.from({ length: 100 }, (_, i) => ({ id: `id_${i}`, created: 999 - i }))
-    items[99] = { id: 'id_last', created: 850 }
-    const result = await probeSegmentCount({
-      listFn: mockListFn({ data: items, has_more: true }),
-      range: probeRange,
-      rateLimiter: noopRateLimiter,
-    })
-    expect(result).toBe(10)
-  })
-
-  it('returns 50 for high density (100 items cover < 10% of time)', async () => {
-    // last item created at 950 → timeProgress = (1000-950)/1000 = 0.05
+  it('returns many segments for dense data', async () => {
+    // last item created at 950 → timeProgress = (1000-950)/1000 = 0.05 → ceil(1/0.05) = 20
     const items = Array.from({ length: 100 }, (_, i) => ({ id: `id_${i}`, created: 999 - i }))
     items[99] = { id: 'id_last', created: 950 }
-    const result = await probeSegmentCount({
+    const result = await probeAndBuildSegments({
       listFn: mockListFn({ data: items, has_more: true }),
       range: probeRange,
-      rateLimiter: noopRateLimiter,
     })
-    expect(result).toBe(50)
+    expect(result.numSegments).toBe(20)
   })
 
-  it('falls back to 10 when items lack created field', async () => {
-    const items = Array.from({ length: 100 }, (_, i) => ({ id: `id_${i}` }))
-    const result = await probeSegmentCount({
+  it('returns MAX_SEGMENTS (50) for extremely dense data', async () => {
+    // last item created at 990 → timeProgress = (1000-990)/1000 = 0.01 → ceil(1/0.01) = 100, capped at 50
+    const items = Array.from({ length: 100 }, (_, i) => ({ id: `id_${i}`, created: 999 }))
+    items[99] = { id: 'id_last', created: 990 }
+    const result = await probeAndBuildSegments({
       listFn: mockListFn({ data: items, has_more: true }),
       range: probeRange,
-      rateLimiter: noopRateLimiter,
     })
-    expect(result).toBe(10)
+    expect(result.numSegments).toBe(50)
+  })
+
+  it('falls back to MAX_SEGMENTS when items lack created field', async () => {
+    // lastItem.created is undefined → fallback to range.gte → timeProgress = (1000-0)/1000 = 1 → 1 segment
+    const items = Array.from({ length: 100 }, (_, i) => ({ id: `id_${i}` }))
+    const result = await probeAndBuildSegments({
+      listFn: mockListFn({ data: items, has_more: true }),
+      range: probeRange,
+    })
+    // (range.lt - range.gte) / totalSpan = 1.0 → ceil(1/1) = 1
+    expect(result.numSegments).toBe(1)
+  })
+
+  it('handles division-by-zero when range.lt === range.gte', async () => {
+    const items = Array.from({ length: 100 }, (_, i) => ({ id: `id_${i}`, created: 500 }))
+    const result = await probeAndBuildSegments({
+      listFn: mockListFn({ data: items, has_more: true }),
+      range: { gte: 1000, lt: 1000 },
+    })
+    expect(result.numSegments).toBe(1)
+    expect(result.segments).toHaveLength(1)
+  })
+
+  it('returns the firstPage data for zero-waste consumption', async () => {
+    const items = [
+      { id: 'id_0', created: 999 },
+      { id: 'id_1', created: 998 },
+    ]
+    const result = await probeAndBuildSegments({
+      listFn: mockListFn({ data: items, has_more: false }),
+      range: probeRange,
+    })
+    expect(result.firstPage.data).toEqual(items)
+    expect(result.firstPage.has_more).toBe(false)
+  })
+
+  it('passes created filter in the probe call', async () => {
+    const spy = async (params: unknown) => {
+      const p = params as { created?: { gte: number; lt: number } }
+      expect(p.created).toEqual({ gte: 0, lt: 1000 })
+      return { data: [], has_more: false }
+    }
+    await probeAndBuildSegments({ listFn: spy, range: probeRange })
   })
 })

--- a/packages/source-stripe/src/src-list-api.test.ts
+++ b/packages/source-stripe/src/src-list-api.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { SegmentState, BackfillState } from './index.js'
-import { compactState, expandState } from './src-list-api.js'
+import { compactState, expandState, probeSegmentCount } from './src-list-api.js'
 
 const seg = (
   index: number,
@@ -148,5 +148,84 @@ describe('compactState → expandState round-trip', () => {
     expect(pending.length).toBeGreaterThanOrEqual(1)
     expect(pending[0].gte).toBe(750)
     expect(pending[pending.length - 1].lt).toBe(1000)
+  })
+})
+
+// MARK: - probeSegmentCount
+
+type MockListResult = { data: unknown[]; has_more: boolean }
+
+function mockListFn(response: MockListResult) {
+  return async () => response
+}
+
+const noopRateLimiter = async () => 0
+
+describe('probeSegmentCount', () => {
+  const probeRange = { gte: 0, lt: 1000 }
+
+  it('returns 1 for an empty stream', async () => {
+    const result = await probeSegmentCount({
+      listFn: mockListFn({ data: [], has_more: false }),
+      range: probeRange,
+      rateLimiter: noopRateLimiter,
+    })
+    expect(result).toBe(1)
+  })
+
+  it('returns 1 when all data fits in one page', async () => {
+    const items = Array.from({ length: 50 }, (_, i) => ({ id: `id_${i}`, created: 900 - i }))
+    const result = await probeSegmentCount({
+      listFn: mockListFn({ data: items, has_more: false }),
+      range: probeRange,
+      rateLimiter: noopRateLimiter,
+    })
+    expect(result).toBe(1)
+  })
+
+  it('returns 1 for low density (100 items cover >= 20% of time)', async () => {
+    // 100 items, last item created at 800 → timeProgress = (1000-800)/1000 = 0.2
+    const items = Array.from({ length: 100 }, (_, i) => ({ id: `id_${i}`, created: 1000 - i * 2 }))
+    items[99] = { id: 'id_last', created: 800 }
+    const result = await probeSegmentCount({
+      listFn: mockListFn({ data: items, has_more: true }),
+      range: probeRange,
+      rateLimiter: noopRateLimiter,
+    })
+    expect(result).toBe(1)
+  })
+
+  it('returns 10 for medium density (100 items cover 10-20% of time)', async () => {
+    // last item created at 850 → timeProgress = (1000-850)/1000 = 0.15
+    const items = Array.from({ length: 100 }, (_, i) => ({ id: `id_${i}`, created: 999 - i }))
+    items[99] = { id: 'id_last', created: 850 }
+    const result = await probeSegmentCount({
+      listFn: mockListFn({ data: items, has_more: true }),
+      range: probeRange,
+      rateLimiter: noopRateLimiter,
+    })
+    expect(result).toBe(10)
+  })
+
+  it('returns 50 for high density (100 items cover < 10% of time)', async () => {
+    // last item created at 950 → timeProgress = (1000-950)/1000 = 0.05
+    const items = Array.from({ length: 100 }, (_, i) => ({ id: `id_${i}`, created: 999 - i }))
+    items[99] = { id: 'id_last', created: 950 }
+    const result = await probeSegmentCount({
+      listFn: mockListFn({ data: items, has_more: true }),
+      range: probeRange,
+      rateLimiter: noopRateLimiter,
+    })
+    expect(result).toBe(50)
+  })
+
+  it('falls back to 10 when items lack created field', async () => {
+    const items = Array.from({ length: 100 }, (_, i) => ({ id: `id_${i}` }))
+    const result = await probeSegmentCount({
+      listFn: mockListFn({ data: items, has_more: true }),
+      range: probeRange,
+      rateLimiter: noopRateLimiter,
+    })
+    expect(result).toBe(10)
   })
 })

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -1,10 +1,24 @@
 import type { Message, TraceMessage } from '@stripe/sync-protocol'
 import { toRecordMessage, stateMsg } from '@stripe/sync-protocol'
+import type { ListFn, ListResult } from '@stripe/sync-openapi'
 import type { ResourceConfig } from './types.js'
 import type { SegmentState, BackfillState } from './index.js'
 import type { RateLimiter } from './rate-limiter.js'
 import { StripeApiRequestError } from '@stripe/sync-openapi'
 import type { StripeClient } from './client.js'
+
+// MARK: - Rate-limit wrapper
+
+const MAX_SEGMENTS = 50
+const MAX_CONCURRENCY = 15
+
+function withRateLimit(listFn: ListFn, rateLimiter: RateLimiter): ListFn {
+  return async (params) => {
+    const wait = await rateLimiter()
+    if (wait > 0) await new Promise((r) => setTimeout(r, wait * 1000))
+    return listFn(params)
+  }
+}
 
 export function errorToTrace(err: unknown, stream: string): TraceMessage {
   const isRateLimit = err instanceof Error && err.message.includes('Rate limit')
@@ -230,7 +244,7 @@ async function getAccountCreatedTimestamp(client: StripeClient): Promise<number>
 function buildSegments(
   startTimestamp: number,
   endTimestamp: number,
-  numSegments = 50
+  numSegments: number
 ): SegmentState[] {
   const range = endTimestamp - startTimestamp
   const segmentSize = Math.max(1, Math.ceil(range / numSegments))
@@ -246,43 +260,69 @@ function buildSegments(
   return segments
 }
 
-// MARK: - Density probe
+// MARK: - Density probe + segment construction
 
 /**
- * Probe data density with a single list call to choose the segment count.
+ * Smooth mapping from density to segment count. `timeProgress` is the fraction
+ * of the backfill time range covered by the first 100 items. The inverse
+ * relationship avoids the cliff edges of discrete tiers.
+ */
+export function segmentCountFromDensity(timeProgress: number): number {
+  if (timeProgress <= 0) return MAX_SEGMENTS
+  return Math.max(1, Math.min(MAX_SEGMENTS, Math.ceil(1 / timeProgress)))
+}
+
+/**
+ * Probe data density with a single list call, then build the segment array.
+ * The probe fetches with a `created` filter (forward-compatible if the range
+ * narrows later) and returns its response so the caller can yield the records
+ * directly — zero wasted API calls.
+ *
  * Stripe returns data in descending `created` order. If 100 items span a
  * large fraction of the time range the resource is sparse and fewer segments
  * suffice; if they cluster in a narrow window the resource is dense and more
  * segments help parallelise.
  */
-export async function probeSegmentCount(opts: {
-  listFn: NonNullable<ResourceConfig['listFn']>
+export async function probeAndBuildSegments(opts: {
+  listFn: ListFn
   range: { gte: number; lt: number }
-  rateLimiter: RateLimiter
-}): Promise<number> {
-  const { listFn, range, rateLimiter } = opts
-  const wait = await rateLimiter()
-  if (wait > 0) await new Promise((r) => setTimeout(r, wait * 1000))
+}): Promise<{ segments: SegmentState[]; numSegments: number; firstPage: ListResult }> {
+  const { listFn, range } = opts
 
-  const response = await listFn({ limit: 100 })
+  const firstPage = await listFn({
+    limit: 100,
+    created: { gte: range.gte, lt: range.lt },
+  })
 
-  if (!response.has_more) return 1
+  if (!firstPage.has_more) {
+    return {
+      segments: [{ index: 0, gte: range.gte, lt: range.lt, page_cursor: null, status: 'pending' }],
+      numSegments: 1,
+      firstPage,
+    }
+  }
 
-  const lastItem = response.data[response.data.length - 1] as { created?: number }
-  if (!lastItem?.created) return 10
-
+  const lastItem = firstPage.data[firstPage.data.length - 1] as { created?: number }
   const totalSpan = range.lt - range.gte
-  const timeProgress = (range.lt - lastItem.created) / totalSpan
+  if (totalSpan <= 0) {
+    return {
+      segments: [{ index: 0, gte: range.gte, lt: range.lt, page_cursor: null, status: 'pending' }],
+      numSegments: 1,
+      firstPage,
+    }
+  }
 
-  if (timeProgress >= 0.2) return 1
-  if (timeProgress >= 0.1) return 10
-  return 50
+  const timeProgress = (range.lt - (lastItem?.created ?? range.gte)) / totalSpan
+  const numSegments = segmentCountFromDensity(timeProgress)
+  const segments = buildSegments(range.gte, range.lt - 1, numSegments)
+
+  return { segments, numSegments, firstPage }
 }
 
 // MARK: - Segment pagination
 
 async function* paginateSegment(opts: {
-  listFn: NonNullable<ResourceConfig['listFn']>
+  listFn: ListFn
   segment: SegmentState
   segments: SegmentState[]
   range: { gte: number; lt: number }
@@ -293,7 +333,6 @@ async function* paginateSegment(opts: {
   supportsForwardPagination: boolean
   backfillLimit?: number
   totalEmitted: { count: number }
-  rateLimiter: RateLimiter
 }): AsyncGenerator<Message> {
   const {
     listFn,
@@ -307,7 +346,6 @@ async function* paginateSegment(opts: {
     supportsForwardPagination,
     backfillLimit,
     totalEmitted,
-    rateLimiter,
   } = opts
 
   let pageCursor: string | null = segment.page_cursor
@@ -324,8 +362,6 @@ async function* paginateSegment(opts: {
       params.starting_after = pageCursor
     }
 
-    const wait = await rateLimiter()
-    if (wait > 0) await new Promise((r) => setTimeout(r, wait * 1000))
     const response = await listFn(params as Parameters<typeof listFn>[0])
 
     for (const item of response.data) {
@@ -366,15 +402,14 @@ async function* paginateSegment(opts: {
 // MARK: - Sequential fallback (original logic)
 
 async function* sequentialBackfillStream(opts: {
-  resourceConfig: ResourceConfig
+  resourceConfig: ResourceConfig & { listFn: ListFn }
   streamName: string
   accountId: string
   pageCursor: string | null
   backfillLimit?: number
-  rateLimiter: RateLimiter
   drainQueue?: () => AsyncGenerator<Message>
 }): AsyncGenerator<Message> {
-  const { resourceConfig, streamName, accountId, backfillLimit, rateLimiter, drainQueue } = opts
+  const { resourceConfig, streamName, accountId, backfillLimit, drainQueue } = opts
   let pageCursor = opts.pageCursor
   let hasMore = true
   let totalEmitted = 0
@@ -394,10 +429,8 @@ async function* sequentialBackfillStream(opts: {
       params.starting_after = pageCursor
     }
 
-    const wait = await rateLimiter()
-    if (wait > 0) await new Promise((r) => setTimeout(r, wait * 1000))
-    const response = await resourceConfig.listFn!(
-      params as Parameters<NonNullable<typeof resourceConfig.listFn>>[0]
+    const response = await resourceConfig.listFn(
+      params as Parameters<typeof resourceConfig.listFn>[0]
     )
 
     for (const item of response.data) {
@@ -498,11 +531,14 @@ export async function* listApiBackfill(opts: {
     } satisfies TraceMessage
 
     try {
+      const rateLimitedListFn = withRateLimit(resourceConfig.listFn!, rateLimiter)
+
       // Parallel path: streams that support created filter
       if (resourceConfig.supportsCreatedFilter) {
         let segments: SegmentState[]
         let range: { gte: number; lt: number }
         let numSegments: number
+        let firstPage: ListResult | null = null
 
         if (streamState?.backfill) {
           // Resume from compact backfill state
@@ -515,26 +551,58 @@ export async function* listApiBackfill(opts: {
           range = { gte: segments[0].gte, lt: segments[segments.length - 1].lt }
           numSegments = segments.length
         } else {
-          // First run: fetch account creation date and build segments
+          // First run: probe density and build segments in one call
           if (accountCreated === null) {
             accountCreated = await getAccountCreatedTimestamp(client)
           }
           const now = Math.floor(Date.now() / 1000)
           range = { gte: accountCreated, lt: now + 1 }
-          numSegments = await probeSegmentCount({
-            listFn: resourceConfig.listFn!,
+          const probe = await probeAndBuildSegments({
+            listFn: rateLimitedListFn,
             range,
-            rateLimiter,
           })
-          segments = buildSegments(accountCreated, now, numSegments)
+          segments = probe.segments
+          numSegments = probe.numSegments
+          firstPage = probe.firstPage
         }
 
         const incompleteSegments = segments.filter((s) => s.status !== 'complete')
         if (incompleteSegments.length > 0) {
           const totalEmitted = { count: 0 }
-          const generators = incompleteSegments.map((segment) =>
+
+          // Yield probe's first page records directly (zero waste)
+          if (firstPage && firstPage.data.length > 0) {
+            const newestSegment = incompleteSegments[0]
+            for (const item of firstPage.data) {
+              yield toRecordMessage(stream.name, {
+                ...(item as Record<string, unknown>),
+                _account_id: accountId,
+              })
+              totalEmitted.count++
+            }
+            // Set cursor so paginateSegment continues from where the probe left off
+            if (firstPage.has_more) {
+              const lastId = (firstPage.data[firstPage.data.length - 1] as { id: string }).id
+              newestSegment.page_cursor = lastId
+            } else {
+              newestSegment.status = 'complete'
+            }
+            // Emit checkpoint after yielding probe data
+            const allComplete = segments.every((s) => s.status === 'complete')
+            yield stateMsg({
+              stream: stream.name,
+              data: {
+                page_cursor: null,
+                status: allComplete ? 'complete' : 'pending',
+                backfill: compactState(segments, range, numSegments),
+              },
+            })
+          }
+
+          const stillIncomplete = segments.filter((s) => s.status !== 'complete')
+          const generators = stillIncomplete.map((segment) =>
             paginateSegment({
-              listFn: resourceConfig.listFn!,
+              listFn: rateLimitedListFn,
               segment,
               segments,
               range,
@@ -545,22 +613,20 @@ export async function* listApiBackfill(opts: {
               supportsForwardPagination: resourceConfig.supportsForwardPagination !== false,
               backfillLimit: streamBackfillLimit,
               totalEmitted,
-              rateLimiter,
             })
           )
 
-          yield* mergeAsync(generators, numSegments)
+          yield* mergeAsync(generators, MAX_CONCURRENCY)
         }
       } else {
         // Sequential path: no created filter support
         const pageCursor: string | null = streamState?.page_cursor ?? null
         yield* sequentialBackfillStream({
-          resourceConfig,
+          resourceConfig: { ...resourceConfig, listFn: rateLimitedListFn },
           streamName: stream.name,
           accountId,
           pageCursor,
           backfillLimit: streamBackfillLimit,
-          rateLimiter,
           drainQueue,
         })
       }

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -4,13 +4,11 @@ import type { ListFn, ListResult } from '@stripe/sync-openapi'
 import type { ResourceConfig } from './types.js'
 import type { SegmentState, BackfillState } from './index.js'
 import type { RateLimiter } from './rate-limiter.js'
+import { MAX_SEGMENTS, MAX_CONCURRENCY } from './rate-limiter.js'
 import { StripeApiRequestError } from '@stripe/sync-openapi'
 import type { StripeClient } from './client.js'
 
 // MARK: - Rate-limit wrapper
-
-const MAX_SEGMENTS = 50
-const MAX_CONCURRENCY = 15
 
 function withRateLimit(listFn: ListFn, rateLimiter: RateLimiter): ListFn {
   return async (params) => {

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -49,8 +49,6 @@ const SKIPPABLE_ERROR_PATTERNS = [
   'not set up to use',
 ]
 
-const DEFAULT_BACKFILL_CONCURRENCY = 10
-
 // MARK: - Compact state (generative — O(concurrency) not O(total segments))
 
 /**
@@ -232,7 +230,7 @@ async function getAccountCreatedTimestamp(client: StripeClient): Promise<number>
 function buildSegments(
   startTimestamp: number,
   endTimestamp: number,
-  numSegments = DEFAULT_BACKFILL_CONCURRENCY
+  numSegments = 50
 ): SegmentState[] {
   const range = endTimestamp - startTimestamp
   const segmentSize = Math.max(1, Math.ceil(range / numSegments))
@@ -246,6 +244,39 @@ function buildSegments(
   }
 
   return segments
+}
+
+// MARK: - Density probe
+
+/**
+ * Probe data density with a single list call to choose the segment count.
+ * Stripe returns data in descending `created` order. If 100 items span a
+ * large fraction of the time range the resource is sparse and fewer segments
+ * suffice; if they cluster in a narrow window the resource is dense and more
+ * segments help parallelise.
+ */
+export async function probeSegmentCount(opts: {
+  listFn: NonNullable<ResourceConfig['listFn']>
+  range: { gte: number; lt: number }
+  rateLimiter: RateLimiter
+}): Promise<number> {
+  const { listFn, range, rateLimiter } = opts
+  const wait = await rateLimiter()
+  if (wait > 0) await new Promise((r) => setTimeout(r, wait * 1000))
+
+  const response = await listFn({ limit: 100 })
+
+  if (!response.has_more) return 1
+
+  const lastItem = response.data[response.data.length - 1] as { created?: number }
+  if (!lastItem?.created) return 10
+
+  const totalSpan = range.lt - range.gte
+  const timeProgress = (range.lt - lastItem.created) / totalSpan
+
+  if (timeProgress >= 0.2) return 1
+  if (timeProgress >= 0.1) return 10
+  return 50
 }
 
 // MARK: - Segment pagination
@@ -418,7 +449,6 @@ export async function* listApiBackfill(opts: {
   accountId: string
   rateLimiter: RateLimiter
   backfillLimit?: number
-  backfillConcurrency?: number
   drainQueue?: () => AsyncGenerator<Message>
 }): AsyncGenerator<Message> {
   const {
@@ -429,7 +459,6 @@ export async function* listApiBackfill(opts: {
     accountId,
     rateLimiter,
     backfillLimit,
-    backfillConcurrency = DEFAULT_BACKFILL_CONCURRENCY,
     drainQueue,
   } = opts
 
@@ -484,7 +513,7 @@ export async function* listApiBackfill(opts: {
           // Legacy: resume from old segment array format
           segments = streamState.segments.map((s) => ({ ...s }))
           range = { gte: segments[0].gte, lt: segments[segments.length - 1].lt }
-          numSegments = backfillConcurrency
+          numSegments = segments.length
         } else {
           // First run: fetch account creation date and build segments
           if (accountCreated === null) {
@@ -492,8 +521,12 @@ export async function* listApiBackfill(opts: {
           }
           const now = Math.floor(Date.now() / 1000)
           range = { gte: accountCreated, lt: now + 1 }
-          numSegments = backfillConcurrency
-          segments = buildSegments(accountCreated, now, backfillConcurrency)
+          numSegments = await probeSegmentCount({
+            listFn: resourceConfig.listFn!,
+            range,
+            rateLimiter,
+          })
+          segments = buildSegments(accountCreated, now, numSegments)
         }
 
         const incompleteSegments = segments.filter((s) => s.status !== 'complete')
@@ -516,7 +549,7 @@ export async function* listApiBackfill(opts: {
             })
           )
 
-          yield* mergeAsync(generators, backfillConcurrency)
+          yield* mergeAsync(generators, numSegments)
         }
       } else {
         // Sequential path: no created filter support

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -570,9 +570,12 @@ export async function* listApiBackfill(opts: {
         if (incompleteSegments.length > 0) {
           const totalEmitted = { count: 0 }
 
-          // Yield probe's first page records directly (zero waste)
-          if (firstPage && firstPage.data.length > 0) {
-            const newestSegment = incompleteSegments[0]
+          // For single-segment streams, yield probe data directly (zero waste).
+          // Multi-segment streams skip this because the probe fetches newest-first
+          // across the full range, and attributing those items to a specific segment
+          // would cause cursor/range mismatches during pagination.
+          if (firstPage && firstPage.data.length > 0 && numSegments === 1) {
+            const onlySegment = incompleteSegments[0]
             for (const item of firstPage.data) {
               yield toRecordMessage(stream.name, {
                 ...(item as Record<string, unknown>),
@@ -580,14 +583,12 @@ export async function* listApiBackfill(opts: {
               })
               totalEmitted.count++
             }
-            // Set cursor so paginateSegment continues from where the probe left off
             if (firstPage.has_more) {
               const lastId = (firstPage.data[firstPage.data.length - 1] as { id: string }).id
-              newestSegment.page_cursor = lastId
+              onlySegment.page_cursor = lastId
             } else {
-              newestSegment.status = 'complete'
+              onlySegment.status = 'complete'
             }
-            // Emit checkpoint after yielding probe data
             const allComplete = segments.every((s) => s.status === 'complete')
             yield stateMsg({
               stream: stream.name,


### PR DESCRIPTION
## Summary
- Remove the `backfill_concurrency` config option — segment count is now auto-detected per stream via a single probe API call
- Smooth density-based segment count replaces discrete 1/10/50 tiers
- Concurrency is decoupled from segment count (capped at 15)
- Probe call doubles as the first page for sparse streams (zero wasted API calls)
- Rate-limit boilerplate consolidated into a single `withRateLimit` wrapper

## Motivation
`backfill_concurrency` was a static config knob that users had to guess at. Too few segments wasted parallelism on dense streams; too many added overhead on sparse ones. This makes it automatic — one extra `list?limit=100` call per stream on first backfill measures data density and picks the right segment count.

## How it works

### Density probe → segment count
`probeAndBuildSegments` fetches 100 items with a `created` filter (forward-compatible if the range narrows later) and measures what fraction of the total time range they span. The segment count is a smooth inverse function:

```
segments = min(50, max(1, ceil(1 / timeProgress)))
```

| 100 items cover... | timeProgress | Segments | Example |
|---|---|---|---|
| all data (`has_more: false`) | n/a | 1 | New account with 30 customers |
| 50% of time range | 0.5 | 2 | Light-use account |
| 10% of time range | 0.1 | 10 | Moderate activity |
| 2% of time range | 0.02 | 50 (max) | High-volume account |

### Decoupled concurrency
Segment count and concurrency are independent. Dense streams get fine-grained 50-segment splits but only `MAX_CONCURRENCY=15` execute simultaneously — avoiding memory pressure from 50 concurrent promises racing while still saturating the rate limit.

### Probe-as-first-page (single-segment streams)
For sparse streams (1 segment), the probe response is yielded directly as records instead of being discarded. The segment's cursor is set so `paginateSegment` continues from where the probe left off. For multi-segment streams, the probe is used purely for density estimation — each segment fetches its own data independently.

### Rate-limit wrapper
`withRateLimit(listFn, rateLimiter)` wraps the list function once at construction time. `paginateSegment`, `sequentialBackfillStream`, and the probe all receive a plain `ListFn` — structurally impossible to forget rate limiting on new call sites.

## Test plan
- `segmentCountFromDensity` unit tests cover smooth curve: zero/negative, sparse, medium, dense, cap at 50, no cliff edges
- `probeAndBuildSegments` unit tests cover: empty stream, single-page, sparse, dense, extremely dense, missing `created` fallback, division-by-zero guard, `created` filter assertion, firstPage data passthrough
- Coexist test asserts probe call shape (`{ limit: 100, created: ... }`)
- All 116 source-stripe unit tests pass
- All CI checks green including E2E Test Server, E2E Stripe, E2E Docker, E2E Service Docker