### PR TITLE
add more context to sync-engine responses

### DIFF
--- a/packages/openapi/index.ts
+++ b/packages/openapi/index.ts
@@ -15,6 +15,7 @@ export {
   buildRetrieveFn,
   resolveTableName,
   StripeApiRequestError,
+  pickDebugHeaders,
 } from './listFnResolver.js'
 export type {
   ListEndpoint,

--- a/packages/openapi/listFnResolver.ts
+++ b/packages/openapi/listFnResolver.ts
@@ -226,14 +226,40 @@ export class StripeApiRequestError extends Error {
     public readonly status: number,
     public readonly body: unknown,
     method: string,
-    path: string
+    path: string,
+    public readonly responseHeaders?: Record<string, string>
   ) {
-    super(extractErrorMessage(body, status, method, path))
+    super(extractErrorMessage(body, status, method, path, responseHeaders))
     this.name = 'StripeApiRequestError'
   }
 }
 
-function extractErrorMessage(body: unknown, status: number, method: string, path: string): string {
+/** Headers worth surfacing in error messages for debugging. */
+const DEBUG_HEADERS = [
+  'request-id',
+  'stripe-should-retry',
+  'stripe-action-id',
+  'stripe-server-environment',
+]
+
+function extractErrorMessage(
+  body: unknown,
+  status: number,
+  method: string,
+  path: string,
+  responseHeaders?: Record<string, string>
+): string {
+  const context = `${method.toUpperCase()} ${path} (${status})`
+
+  const headerParts: string[] = []
+  if (responseHeaders) {
+    for (const key of DEBUG_HEADERS) {
+      const value = responseHeaders[key]
+      if (value) headerParts.push(`${key}=${value}`)
+    }
+  }
+  const headerStr = headerParts.length > 0 ? ` {${headerParts.join(', ')}}` : ''
+
   if (
     body &&
     typeof body === 'object' &&
@@ -243,10 +269,10 @@ function extractErrorMessage(body: unknown, status: number, method: string, path
     'message' in body.error &&
     typeof body.error.message === 'string'
   ) {
-    return body.error.message
+    return `${body.error.message} [${context}]${headerStr}`
   }
 
-  return `Stripe API request failed (${status}) for ${method.toUpperCase()} ${path}`
+  return `Stripe API request failed: ${context}${headerStr}`
 }
 
 async function readJson(response: Response): Promise<unknown> {
@@ -262,7 +288,8 @@ async function readJson(response: Response): Promise<unknown> {
 
 function assertOk(response: Response, body: unknown, method: string, path: string): void {
   if (!response.ok) {
-    throw new StripeApiRequestError(response.status, body, method, path)
+    const responseHeaders = Object.fromEntries(response.headers.entries())
+    throw new StripeApiRequestError(response.status, body, method, path, responseHeaders)
   }
 }
 

--- a/packages/openapi/listFnResolver.ts
+++ b/packages/openapi/listFnResolver.ts
@@ -242,6 +242,20 @@ const DEBUG_HEADERS = [
   'stripe-server-environment',
 ]
 
+/**
+ * Extract only the debug-relevant headers from a Response, avoiding
+ * `Object.fromEntries(headers.entries())` which materializes every header
+ * and can silently drop duplicate keys like `set-cookie`.
+ */
+export function pickDebugHeaders(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const key of DEBUG_HEADERS) {
+    const v = headers.get(key)
+    if (v) out[key] = v
+  }
+  return out
+}
+
 function extractErrorMessage(
   body: unknown,
   status: number,
@@ -288,8 +302,7 @@ async function readJson(response: Response): Promise<unknown> {
 
 function assertOk(response: Response, body: unknown, method: string, path: string): void {
   if (!response.ok) {
-    const responseHeaders = Object.fromEntries(response.headers.entries())
-    throw new StripeApiRequestError(response.status, body, method, path, responseHeaders)
+    throw new StripeApiRequestError(response.status, body, method, path, pickDebugHeaders(response.headers))
   }
 }
 

--- a/packages/source-stripe/src/client.test.ts
+++ b/packages/source-stripe/src/client.test.ts
@@ -51,7 +51,8 @@ describe('makeClient', () => {
       '/v1/account'
     )
     expect(err.status).toBe(401)
-    expect(err.message).toBe('Invalid API Key')
+    expect(err.message).toContain('Invalid API Key')
+    expect(err.message).toContain('GET /v1/account (401)')
   })
 
   it('retries transient GET failures and eventually succeeds', async () => {

--- a/packages/source-stripe/src/client.ts
+++ b/packages/source-stripe/src/client.ts
@@ -71,10 +71,24 @@ export function makeClient(
       env
     )
 
-    const json = (await response.json()) as unknown
+    const responseHeaders = Object.fromEntries(response.headers.entries())
+
+    const text = await response.text()
+    let json: unknown
+    try {
+      json = JSON.parse(text)
+    } catch {
+      throw new StripeApiRequestError(
+        response.status,
+        { error: { message: `Non-JSON response: ${text.slice(0, 200)}` } },
+        method,
+        path,
+        responseHeaders
+      )
+    }
 
     if (!response.ok) {
-      throw new StripeApiRequestError(response.status, json, method, path)
+      throw new StripeApiRequestError(response.status, json, method, path, responseHeaders)
     }
 
     return json

--- a/packages/source-stripe/src/client.ts
+++ b/packages/source-stripe/src/client.ts
@@ -3,6 +3,7 @@ import {
   StripeWebhookEndpointSchema,
   StripeApiListSchema,
   StripeApiRequestError,
+  pickDebugHeaders,
   type StripeAccount,
   type StripeApiList,
   type StripeWebhookEndpoint,
@@ -71,24 +72,25 @@ export function makeClient(
       env
     )
 
-    const responseHeaders = Object.fromEntries(response.headers.entries())
+    const debugHeaders = pickDebugHeaders(response.headers)
 
     const text = await response.text()
     let json: unknown
     try {
       json = JSON.parse(text)
     } catch {
+      const preview = text.slice(0, 200).replace(/[\r\n]+/g, '\\n')
       throw new StripeApiRequestError(
         response.status,
-        { error: { message: `Non-JSON response: ${text.slice(0, 200)}` } },
+        { error: { message: `Non-JSON response: ${preview}` } },
         method,
         path,
-        responseHeaders
+        debugHeaders
       )
     }
 
     if (!response.ok) {
-      throw new StripeApiRequestError(response.status, json, method, path, responseHeaders)
+      throw new StripeApiRequestError(response.status, json, method, path, debugHeaders)
     }
 
     return json


### PR DESCRIPTION
## Summary

<!-- What changed in plain language -->

- Adds helpful response context

## How to test (optional)

<!-- Add steps only if useful -->

- lmk if there's a good way to test

## Related

<!-- Link issue(s) if any -->

- Closes #

> Thanks for contributing ❤️
