### PR TITLE
fix: skip 'not enabled for' errors, stop swallowing missing-param and bad-URL errors

### DIFF
--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -36,16 +36,15 @@ export function errorToTrace(err: unknown, stream: string): TraceMessage {
 //   400 "This endpoint is not in live mode"                     → not in live mode
 //   400 "Must provide customer"                                 → Must provide customer
 //   400 "Must provide source or customer"                       → Must provide
-//   400 "Missing required param: customer"                      → Missing required param
-//   400 "Unrecognized request URL (GET: /v1/exchange_rates)"    → Unrecognized request URL
+//   400 "This API surface is not enabled for testmode usage."   → not enabled for
+//   400 "Accounts v2 is not enabled for your platform."         → not enabled for
 //   400 "Your account is not set up to use Issuing."            → not set up to use
 const SKIPPABLE_ERROR_PATTERNS = [
   'only available in testmode',
   'not in live mode',
+  'not enabled for',
   'Must provide customer',
   'Must provide ',
-  'Missing required param',
-  'Unrecognized request URL',
   'not set up to use',
 ]
 


### PR DESCRIPTION
## Summary

Updates the `SKIPPABLE_ERROR_PATTERNS` list in the Stripe source connector to fix two problems:

1. **Add `'not enabled for'` to skippable patterns** — Endpoints like Accounts v2 return 400 "not enabled for your platform" or "not enabled for testmode usage" when the account/mode doesn't support them. These were causing infinite Temporal retries on endpoints that will never succeed for the current account.

2. **Remove `'Missing required param'` and `'Unrecognized request URL'`** — These were being silently swallowed but indicate real bugs:
   - "Missing required param" means the source connector is constructing the API call incorrectly and should surface as an error so it can be fixed.
   - "Unrecognized request URL" was originally added as a band-aid for `/v1/exchange_rates`, which is now filtered out at the discover layer via `deprecatedPaths.ts` and spec cleaning.

## Changes

- `packages/source-stripe/src/src-list-api.ts`: Add `'not enabled for'` pattern, remove `'Missing required param'` and `'Unrecognized request URL'` patterns, update comment examples.