### PR TITLE
fix: destination write errors now propagate correctly with useful messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,6 @@ jobs:
       github.event_name == 'push'
       && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04-arm
-
     steps:
       - uses: actions/checkout@v5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.2.0 (2026-04-11)
 
 ### Features
+
 - Auto-publish packages to npmjs.org on version bump (#272)
 - Add `--live` CLI flag and `?only` setup/teardown filter (#271)
 - Add multi-key sync support (#211)
@@ -47,6 +48,7 @@
 - Non-default sync schema names (#141)
 
 ### Bug Fixes
+
 - Fix `/internal/query` error handling (#256)
 - Strip deprecated paths from OpenAPI specs (#264)
 - Require Stripe-Version header, skip unavailable endpoints (#262)
@@ -60,6 +62,7 @@
 - Skip unsupported webhook objects during live sync (#156)
 
 ### Breaking Changes
+
 - Rename `@stripe/sync-protocol` to `@stripe/protocol`; pipeline stages moved to engine
 - Rename `syncs` to `pipelines` throughout the service API
 - Rename `SyncParams` to `PipelineConfig`
@@ -69,4 +72,4 @@
 - `api_version` is now required in `StripeClientConfig` (#258)
 - `emitted_at` changed from Unix ms integer to ISO 8601 string (#231)
 - Rename `X-Sync-Params` header to `X-Pipeline` with separate `X-State` header
-All notable changes to sync-engine will be documented in this file.
+  All notable changes to sync-engine will be documented in this file.

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -62,7 +62,12 @@ function syncRequestContext(pipeline: {
 }
 
 function traceError(err: unknown): TraceMessage {
-  const message = err instanceof Error ? err.message : String(err)
+  let message: string
+  if (err instanceof Error) {
+    message = err.message || (err as NodeJS.ErrnoException).code || err.constructor.name
+  } else {
+    message = String(err)
+  }
   const stack_trace = err instanceof Error ? err.stack : undefined
   return {
     type: 'trace',
@@ -84,10 +89,13 @@ async function* logApiStream<T>(
   startedAt = Date.now()
 ): AsyncIterable<T | TraceMessage> {
   let itemCount = 0
+  let hasErrorTrace = false
   try {
     for await (const item of iter) {
       itemCount++
       if (dangerouslyVerbose) logger.debug({ ...context, item }, `${label} output`)
+      const msg = item as { type?: string; trace?: { trace_type?: string } }
+      if (msg?.type === 'trace' && msg?.trace?.trace_type === 'error') hasErrorTrace = true
       yield item
     }
     logger.info({ ...context, itemCount, durationMs: Date.now() - startedAt }, `${label} completed`)
@@ -96,7 +104,7 @@ async function* logApiStream<T>(
       { ...context, itemCount, durationMs: Date.now() - startedAt, err: error },
       `${label} failed`
     )
-    yield traceError(error)
+    if (!hasErrorTrace) yield traceError(error)
   }
 }
 

--- a/apps/engine/src/lib/engine.ts
+++ b/apps/engine/src/lib/engine.ts
@@ -413,11 +413,7 @@ export async function createEngine(resolver: ConnectorResolver): Promise<Engine>
       const { catalog } = await discoverCatalog(engine, pipeline)
       const state = opts?.state
 
-      const raw = connector.read(
-        { config: sourceConfig, catalog, state },
-        input,
-        signal
-      )
+      const raw = connector.read({ config: sourceConfig, catalog, state }, input, signal)
       const logged = withLoggedStream(
         'Engine source read',
         {
@@ -474,12 +470,7 @@ export async function createEngine(resolver: ConnectorResolver): Promise<Engine>
       const now = () => new Date().toISOString()
 
       // Read from source (pass state + signal but not state_limit — state_limit controls sync output)
-      const readOutput = engine.pipeline_read(
-        pipeline,
-        { state: opts?.state },
-        input,
-        signal
-      )
+      const readOutput = engine.pipeline_read(pipeline, { state: opts?.state }, input, signal)
 
       // Split: data + eof → destination path, source signals → caller
       // Eof from pipeline_read is excluded from source signals (pipeline_sync adds its own)

--- a/apps/engine/src/lib/exec-helpers.ts
+++ b/apps/engine/src/lib/exec-helpers.ts
@@ -52,7 +52,7 @@ export async function* spawnAndStream<T>(
   yield* parseNdjsonChunks<T>(child.stdout)
   await exitPromise
 
-  if (exitCode !== 0 && !(signal?.aborted)) {
+  if (exitCode !== 0 && !signal?.aborted) {
     const stderr = Buffer.concat(stderrChunks).toString()
     throw new Error(`${bin} exited with code ${exitCode}: ${stderr}`)
   }
@@ -105,7 +105,7 @@ export async function* spawnWithStdin<TIn, TOut>(
   yield* parseNdjsonChunks<TOut>(child.stdout)
   await exitPromise
 
-  if (exitCode !== 0 && !(signal?.aborted)) {
+  if (exitCode !== 0 && !signal?.aborted) {
     const stderr = Buffer.concat(stderrChunks).toString()
     throw new Error(`${bin} exited with code ${exitCode}: ${stderr}`)
   }

--- a/apps/engine/src/lib/pipeline.ts
+++ b/apps/engine/src/lib/pipeline.ts
@@ -227,10 +227,7 @@ export function takeLimits<T extends Message>(
         // Check if already aborted before starting the race
         if (opts.signal?.aborted) {
           cleanup()
-          logger.warn(
-            { elapsed_ms: Date.now() - startedAt, event: 'SYNC_ABORTED' },
-            'SYNC_ABORTED'
-          )
+          logger.warn({ elapsed_ms: Date.now() - startedAt, event: 'SYNC_ABORTED' }, 'SYNC_ABORTED')
           yield makeEof('aborted')
           await iterator.return?.(undefined)
           return
@@ -274,10 +271,7 @@ export function takeLimits<T extends Message>(
         }
 
         if (winner.kind === 'aborted') {
-          logger.warn(
-            { elapsed_ms: Date.now() - startedAt, event: 'SYNC_ABORTED' },
-            'SYNC_ABORTED'
-          )
+          logger.warn({ elapsed_ms: Date.now() - startedAt, event: 'SYNC_ABORTED' }, 'SYNC_ABORTED')
           yield makeEof('aborted')
           iterator.return?.(undefined)
           return

--- a/apps/engine/src/lib/remote-engine.ts
+++ b/apps/engine/src/lib/remote-engine.ts
@@ -175,7 +175,13 @@ export function createRemoteEngine(engineUrl: string): Engine {
       messages: AsyncIterable<Message>,
       signal?: AbortSignal
     ): AsyncIterable<DestinationOutput> {
-      const res = await post('/pipeline_write', pipeline, undefined, toNdjsonStream(messages), signal)
+      const res = await post(
+        '/pipeline_write',
+        pipeline,
+        undefined,
+        toNdjsonStream(messages),
+        signal
+      )
       yield* parseNdjsonStream<DestinationOutput>(res.body!)
     },
 

--- a/docs/plans/2026-04-13-adaptive-backfill.md
+++ b/docs/plans/2026-04-13-adaptive-backfill.md
@@ -88,7 +88,7 @@ This gives a smooth curve: `ceil(1 / timeProgress)` naturally maps density to se
 ```ts
 const numSegments = segmentCountFromDensity(timeProgress)
 const segments = buildSegments(accountCreated, now, numSegments)
-yield* mergeAsync(generators, MAX_CONCURRENCY) // always capped
+yield * mergeAsync(generators, MAX_CONCURRENCY) // always capped
 ```
 
 This means a dense stream gets 50 fine-grained segments but only 15 execute at a time, avoiding the "50 concurrent promises" problem.
@@ -105,7 +105,7 @@ The simplest improvement: make the probe the first page of the first (most recen
 
 ```ts
 async function probeAndBuildSegments(opts: {
-  listFn: ListFn  // already rate-limited from Change 1
+  listFn: ListFn // already rate-limited from Change 1
   range: { gte: number; lt: number }
 }): Promise<{ segments: SegmentState[]; firstPage: ListResult }> {
   const { listFn, range } = opts
@@ -261,8 +261,8 @@ Change 3b: Adaptive subdivision (future)
 ### Constants
 
 ```ts
-const MAX_SEGMENTS = 50       // finest granularity for any stream
-const MAX_CONCURRENCY = 15    // max in-flight segment generators
+const MAX_SEGMENTS = 50 // finest granularity for any stream
+const MAX_CONCURRENCY = 15 // max in-flight segment generators
 const MIN_SEGMENT_SPAN = 86400 // don't subdivide below 1 day (for 3b)
 ```
 

--- a/docs/plans/2026-04-13-auto-publish-fixes.md
+++ b/docs/plans/2026-04-13-auto-publish-fixes.md
@@ -31,6 +31,7 @@ npmjs.org. This should be replaced with npm's [trusted publishing][tp]
 - Removes the risk of leaked/expired tokens breaking publishes.
 
 Steps to migrate:
+
 1. Link each `@stripe/sync-*` package to the GitHub repo in npm's
    trusted publishing settings.
 2. Add `permissions: id-token: write` to the `publish_npmjs` job.

--- a/docs/plans/2026-04-14-backfill-child-workflow.md
+++ b/docs/plans/2026-04-14-backfill-child-workflow.md
@@ -82,6 +82,7 @@ interface BackfillLoopResult {
 ```
 
 Properties:
+
 - **Finite**: runs until all streams complete or an error stops it
 - **Own event history**: backfill pagination doesn't bloat the pipeline workflow
 - **Own `continueAsNew`**: manages its own history size independently
@@ -140,17 +141,25 @@ export async function pipelineWorkflow(
 
   // Main loop
   while (desiredStatus !== 'deleted') {
-    if (state.errored) { await waitForErrorRecovery(); continue }
-    if (desiredStatus === 'paused') { await waitForResume(); continue }
+    if (state.errored) {
+      await waitForErrorRecovery()
+      continue
+    }
+    if (desiredStatus === 'paused') {
+      await waitForResume()
+      continue
+    }
 
     await Promise.all([
-      liveLoop(),          // signals → pipelineSync activity
-      reconcileScheduler() // periodic backfillLoop child workflows
+      liveLoop(), // signals → pipelineSync activity
+      reconcileScheduler(), // periodic backfillLoop child workflows
     ])
 
     if (shouldContinueAsNew()) {
       await continueAsNew<typeof pipelineWorkflow>(pipelineId, {
-        desiredStatus, sourceState, state,
+        desiredStatus,
+        sourceState,
+        state,
       })
     }
   }
@@ -228,9 +237,9 @@ Existing running workflows need to transition. Deploy new workflow code, let exi
 ## Constants
 
 ```ts
-const BACKFILL_CONTINUE_AS_NEW_THRESHOLD = 500   // for backfillLoop
-const PIPELINE_CONTINUE_AS_NEW_THRESHOLD = 1000  // pipeline is much lighter now
-const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000      // reconcile schedule
+const BACKFILL_CONTINUE_AS_NEW_THRESHOLD = 500 // for backfillLoop
+const PIPELINE_CONTINUE_AS_NEW_THRESHOLD = 1000 // pipeline is much lighter now
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000 // reconcile schedule
 ```
 
 ## Open questions

--- a/docs/plans/2026-04-14-never-fail-workflow.md
+++ b/docs/plans/2026-04-14-never-fail-workflow.md
@@ -20,14 +20,14 @@ Source error → errorToTrace() → drainMessages() → classifySyncErrors():
 
 ### What `system_error` retries look like in practice
 
-| Error | Self-heals? | 10 retries useful? |
-|---|---|---|
-| Rate limit (429) | Yes | Yes |
-| Stripe 5xx | Usually | Yes |
-| Network timeout | Usually | Yes |
-| Connector bug (bad params) | No | No — 30 min wasted |
-| Schema mismatch | No | No |
-| JSON parse failure | No | No |
+| Error                      | Self-heals? | 10 retries useful? |
+| -------------------------- | ----------- | ------------------ |
+| Rate limit (429)           | Yes         | Yes                |
+| Stripe 5xx                 | Usually     | Yes                |
+| Network timeout            | Usually     | Yes                |
+| Connector bug (bad params) | No          | No — 30 min wasted |
+| Schema mismatch            | No          | No                 |
+| JSON parse failure         | No          | No                 |
 
 Most `system_error` cases are deterministic. Retrying them wastes time and API quota before the workflow dies anyway.
 
@@ -54,6 +54,7 @@ The pipeline workflow is an entity. It runs until explicitly deleted. Every erro
 ### Change 1: Activity never throws for classified errors
 
 **Current** (`pipeline-sync.ts`):
+
 ```ts
 if (transient.length > 0) {
   throw ApplicationFailure.retryable(summarizeSyncErrors(transient), 'TransientSyncError')
@@ -61,6 +62,7 @@ if (transient.length > 0) {
 ```
 
 **Proposed**: The activity always returns — never throws for classified errors.
+
 ```ts
 if (errors.length > 0) {
   return { errors, state, eof }
@@ -87,7 +89,7 @@ if (transient.length > 0) {
   continue
 }
 
-transientFailureCount = 0  // reset on success
+transientFailureCount = 0 // reset on success
 ```
 
 This keeps the workflow alive. Transient errors that won't self-heal eventually escalate to the errored state, where the workflow parks and waits for a signal.
@@ -98,15 +100,15 @@ This keeps the workflow alive. Transient errors that won't self-heal eventually 
 
 Split the catch-all `system_error` into genuinely transient vs. deterministic:
 
-| Error | Current type | Proposed type |
-|---|---|---|
-| Rate limit (429) | `transient_error` | `transient_error` (no change) |
-| Auth (401/403) | `auth_error` | `auth_error` (no change) |
-| Network timeout / ECONNRESET | `system_error` | `transient_error` |
-| Stripe 5xx | `system_error` | `transient_error` |
-| JSON parse failure | `system_error` | `system_error` → permanent |
-| Connector bug (bad params) | `system_error` | `system_error` → permanent |
-| Unknown stream | `config_error` | `config_error` (no change) |
+| Error                        | Current type      | Proposed type                 |
+| ---------------------------- | ----------------- | ----------------------------- |
+| Rate limit (429)             | `transient_error` | `transient_error` (no change) |
+| Auth (401/403)               | `auth_error`      | `auth_error` (no change)      |
+| Network timeout / ECONNRESET | `system_error`    | `transient_error`             |
+| Stripe 5xx                   | `system_error`    | `transient_error`             |
+| JSON parse failure           | `system_error`    | `system_error` → permanent    |
+| Connector bug (bad params)   | `system_error`    | `system_error` → permanent    |
+| Unknown stream               | `config_error`    | `config_error` (no change)    |
 
 The classifier expands:
 
@@ -125,7 +127,7 @@ function classifyError(err: unknown): TraceError['failure_type'] {
   }
   if (isNetworkError(err)) return 'transient_error'
   if (err instanceof Error && err.message.includes('Rate limit')) return 'transient_error'
-  return 'system_error'  // deterministic by default
+  return 'system_error' // deterministic by default
 }
 ```
 
@@ -134,6 +136,7 @@ Only `transient_error` gets retried. Everything else parks.
 ### Change 3: Preserve `failure_type` through `collectMessages`
 
 **Current** (`packages/protocol/src/helpers.ts`):
+
 ```ts
 } else if (msg.type === 'trace' && msg.trace.trace_type === 'error') {
   throw new Error(msg.trace.error.message)
@@ -141,6 +144,7 @@ Only `transient_error` gets retried. Everything else parks.
 ```
 
 **Proposed**:
+
 ```ts
 export class TraceErrorException extends Error {
   constructor(
@@ -167,12 +171,12 @@ Then `pipelineSetup` can distinguish config errors from transient ones instead o
 
 ### Recovery signals
 
-| Signal | Trigger | Workflow action |
-|---|---|---|
-| `desired_status: active` | User re-enables | Clear errored state, re-enter main loop (existing) |
-| `credentials_updated` | User rotates API key | Clear if `auth_error` |
-| `config_updated` | User modifies config | Clear, re-run setup if needed |
-| `deployment_updated` | New connector deployed | Clear if `system_error` |
+| Signal                   | Trigger                | Workflow action                                    |
+| ------------------------ | ---------------------- | -------------------------------------------------- |
+| `desired_status: active` | User re-enables        | Clear errored state, re-enter main loop (existing) |
+| `credentials_updated`    | User rotates API key   | Clear if `auth_error`                              |
+| `config_updated`         | User modifies config   | Clear, re-run setup if needed                      |
+| `deployment_updated`     | New connector deployed | Clear if `system_error`                            |
 
 Today only `desired_status: active` triggers recovery. The others let the workflow react to specific fixes without requiring the user to manually toggle the pipeline.
 
@@ -224,12 +228,12 @@ Phase 3 (reclassifying `system_error` as permanent) changes behavior — errors 
 ## Constants
 
 ```ts
-const MAX_TRANSIENT_RETRIES = 5  // before escalating to permanent
+const MAX_TRANSIENT_RETRIES = 5 // before escalating to permanent
 ```
 
 ## Open questions
 
 1. **Should `system_error` get 1 retry before parking?** Some system errors might be flaky. One retry before escalation could be a reasonable middle ground.
-2. **How does the operator know what to do?** When the workflow parks, it needs visibility into *why* and *what action to take*. Should the workflow write error details to the pipeline store?
+2. **How does the operator know what to do?** When the workflow parks, it needs visibility into _why_ and _what action to take_. Should the workflow write error details to the pipeline store?
 3. **Should `SKIPPABLE_ERROR_PATTERNS` move to the workflow layer?** Currently the source connector silently swallows these. If the workflow handled all error classification, the source would just emit errors and let the orchestrator decide. Cleaner separation, but requires the workflow to understand Stripe-specific error messages.
 4. **Backward compatibility.** Changing activity return types is a Temporal versioning concern. Existing in-flight workflows expect the throw behavior for transient errors.

--- a/e2e/test-disconnect.test.ts
+++ b/e2e/test-disconnect.test.ts
@@ -51,7 +51,9 @@ interface MockStripeServer {
   close: () => Promise<void>
 }
 
-async function startMockStripeApi(opts: { delayMs?: number; port?: number } = {}): Promise<MockStripeServer> {
+async function startMockStripeApi(
+  opts: { delayMs?: number; port?: number } = {}
+): Promise<MockStripeServer> {
   const delayMs = opts.delayMs ?? 0
   const port = opts.port ?? 0
   let count = 0
@@ -269,11 +271,7 @@ async function waitForServer(
   throw new Error(`Server at ${url} did not become healthy in ${timeout}ms`)
 }
 
-async function waitForLog(
-  engine: EngineProcess,
-  needle: string,
-  timeout = 5_000
-): Promise<void> {
+async function waitForLog(engine: EngineProcess, needle: string, timeout = 5_000): Promise<void> {
   const deadline = Date.now() + timeout
   while (Date.now() < deadline) {
     if (engine.stderr.includes(needle)) return
@@ -380,7 +378,10 @@ for (const runtime of runtimes) {
     let engine: EngineProcess
 
     beforeAll(async () => {
-      mockApi = await startMockStripeApi({ delayMs: 200, port: runtime.name === 'docker' ? 18888 : 0 })
+      mockApi = await startMockStripeApi({
+        delayMs: 200,
+        port: runtime.name === 'docker' ? 18888 : 0,
+      })
       const port = getPort()
       engine = await runtime.start(port, mockApi.url)
     }, 120_000)
@@ -395,7 +396,9 @@ for (const runtime of runtimes) {
     })
 
     it('client disconnect stops the engine from making further API calls', async () => {
-      const pipelineHeader = makePipelineHeader(normalizeMockUrlForRuntime(runtime.name, mockApi.url))
+      const pipelineHeader = makePipelineHeader(
+        normalizeMockUrlForRuntime(runtime.name, mockApi.url)
+      )
       const ac = new AbortController()
 
       // Start a streaming sync request
@@ -403,13 +406,15 @@ for (const runtime of runtimes) {
         method: 'POST',
         headers: { 'X-Pipeline': pipelineHeader },
         signal: ac.signal,
-      }).then(async (res) => {
-        if (!res.ok) {
-          const body = await res.text().catch(() => '')
-          console.error(`pipeline_read returned ${res.status}: ${body}`)
-        }
-        return res
-      }).catch(() => null)
+      })
+        .then(async (res) => {
+          if (!res.ok) {
+            const body = await res.text().catch(() => '')
+            console.error(`pipeline_read returned ${res.status}: ${body}`)
+          }
+          return res
+        })
+        .catch(() => null)
 
       // Wait for some requests to hit the mock
       await new Promise((r) => setTimeout(r, 1500))
@@ -433,7 +438,9 @@ for (const runtime of runtimes) {
     }, 30_000)
 
     it('soft time limit returns eof with cutoff=soft and elapsed_ms', async () => {
-      const pipelineHeader = makePipelineHeader(normalizeMockUrlForRuntime(runtime.name, mockApi.url))
+      const pipelineHeader = makePipelineHeader(
+        normalizeMockUrlForRuntime(runtime.name, mockApi.url)
+      )
 
       const start = Date.now()
       const res = await fetch(`${engine.url}/pipeline_read?time_limit=3`, {

--- a/packages/destination-postgres/src/index.ts
+++ b/packages/destination-postgres/src/index.ts
@@ -103,7 +103,21 @@ export {
 function isTransient(err: unknown): boolean {
   if (!(err instanceof Error)) return false
   const msg = err.message.toLowerCase()
-  return msg.includes('econnrefused') || msg.includes('timeout') || msg.includes('connection')
+  const code = ((err as NodeJS.ErrnoException).code ?? '').toLowerCase()
+  return (
+    msg.includes('econnrefused') ||
+    msg.includes('timeout') ||
+    msg.includes('connection') ||
+    code.includes('econnrefused') ||
+    code.includes('etimedout') ||
+    code.includes('econnreset')
+  )
+}
+
+function errorMessage(err: unknown): string {
+  if (!(err instanceof Error)) return String(err)
+  if (err.message) return err.message
+  return (err as NodeJS.ErrnoException).code ?? err.constructor.name
 }
 
 function createPool(config: PoolConfig): pg.Pool {
@@ -244,6 +258,14 @@ const destination = {
       }
 
       await flushAll()
+
+      yield {
+        type: 'log' as const,
+        log: {
+          level: 'info' as const,
+          message: `Postgres destination: wrote to schema "${config.schema}"`,
+        },
+      }
     } catch (err: unknown) {
       try {
         await flushAll()
@@ -259,21 +281,14 @@ const destination = {
             failure_type: isTransient(err)
               ? ('transient_error' as const)
               : ('system_error' as const),
-            message: err instanceof Error ? err.message : String(err),
+            message: errorMessage(err),
             stack_trace: err instanceof Error ? err.stack : undefined,
           },
         },
       }
+      throw err
     } finally {
       await pool.end()
-    }
-
-    yield {
-      type: 'log' as const,
-      log: {
-        level: 'info' as const,
-        message: `Postgres destination: wrote to schema "${config.schema}"`,
-      },
     }
   },
 } satisfies Destination<Config>

--- a/packages/protocol/src/async-iterable-utils.ts
+++ b/packages/protocol/src/async-iterable-utils.ts
@@ -161,7 +161,6 @@ export function split<T, U extends T>(
   }
   matches.onReturn = abort
   rest.onReturn = abort
-
   ;(async () => {
     try {
       while (true) {


### PR DESCRIPTION
## Summary

- **Success log was unconditional** — moved inside `try` block so it only fires on actual success
- **Error was swallowed** — added `throw err` after yielding the error trace so the engine sees the failure and stops the sync
- **Duplicate / empty error trace** — `logApiStream` in `app.ts` was catching the re-thrown error and emitting a second trace with `system_error` and empty `message`; fixed by suppressing the duplicate when the pipeline already yielded one, and falling back to `err.code` when `err.message` is empty (Bun's pg driver sets `code: ECONNREFUSED` with no message)
- **`isTransient` now checks `err.code`** so ECONNREFUSED correctly classifies as `transient_error`

## Test plan
- [ ] With postgres unreachable: single `trace/error` with `failure_type: transient_error` and `message: ECONNREFUSED`, no `eof: complete`
- [ ] With postgres reachable: `log: wrote to schema` emitted, `eof` fires normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)