### PR TITLE
feat: support pipeline/state config in JSON request body

### DIFF
--- a/apps/engine/src/__generated__/openapi.d.ts
+++ b/apps/engine/src/__generated__/openapi.d.ts
@@ -112,7 +112,7 @@ export interface paths {
         put?: never;
         /**
          * Read records from source
-         * @description Streams NDJSON messages (records, state, catalog). Optional NDJSON body provides live events as input.
+         * @description Streams NDJSON messages (records, state, catalog). Optional NDJSON body provides live events as input. Alternatively, send Content-Type: application/json with {pipeline, state?, body?} to pass config in the body.
          */
         post: operations["pipeline_read"];
         delete?: never;
@@ -132,7 +132,7 @@ export interface paths {
         put?: never;
         /**
          * Write records to destination
-         * @description Reads NDJSON messages from the request body and writes them to the destination. Pipe /read output as input.
+         * @description Reads NDJSON messages from the request body and writes them to the destination. Pipe /read output as input. Alternatively, send Content-Type: application/json with {pipeline, body: [...messages]}.
          */
         post: operations["pipeline_write"];
         delete?: never;
@@ -152,7 +152,7 @@ export interface paths {
         put?: never;
         /**
          * Run sync pipeline (read → write)
-         * @description Without a request body, reads from the source connector and writes to the destination (backfill mode). With an NDJSON request body, uses the provided messages as input instead of reading from the source (push mode — e.g. piped webhook events).
+         * @description Without a request body, reads from the source connector and writes to the destination (backfill mode). With an NDJSON request body, uses the provided messages as input instead of reading from the source (push mode — e.g. piped webhook events). Alternatively, send Content-Type: application/json with {pipeline, state?, body?} to pass config in the body.
          */
         post: operations["pipeline_sync"];
         delete?: never;
@@ -233,6 +233,128 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        PipelineConfig: {
+            source: components["schemas"]["SourceConfig"];
+            destination: components["schemas"]["DestinationConfig"];
+            streams?: {
+                /** @description Stream (table) name to sync. */
+                name: string;
+                /**
+                 * @description How the source reads this stream. Defaults to full_refresh.
+                 * @enum {string}
+                 */
+                sync_mode?: "incremental" | "full_refresh";
+                /** @description If set, only these fields are synced. */
+                fields?: string[];
+                /** @description Cap backfill to this many records, then mark the stream complete. */
+                backfill_limit?: number;
+            }[];
+        };
+        SourceConfig: {
+            /** @constant */
+            type: "stripe";
+            stripe: components["schemas"]["SourceStripeConfig"];
+        };
+        SourceStripeConfig: {
+            /** @description Stripe API key (sk_test_... or sk_live_...) */
+            api_key: string;
+            /** @description Stripe account ID (resolved from API if omitted) */
+            account_id?: string;
+            /** @description Whether this is a live mode sync */
+            livemode?: boolean;
+            /** @enum {string} */
+            api_version?: "2026-03-25.dahlia" | "2026-02-25.clover" | "2026-01-28.clover" | "2025-12-15.clover" | "2025-11-17.clover" | "2025-10-29.clover" | "2025-09-30.clover" | "2025-08-27.basil" | "2025-07-30.basil" | "2025-06-30.basil" | "2025-05-28.basil" | "2025-04-30.basil" | "2025-03-31.basil" | "2025-02-24.acacia" | "2025-01-27.acacia" | "2024-12-18.acacia" | "2024-11-20.acacia" | "2024-10-28.acacia" | "2024-09-30.acacia" | "2024-06-20" | "2024-04-10" | "2024-04-03" | "2023-10-16" | "2023-08-16" | "2022-11-15" | "2022-08-01" | "2020-08-27" | "2020-03-02" | "2019-12-03" | "2019-11-05" | "2019-10-17" | "2019-10-08" | "2019-09-09" | "2019-08-14" | "2019-05-16" | "2019-03-14" | "2019-02-19" | "2019-02-11" | "2018-11-08" | "2018-10-31" | "2018-09-24" | "2018-09-06" | "2018-08-23" | "2018-07-27" | "2018-05-21" | "2018-02-28" | "2018-02-06" | "2018-02-05" | "2018-01-23" | "2017-12-14" | "2017-08-15";
+            /**
+             * Format: uri
+             * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
+             */
+            base_url?: string;
+            /**
+             * Format: uri
+             * @description URL for managed webhook endpoint registration
+             */
+            webhook_url?: string;
+            /** @description Webhook signing secret (whsec_...) for signature verification */
+            webhook_secret?: string;
+            /** @description Enable WebSocket streaming for live events */
+            websocket?: boolean;
+            /** @description Enable events API polling for incremental sync after backfill */
+            poll_events?: boolean;
+            /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
+            webhook_port?: number;
+            /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
+            revalidate_objects?: string[];
+            /** @description Max objects to backfill per stream (useful for testing) */
+            backfill_limit?: number;
+            /** @description Max Stripe API requests per second (default: 25) */
+            rate_limit?: number;
+        };
+        DestinationConfig: {
+            /** @constant */
+            type: "postgres";
+            postgres: components["schemas"]["DestinationPostgresConfig"];
+        } | {
+            /** @constant */
+            type: "google_sheets";
+            google_sheets: components["schemas"]["DestinationGoogleSheetsConfig"];
+        };
+        DestinationPostgresConfig: {
+            /** @description Postgres connection string (alias for connection_string) */
+            url?: string;
+            /** @description Postgres connection string */
+            connection_string?: string;
+            /** @description Postgres host (required for AWS IAM) */
+            host?: string;
+            /**
+             * @description Postgres port
+             * @default 5432
+             */
+            port: number;
+            /** @description Database name (required for AWS IAM) */
+            database?: string;
+            /** @description Database user (required for AWS IAM) */
+            user?: string;
+            /** @description Target schema name (e.g. "stripe_sync") */
+            schema: string;
+            /**
+             * @description Records to buffer before flushing
+             * @default 100
+             */
+            batch_size: number;
+            /** @description AWS RDS IAM authentication config */
+            aws?: {
+                /** @description AWS region for RDS instance */
+                region: string;
+                /** @description IAM role ARN to assume (cross-account) */
+                role_arn?: string;
+                /** @description External ID for STS AssumeRole */
+                external_id?: string;
+            };
+            /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
+            ssl_ca_pem?: string;
+        };
+        DestinationGoogleSheetsConfig: {
+            /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
+            client_id?: string;
+            /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
+            client_secret?: string;
+            /** @description OAuth2 access token */
+            access_token: string;
+            /** @description OAuth2 refresh token */
+            refresh_token: string;
+            /** @description Target spreadsheet ID (created if omitted) */
+            spreadsheet_id?: string;
+            /**
+             * @description Title when creating a new spreadsheet
+             * @default Stripe Sync
+             */
+            spreadsheet_title: string;
+            /**
+             * @description Rows per Sheets API append call
+             * @default 50
+             */
+            batch_size: number;
+        };
         RecordMessage: {
             /** @description Who emitted this message: "source/{type}", "destination/{type}", or "engine". Set by the engine. */
             _emitted_by?: string;
@@ -609,111 +731,6 @@ export interface components {
             /** @description Description of the event (for example, `invoice.created` or `charge.refunded`). */
             type: string;
         };
-        SourceConfig: {
-            /** @constant */
-            type: "stripe";
-            stripe: components["schemas"]["SourceStripeConfig"];
-        };
-        SourceStripeConfig: {
-            /** @description Stripe API key (sk_test_... or sk_live_...) */
-            api_key: string;
-            /** @description Stripe account ID (resolved from API if omitted) */
-            account_id?: string;
-            /** @description Whether this is a live mode sync */
-            livemode?: boolean;
-            /** @enum {string} */
-            api_version?: "2026-03-25.dahlia" | "2026-02-25.clover" | "2026-01-28.clover" | "2025-12-15.clover" | "2025-11-17.clover" | "2025-10-29.clover" | "2025-09-30.clover" | "2025-08-27.basil" | "2025-07-30.basil" | "2025-06-30.basil" | "2025-05-28.basil" | "2025-04-30.basil" | "2025-03-31.basil" | "2025-02-24.acacia" | "2025-01-27.acacia" | "2024-12-18.acacia" | "2024-11-20.acacia" | "2024-10-28.acacia" | "2024-09-30.acacia" | "2024-06-20" | "2024-04-10" | "2024-04-03" | "2023-10-16" | "2023-08-16" | "2022-11-15" | "2022-08-01" | "2020-08-27" | "2020-03-02" | "2019-12-03" | "2019-11-05" | "2019-10-17" | "2019-10-08" | "2019-09-09" | "2019-08-14" | "2019-05-16" | "2019-03-14" | "2019-02-19" | "2019-02-11" | "2018-11-08" | "2018-10-31" | "2018-09-24" | "2018-09-06" | "2018-08-23" | "2018-07-27" | "2018-05-21" | "2018-02-28" | "2018-02-06" | "2018-02-05" | "2018-01-23" | "2017-12-14" | "2017-08-15";
-            /**
-             * Format: uri
-             * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
-             */
-            base_url?: string;
-            /**
-             * Format: uri
-             * @description URL for managed webhook endpoint registration
-             */
-            webhook_url?: string;
-            /** @description Webhook signing secret (whsec_...) for signature verification */
-            webhook_secret?: string;
-            /** @description Enable WebSocket streaming for live events */
-            websocket?: boolean;
-            /** @description Enable events API polling for incremental sync after backfill */
-            poll_events?: boolean;
-            /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
-            webhook_port?: number;
-            /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
-            revalidate_objects?: string[];
-            /** @description Max objects to backfill per stream (useful for testing) */
-            backfill_limit?: number;
-            /** @description Max Stripe API requests per second (default: 25) */
-            rate_limit?: number;
-        };
-        DestinationConfig: {
-            /** @constant */
-            type: "postgres";
-            postgres: components["schemas"]["DestinationPostgresConfig"];
-        } | {
-            /** @constant */
-            type: "google_sheets";
-            google_sheets: components["schemas"]["DestinationGoogleSheetsConfig"];
-        };
-        DestinationPostgresConfig: {
-            /** @description Postgres connection string (alias for connection_string) */
-            url?: string;
-            /** @description Postgres connection string */
-            connection_string?: string;
-            /** @description Postgres host (required for AWS IAM) */
-            host?: string;
-            /**
-             * @description Postgres port
-             * @default 5432
-             */
-            port: number;
-            /** @description Database name (required for AWS IAM) */
-            database?: string;
-            /** @description Database user (required for AWS IAM) */
-            user?: string;
-            /** @description Target schema name (e.g. "stripe_sync") */
-            schema: string;
-            /**
-             * @description Records to buffer before flushing
-             * @default 100
-             */
-            batch_size: number;
-            /** @description AWS RDS IAM authentication config */
-            aws?: {
-                /** @description AWS region for RDS instance */
-                region: string;
-                /** @description IAM role ARN to assume (cross-account) */
-                role_arn?: string;
-                /** @description External ID for STS AssumeRole */
-                external_id?: string;
-            };
-            /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
-            ssl_ca_pem?: string;
-        };
-        DestinationGoogleSheetsConfig: {
-            /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
-            client_id?: string;
-            /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
-            client_secret?: string;
-            /** @description OAuth2 access token */
-            access_token: string;
-            /** @description OAuth2 refresh token */
-            refresh_token: string;
-            /** @description Target spreadsheet ID (created if omitted) */
-            spreadsheet_id?: string;
-            /**
-             * @description Title when creating a new spreadsheet
-             * @default Stripe Sync
-             */
-            spreadsheet_title: string;
-            /**
-             * @description Rows per Sheets API append call
-             * @default 50
-             */
-            batch_size: number;
-        };
         /** @description Full sync checkpoint with separate sections for source, destination, and engine. Connectors only see their own section; the engine manages routing. */
         SyncState: {
             /** @description Source connector state — cursors, backfill progress, events cursors. */
@@ -762,23 +779,6 @@ export interface components {
             type: "source_input";
             source_input: components["schemas"]["SourceStripeInput"];
         };
-        PipelineConfig: {
-            source: components["schemas"]["SourceConfig"];
-            destination: components["schemas"]["DestinationConfig"];
-            streams?: {
-                /** @description Stream (table) name to sync. */
-                name: string;
-                /**
-                 * @description How the source reads this stream. Defaults to full_refresh.
-                 * @enum {string}
-                 */
-                sync_mode?: "incremental" | "full_refresh";
-                /** @description If set, only these fields are synced. */
-                fields?: string[];
-                /** @description Cap backfill to this many records, then mark the stream complete. */
-                backfill_limit?: number;
-            }[];
-        };
     };
     responses: never;
     parameters: never;
@@ -818,14 +818,19 @@ export interface operations {
     pipeline_check: {
         parameters: {
             query?: never;
-            header: {
-                /** @description JSON-encoded PipelineConfig */
-                "x-pipeline": string;
+            header?: {
+                "x-pipeline"?: string;
             };
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": {
+                    pipeline?: components["schemas"]["PipelineConfig"];
+                };
+            };
+        };
         responses: {
             /** @description NDJSON stream of check messages */
             200: {
@@ -855,14 +860,19 @@ export interface operations {
                 /** @description Run only the source or destination side. Useful for optimistic destination setup (e.g. creating tables early in a UI) or isolating a connector when debugging. */
                 only?: "source" | "destination";
             };
-            header: {
-                /** @description JSON-encoded PipelineConfig */
-                "x-pipeline": string;
+            header?: {
+                "x-pipeline"?: string;
             };
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": {
+                    pipeline?: components["schemas"]["PipelineConfig"];
+                };
+            };
+        };
         responses: {
             /** @description NDJSON stream of setup messages */
             200: {
@@ -892,14 +902,19 @@ export interface operations {
                 /** @description Run only the source or destination side. Useful for optimistic destination setup (e.g. creating tables early in a UI) or isolating a connector when debugging. */
                 only?: "source" | "destination";
             };
-            header: {
-                /** @description JSON-encoded PipelineConfig */
-                "x-pipeline": string;
+            header?: {
+                "x-pipeline"?: string;
             };
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": {
+                    pipeline?: components["schemas"]["PipelineConfig"];
+                };
+            };
+        };
         responses: {
             /** @description NDJSON stream of teardown messages */
             200: {
@@ -926,14 +941,23 @@ export interface operations {
     source_discover: {
         parameters: {
             query?: never;
-            header: {
-                /** @description JSON-encoded source config ({ type, ...config }) */
-                "x-source": string;
+            header?: {
+                "x-source"?: string;
             };
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": {
+                    source?: {
+                        type: string;
+                    } & {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+        };
         responses: {
             /** @description NDJSON stream of discover messages */
             200: {
@@ -965,9 +989,8 @@ export interface operations {
                 /** @description Stop streaming after N seconds. */
                 time_limit?: number;
             };
-            header: {
-                /** @description JSON-encoded PipelineConfig */
-                "x-pipeline": string;
+            header?: {
+                "x-pipeline"?: string;
                 /** @description JSON-encoded SyncState ({ source, destination, engine }) or legacy SourceState/flat formats */
                 "x-state"?: string;
             };
@@ -977,6 +1000,11 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/x-ndjson": components["schemas"]["SourceInputMessage"];
+                "application/json": {
+                    pipeline?: components["schemas"]["PipelineConfig"];
+                    state?: components["schemas"]["SyncState"];
+                    body?: unknown[];
+                };
             };
         };
         responses: {
@@ -1005,9 +1033,8 @@ export interface operations {
     pipeline_write: {
         parameters: {
             query?: never;
-            header: {
-                /** @description JSON-encoded PipelineConfig */
-                "x-pipeline": string;
+            header?: {
+                "x-pipeline"?: string;
             };
             path?: never;
             cookie?: never;
@@ -1015,6 +1042,10 @@ export interface operations {
         requestBody: {
             content: {
                 "application/x-ndjson": components["schemas"]["Message"];
+                "application/json": {
+                    pipeline?: components["schemas"]["PipelineConfig"];
+                    body?: unknown[];
+                };
             };
         };
         responses: {
@@ -1048,9 +1079,8 @@ export interface operations {
                 /** @description Stop streaming after N seconds. */
                 time_limit?: number;
             };
-            header: {
-                /** @description JSON-encoded PipelineConfig */
-                "x-pipeline": string;
+            header?: {
+                "x-pipeline"?: string;
                 /** @description JSON-encoded SyncState ({ source, destination, engine }) or legacy SourceState/flat formats */
                 "x-state"?: string;
             };
@@ -1060,6 +1090,11 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/x-ndjson": components["schemas"]["SourceInputMessage"];
+                "application/json": {
+                    pipeline?: components["schemas"]["PipelineConfig"];
+                    state?: components["schemas"]["SyncState"];
+                    body?: unknown[];
+                };
             };
         };
         responses: {

--- a/apps/engine/src/__generated__/openapi.json
+++ b/apps/engine/src/__generated__/openapi.json
@@ -62,17 +62,27 @@
           {
             "in": "header",
             "name": "x-pipeline",
-            "required": true,
-            "description": "JSON-encoded PipelineConfig",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PipelineConfig"
+            "schema": {
+              "description": "JSON-encoded PipelineConfig",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pipeline": {
+                    "$ref": "#/components/schemas/PipelineConfig"
+                  }
                 }
               }
             }
           }
-        ],
+        },
         "responses": {
           "200": {
             "description": "NDJSON stream of check messages",
@@ -114,6 +124,14 @@
         "description": "Creates destination tables and applies migrations. Streams NDJSON messages (control, log, trace) tagged with _emitted_by. Pass ?only=destination to run destination setup alone (e.g. optimistic table creation) or ?only=source to isolate the source.",
         "parameters": [
           {
+            "in": "header",
+            "name": "x-pipeline",
+            "schema": {
+              "description": "JSON-encoded PipelineConfig",
+              "type": "string"
+            }
+          },
+          {
             "in": "query",
             "name": "only",
             "schema": {
@@ -126,21 +144,23 @@
               ]
             },
             "description": "Run only the source or destination side. Useful for optimistic destination setup (e.g. creating tables early in a UI) or isolating a connector when debugging."
-          },
-          {
-            "in": "header",
-            "name": "x-pipeline",
-            "required": true,
-            "description": "JSON-encoded PipelineConfig",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PipelineConfig"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pipeline": {
+                    "$ref": "#/components/schemas/PipelineConfig"
+                  }
                 }
               }
             }
           }
-        ],
+        },
         "responses": {
           "200": {
             "description": "NDJSON stream of setup messages",
@@ -182,6 +202,14 @@
         "description": "Drops destination tables. Streams NDJSON messages (log, trace) tagged with _emitted_by. Pass ?only=destination or ?only=source to run a single side.",
         "parameters": [
           {
+            "in": "header",
+            "name": "x-pipeline",
+            "schema": {
+              "description": "JSON-encoded PipelineConfig",
+              "type": "string"
+            }
+          },
+          {
             "in": "query",
             "name": "only",
             "schema": {
@@ -194,21 +222,23 @@
               ]
             },
             "description": "Run only the source or destination side. Useful for optimistic destination setup (e.g. creating tables early in a UI) or isolating a connector when debugging."
-          },
-          {
-            "in": "header",
-            "name": "x-pipeline",
-            "required": true,
-            "description": "JSON-encoded PipelineConfig",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PipelineConfig"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pipeline": {
+                    "$ref": "#/components/schemas/PipelineConfig"
+                  }
                 }
               }
             }
           }
-        ],
+        },
         "responses": {
           "200": {
             "description": "NDJSON stream of teardown messages",
@@ -252,26 +282,36 @@
           {
             "in": "header",
             "name": "x-source",
-            "required": true,
-            "description": "JSON-encoded source config ({ type, ...config })",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "type"
-                  ],
-                  "additionalProperties": {}
+            "schema": {
+              "description": "JSON-encoded source config ({ type, ...config })",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": {}
+                  }
                 }
               }
             }
           }
-        ],
+        },
         "responses": {
           "200": {
             "description": "NDJSON stream of discover messages",
@@ -310,8 +350,16 @@
           "Stateless Sync API"
         ],
         "summary": "Read records from source",
-        "description": "Streams NDJSON messages (records, state, catalog). Optional NDJSON body provides live events as input.",
+        "description": "Streams NDJSON messages (records, state, catalog). Optional NDJSON body provides live events as input. Alternatively, send Content-Type: application/json with {pipeline, state?, body?} to pass config in the body.",
         "parameters": [
+          {
+            "in": "header",
+            "name": "x-pipeline",
+            "schema": {
+              "description": "JSON-encoded PipelineConfig",
+              "type": "string"
+            }
+          },
           {
             "in": "query",
             "name": "state_limit",
@@ -337,19 +385,6 @@
           },
           {
             "in": "header",
-            "name": "x-pipeline",
-            "required": true,
-            "description": "JSON-encoded PipelineConfig",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PipelineConfig"
-                }
-              }
-            }
-          },
-          {
-            "in": "header",
             "name": "x-state",
             "required": false,
             "description": "JSON-encoded SyncState ({ source, destination, engine }) or legacy SourceState/flat formats",
@@ -368,6 +403,23 @@
             "application/x-ndjson": {
               "schema": {
                 "$ref": "#/components/schemas/SourceInputMessage"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pipeline": {
+                    "$ref": "#/components/schemas/PipelineConfig"
+                  },
+                  "state": {
+                    "$ref": "#/components/schemas/SyncState"
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {}
+                  }
+                }
               }
             }
           }
@@ -410,19 +462,14 @@
           "Stateless Sync API"
         ],
         "summary": "Write records to destination",
-        "description": "Reads NDJSON messages from the request body and writes them to the destination. Pipe /read output as input.",
+        "description": "Reads NDJSON messages from the request body and writes them to the destination. Pipe /read output as input. Alternatively, send Content-Type: application/json with {pipeline, body: [...messages]}.",
         "parameters": [
           {
             "in": "header",
             "name": "x-pipeline",
-            "required": true,
-            "description": "JSON-encoded PipelineConfig",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PipelineConfig"
-                }
-              }
+            "schema": {
+              "description": "JSON-encoded PipelineConfig",
+              "type": "string"
             }
           }
         ],
@@ -432,6 +479,20 @@
             "application/x-ndjson": {
               "schema": {
                 "$ref": "#/components/schemas/Message"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pipeline": {
+                    "$ref": "#/components/schemas/PipelineConfig"
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {}
+                  }
+                }
               }
             }
           }
@@ -474,8 +535,16 @@
           "Stateless Sync API"
         ],
         "summary": "Run sync pipeline (read → write)",
-        "description": "Without a request body, reads from the source connector and writes to the destination (backfill mode). With an NDJSON request body, uses the provided messages as input instead of reading from the source (push mode — e.g. piped webhook events).",
+        "description": "Without a request body, reads from the source connector and writes to the destination (backfill mode). With an NDJSON request body, uses the provided messages as input instead of reading from the source (push mode — e.g. piped webhook events). Alternatively, send Content-Type: application/json with {pipeline, state?, body?} to pass config in the body.",
         "parameters": [
+          {
+            "in": "header",
+            "name": "x-pipeline",
+            "schema": {
+              "description": "JSON-encoded PipelineConfig",
+              "type": "string"
+            }
+          },
           {
             "in": "query",
             "name": "state_limit",
@@ -501,19 +570,6 @@
           },
           {
             "in": "header",
-            "name": "x-pipeline",
-            "required": true,
-            "description": "JSON-encoded PipelineConfig",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PipelineConfig"
-                }
-              }
-            }
-          },
-          {
-            "in": "header",
             "name": "x-state",
             "required": false,
             "description": "JSON-encoded SyncState ({ source, destination, engine }) or legacy SourceState/flat formats",
@@ -532,6 +588,23 @@
             "application/x-ndjson": {
               "schema": {
                 "$ref": "#/components/schemas/SourceInputMessage"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pipeline": {
+                    "$ref": "#/components/schemas/PipelineConfig"
+                  },
+                  "state": {
+                    "$ref": "#/components/schemas/SyncState"
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {}
+                  }
+                }
               }
             }
           }
@@ -764,6 +837,354 @@
   },
   "components": {
     "schemas": {
+      "PipelineConfig": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "$ref": "#/components/schemas/SourceConfig"
+          },
+          "destination": {
+            "$ref": "#/components/schemas/DestinationConfig"
+          },
+          "streams": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Stream (table) name to sync."
+                },
+                "sync_mode": {
+                  "description": "How the source reads this stream. Defaults to full_refresh.",
+                  "type": "string",
+                  "enum": [
+                    "incremental",
+                    "full_refresh"
+                  ]
+                },
+                "fields": {
+                  "description": "If set, only these fields are synced.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "backfill_limit": {
+                  "description": "Cap backfill to this many records, then mark the stream complete.",
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "required": [
+                "name"
+              ]
+            }
+          }
+        },
+        "required": [
+          "source",
+          "destination"
+        ]
+      },
+      "SourceConfig": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "stripe"
+              },
+              "stripe": {
+                "$ref": "#/components/schemas/SourceStripeConfig"
+              }
+            },
+            "required": [
+              "type",
+              "stripe"
+            ]
+          }
+        ],
+        "type": "object",
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
+      "SourceStripeConfig": {
+        "type": "object",
+        "properties": {
+          "api_key": {
+            "type": "string",
+            "description": "Stripe API key (sk_test_... or sk_live_...)"
+          },
+          "account_id": {
+            "type": "string",
+            "description": "Stripe account ID (resolved from API if omitted)"
+          },
+          "livemode": {
+            "type": "boolean",
+            "description": "Whether this is a live mode sync"
+          },
+          "api_version": {
+            "type": "string",
+            "enum": [
+              "2026-03-25.dahlia",
+              "2026-02-25.clover",
+              "2026-01-28.clover",
+              "2025-12-15.clover",
+              "2025-11-17.clover",
+              "2025-10-29.clover",
+              "2025-09-30.clover",
+              "2025-08-27.basil",
+              "2025-07-30.basil",
+              "2025-06-30.basil",
+              "2025-05-28.basil",
+              "2025-04-30.basil",
+              "2025-03-31.basil",
+              "2025-02-24.acacia",
+              "2025-01-27.acacia",
+              "2024-12-18.acacia",
+              "2024-11-20.acacia",
+              "2024-10-28.acacia",
+              "2024-09-30.acacia",
+              "2024-06-20",
+              "2024-04-10",
+              "2024-04-03",
+              "2023-10-16",
+              "2023-08-16",
+              "2022-11-15",
+              "2022-08-01",
+              "2020-08-27",
+              "2020-03-02",
+              "2019-12-03",
+              "2019-11-05",
+              "2019-10-17",
+              "2019-10-08",
+              "2019-09-09",
+              "2019-08-14",
+              "2019-05-16",
+              "2019-03-14",
+              "2019-02-19",
+              "2019-02-11",
+              "2018-11-08",
+              "2018-10-31",
+              "2018-09-24",
+              "2018-09-06",
+              "2018-08-23",
+              "2018-07-27",
+              "2018-05-21",
+              "2018-02-28",
+              "2018-02-06",
+              "2018-02-05",
+              "2018-01-23",
+              "2017-12-14",
+              "2017-08-15"
+            ]
+          },
+          "base_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)"
+          },
+          "webhook_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL for managed webhook endpoint registration"
+          },
+          "webhook_secret": {
+            "type": "string",
+            "description": "Webhook signing secret (whsec_...) for signature verification"
+          },
+          "websocket": {
+            "type": "boolean",
+            "description": "Enable WebSocket streaming for live events"
+          },
+          "poll_events": {
+            "type": "boolean",
+            "description": "Enable events API polling for incremental sync after backfill"
+          },
+          "webhook_port": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Port for built-in webhook HTTP listener (e.g. 4242)"
+          },
+          "revalidate_objects": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Object types to re-fetch from Stripe API on webhook (e.g. [\"subscription\"])"
+          },
+          "backfill_limit": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "description": "Max objects to backfill per stream (useful for testing)"
+          },
+          "rate_limit": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "description": "Max Stripe API requests per second (default: 25)"
+          }
+        },
+        "required": [
+          "api_key"
+        ],
+        "additionalProperties": false
+      },
+      "DestinationConfig": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "postgres"
+              },
+              "postgres": {
+                "$ref": "#/components/schemas/DestinationPostgresConfig"
+              }
+            },
+            "required": [
+              "type",
+              "postgres"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "google_sheets"
+              },
+              "google_sheets": {
+                "$ref": "#/components/schemas/DestinationGoogleSheetsConfig"
+              }
+            },
+            "required": [
+              "type",
+              "google_sheets"
+            ]
+          }
+        ],
+        "type": "object",
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
+      "DestinationPostgresConfig": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Postgres connection string (alias for connection_string)"
+          },
+          "connection_string": {
+            "type": "string",
+            "description": "Postgres connection string"
+          },
+          "host": {
+            "type": "string",
+            "description": "Postgres host (required for AWS IAM)"
+          },
+          "port": {
+            "default": 5432,
+            "type": "number",
+            "description": "Postgres port"
+          },
+          "database": {
+            "type": "string",
+            "description": "Database name (required for AWS IAM)"
+          },
+          "user": {
+            "type": "string",
+            "description": "Database user (required for AWS IAM)"
+          },
+          "schema": {
+            "type": "string",
+            "description": "Target schema name (e.g. \"stripe_sync\")"
+          },
+          "batch_size": {
+            "default": 100,
+            "type": "number",
+            "description": "Records to buffer before flushing"
+          },
+          "aws": {
+            "type": "object",
+            "properties": {
+              "region": {
+                "type": "string",
+                "description": "AWS region for RDS instance"
+              },
+              "role_arn": {
+                "type": "string",
+                "description": "IAM role ARN to assume (cross-account)"
+              },
+              "external_id": {
+                "type": "string",
+                "description": "External ID for STS AssumeRole"
+              }
+            },
+            "required": [
+              "region"
+            ],
+            "additionalProperties": false,
+            "description": "AWS RDS IAM authentication config"
+          },
+          "ssl_ca_pem": {
+            "type": "string",
+            "description": "PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA)"
+          }
+        },
+        "required": [
+          "schema"
+        ],
+        "additionalProperties": false
+      },
+      "DestinationGoogleSheetsConfig": {
+        "type": "object",
+        "properties": {
+          "client_id": {
+            "type": "string",
+            "description": "Google OAuth2 client ID (env: GOOGLE_CLIENT_ID)"
+          },
+          "client_secret": {
+            "type": "string",
+            "description": "Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET)"
+          },
+          "access_token": {
+            "type": "string",
+            "description": "OAuth2 access token"
+          },
+          "refresh_token": {
+            "type": "string",
+            "description": "OAuth2 refresh token"
+          },
+          "spreadsheet_id": {
+            "type": "string",
+            "description": "Target spreadsheet ID (created if omitted)"
+          },
+          "spreadsheet_title": {
+            "default": "Stripe Sync",
+            "type": "string",
+            "description": "Title when creating a new spreadsheet"
+          },
+          "batch_size": {
+            "default": 50,
+            "type": "number",
+            "description": "Rows per Sheets API append call"
+          }
+        },
+        "required": [
+          "access_token",
+          "refresh_token"
+        ],
+        "additionalProperties": false
+      },
       "RecordMessage": {
         "type": "object",
         "properties": {
@@ -1699,303 +2120,6 @@
         ],
         "additionalProperties": false
       },
-      "SourceConfig": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "stripe"
-              },
-              "stripe": {
-                "$ref": "#/components/schemas/SourceStripeConfig"
-              }
-            },
-            "required": [
-              "type",
-              "stripe"
-            ]
-          }
-        ],
-        "type": "object",
-        "discriminator": {
-          "propertyName": "type"
-        }
-      },
-      "SourceStripeConfig": {
-        "type": "object",
-        "properties": {
-          "api_key": {
-            "type": "string",
-            "description": "Stripe API key (sk_test_... or sk_live_...)"
-          },
-          "account_id": {
-            "type": "string",
-            "description": "Stripe account ID (resolved from API if omitted)"
-          },
-          "livemode": {
-            "type": "boolean",
-            "description": "Whether this is a live mode sync"
-          },
-          "api_version": {
-            "type": "string",
-            "enum": [
-              "2026-03-25.dahlia",
-              "2026-02-25.clover",
-              "2026-01-28.clover",
-              "2025-12-15.clover",
-              "2025-11-17.clover",
-              "2025-10-29.clover",
-              "2025-09-30.clover",
-              "2025-08-27.basil",
-              "2025-07-30.basil",
-              "2025-06-30.basil",
-              "2025-05-28.basil",
-              "2025-04-30.basil",
-              "2025-03-31.basil",
-              "2025-02-24.acacia",
-              "2025-01-27.acacia",
-              "2024-12-18.acacia",
-              "2024-11-20.acacia",
-              "2024-10-28.acacia",
-              "2024-09-30.acacia",
-              "2024-06-20",
-              "2024-04-10",
-              "2024-04-03",
-              "2023-10-16",
-              "2023-08-16",
-              "2022-11-15",
-              "2022-08-01",
-              "2020-08-27",
-              "2020-03-02",
-              "2019-12-03",
-              "2019-11-05",
-              "2019-10-17",
-              "2019-10-08",
-              "2019-09-09",
-              "2019-08-14",
-              "2019-05-16",
-              "2019-03-14",
-              "2019-02-19",
-              "2019-02-11",
-              "2018-11-08",
-              "2018-10-31",
-              "2018-09-24",
-              "2018-09-06",
-              "2018-08-23",
-              "2018-07-27",
-              "2018-05-21",
-              "2018-02-28",
-              "2018-02-06",
-              "2018-02-05",
-              "2018-01-23",
-              "2017-12-14",
-              "2017-08-15"
-            ]
-          },
-          "base_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)"
-          },
-          "webhook_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "URL for managed webhook endpoint registration"
-          },
-          "webhook_secret": {
-            "type": "string",
-            "description": "Webhook signing secret (whsec_...) for signature verification"
-          },
-          "websocket": {
-            "type": "boolean",
-            "description": "Enable WebSocket streaming for live events"
-          },
-          "poll_events": {
-            "type": "boolean",
-            "description": "Enable events API polling for incremental sync after backfill"
-          },
-          "webhook_port": {
-            "type": "integer",
-            "minimum": -9007199254740991,
-            "maximum": 9007199254740991,
-            "description": "Port for built-in webhook HTTP listener (e.g. 4242)"
-          },
-          "revalidate_objects": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Object types to re-fetch from Stripe API on webhook (e.g. [\"subscription\"])"
-          },
-          "backfill_limit": {
-            "type": "integer",
-            "exclusiveMinimum": 0,
-            "maximum": 9007199254740991,
-            "description": "Max objects to backfill per stream (useful for testing)"
-          },
-          "rate_limit": {
-            "type": "integer",
-            "exclusiveMinimum": 0,
-            "maximum": 9007199254740991,
-            "description": "Max Stripe API requests per second (default: 25)"
-          }
-        },
-        "required": [
-          "api_key"
-        ],
-        "additionalProperties": false
-      },
-      "DestinationConfig": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "postgres"
-              },
-              "postgres": {
-                "$ref": "#/components/schemas/DestinationPostgresConfig"
-              }
-            },
-            "required": [
-              "type",
-              "postgres"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "google_sheets"
-              },
-              "google_sheets": {
-                "$ref": "#/components/schemas/DestinationGoogleSheetsConfig"
-              }
-            },
-            "required": [
-              "type",
-              "google_sheets"
-            ]
-          }
-        ],
-        "type": "object",
-        "discriminator": {
-          "propertyName": "type"
-        }
-      },
-      "DestinationPostgresConfig": {
-        "type": "object",
-        "properties": {
-          "url": {
-            "type": "string",
-            "description": "Postgres connection string (alias for connection_string)"
-          },
-          "connection_string": {
-            "type": "string",
-            "description": "Postgres connection string"
-          },
-          "host": {
-            "type": "string",
-            "description": "Postgres host (required for AWS IAM)"
-          },
-          "port": {
-            "default": 5432,
-            "type": "number",
-            "description": "Postgres port"
-          },
-          "database": {
-            "type": "string",
-            "description": "Database name (required for AWS IAM)"
-          },
-          "user": {
-            "type": "string",
-            "description": "Database user (required for AWS IAM)"
-          },
-          "schema": {
-            "type": "string",
-            "description": "Target schema name (e.g. \"stripe_sync\")"
-          },
-          "batch_size": {
-            "default": 100,
-            "type": "number",
-            "description": "Records to buffer before flushing"
-          },
-          "aws": {
-            "type": "object",
-            "properties": {
-              "region": {
-                "type": "string",
-                "description": "AWS region for RDS instance"
-              },
-              "role_arn": {
-                "type": "string",
-                "description": "IAM role ARN to assume (cross-account)"
-              },
-              "external_id": {
-                "type": "string",
-                "description": "External ID for STS AssumeRole"
-              }
-            },
-            "required": [
-              "region"
-            ],
-            "additionalProperties": false,
-            "description": "AWS RDS IAM authentication config"
-          },
-          "ssl_ca_pem": {
-            "type": "string",
-            "description": "PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA)"
-          }
-        },
-        "required": [
-          "schema"
-        ],
-        "additionalProperties": false
-      },
-      "DestinationGoogleSheetsConfig": {
-        "type": "object",
-        "properties": {
-          "client_id": {
-            "type": "string",
-            "description": "Google OAuth2 client ID (env: GOOGLE_CLIENT_ID)"
-          },
-          "client_secret": {
-            "type": "string",
-            "description": "Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET)"
-          },
-          "access_token": {
-            "type": "string",
-            "description": "OAuth2 access token"
-          },
-          "refresh_token": {
-            "type": "string",
-            "description": "OAuth2 refresh token"
-          },
-          "spreadsheet_id": {
-            "type": "string",
-            "description": "Target spreadsheet ID (created if omitted)"
-          },
-          "spreadsheet_title": {
-            "default": "Stripe Sync",
-            "type": "string",
-            "description": "Title when creating a new spreadsheet"
-          },
-          "batch_size": {
-            "default": 50,
-            "type": "number",
-            "description": "Rows per Sheets API append call"
-          }
-        },
-        "required": [
-          "access_token",
-          "refresh_token"
-        ],
-        "additionalProperties": false
-      },
       "SyncState": {
         "type": "object",
         "properties": {
@@ -2285,59 +2409,6 @@
         "required": [
           "type",
           "source_input"
-        ],
-        "additionalProperties": false
-      },
-      "PipelineConfig": {
-        "type": "object",
-        "properties": {
-          "source": {
-            "$ref": "#/components/schemas/SourceConfig"
-          },
-          "destination": {
-            "$ref": "#/components/schemas/DestinationConfig"
-          },
-          "streams": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Stream (table) name to sync."
-                },
-                "sync_mode": {
-                  "description": "How the source reads this stream. Defaults to full_refresh.",
-                  "type": "string",
-                  "enum": [
-                    "incremental",
-                    "full_refresh"
-                  ]
-                },
-                "fields": {
-                  "description": "If set, only these fields are synced.",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "backfill_limit": {
-                  "description": "Cap backfill to this many records, then mark the stream complete.",
-                  "type": "integer",
-                  "exclusiveMinimum": 0,
-                  "maximum": 9007199254740991
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "additionalProperties": false
-            }
-          }
-        },
-        "required": [
-          "source",
-          "destination"
         ],
         "additionalProperties": false
       }

--- a/apps/engine/src/api/app.test.ts
+++ b/apps/engine/src/api/app.test.ts
@@ -868,6 +868,207 @@ describe('POST /source_discover', () => {
 })
 
 // ---------------------------------------------------------------------------
+// JSON body mode (Content-Type: application/json)
+// ---------------------------------------------------------------------------
+
+const syncParamsObj = JSON.parse(syncParams)
+
+describe('JSON body mode', () => {
+  it('POST /pipeline_check accepts pipeline in JSON body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pipeline: syncParamsObj }),
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('application/x-ndjson')
+    const events = await readNdjson<Record<string, unknown>>(res)
+    const statuses = events.filter((e) => e.type === 'connection_status')
+    expect(statuses).toHaveLength(2)
+  })
+
+  it('POST /pipeline_setup accepts pipeline in JSON body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_setup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pipeline: syncParamsObj }),
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('application/x-ndjson')
+  })
+
+  it('POST /pipeline_teardown accepts pipeline in JSON body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_teardown', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pipeline: syncParamsObj }),
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('application/x-ndjson')
+  })
+
+  it('POST /source_discover accepts source in JSON body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/source_discover', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        source: { type: 'test', test: { streams: { customers: {} } } },
+      }),
+    })
+    expect(res.status).toBe(200)
+    const events = await readNdjson<Record<string, unknown>>(res)
+    expect(events.some((e) => e.type === 'catalog')).toBe(true)
+  })
+
+  it('POST /pipeline_read accepts pipeline + state + body array in JSON body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_read', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        pipeline: syncParamsObj,
+        body: [
+          {
+            type: 'record',
+            record: {
+              stream: 'customers',
+              data: { id: 'cus_1', name: 'Alice' },
+              emitted_at: new Date().toISOString(),
+            },
+          },
+          {
+            type: 'source_state',
+            source_state: { stream: 'customers', data: { status: 'complete' } },
+          },
+        ],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const events = await readNdjson<Message>(res)
+    expect(events).toHaveLength(3)
+    expect(events[0]!.type).toBe('record')
+    expect(events[1]!.type).toBe('source_state')
+    expect(events[2]).toMatchObject({ type: 'eof', eof: { reason: 'complete' } })
+  })
+
+  it('POST /pipeline_read accepts pipeline in JSON body without input', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_read', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pipeline: syncParamsObj }),
+    })
+    expect(res.status).toBe(200)
+    const events = await readNdjson<Message>(res)
+    expect(events.some((e) => e.type === 'eof')).toBe(true)
+  })
+
+  it('POST /pipeline_write accepts pipeline + body array in JSON body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_write', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        pipeline: syncParamsObj,
+        body: [
+          {
+            type: 'record',
+            record: {
+              stream: 'customers',
+              data: { id: 'cus_1' },
+              emitted_at: '2024-01-01T00:00:00.000Z',
+            },
+          },
+          {
+            type: 'source_state',
+            source_state: { stream: 'customers', data: { cursor: 'cus_1' } },
+          },
+        ],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const events = await readNdjson<Record<string, unknown>>(res)
+    expect(events.some((e) => e.type === 'source_state')).toBe(true)
+  })
+
+  it('POST /pipeline_sync accepts pipeline + state + body array in JSON body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        pipeline: syncParamsObj,
+        body: [
+          {
+            type: 'record',
+            record: {
+              stream: 'customers',
+              data: { id: 'cus_1', name: 'Alice' },
+              emitted_at: new Date().toISOString(),
+            },
+          },
+          {
+            type: 'source_state',
+            source_state: { stream: 'customers', data: { status: 'complete' } },
+          },
+        ],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const events = await readNdjson<Record<string, unknown>>(res)
+    expect(events.some((e) => e.type === 'source_state')).toBe(true)
+    expect(events.some((e) => e.type === 'eof')).toBe(true)
+  })
+
+  it('POST /pipeline_sync without body array runs backfill mode', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pipeline: syncParamsObj }),
+    })
+    expect(res.status).toBe(200)
+    const events = await readNdjson<Record<string, unknown>>(res)
+    expect(events.some((e) => e.type === 'eof')).toBe(true)
+  })
+
+  it('returns 400 when JSON body is missing pipeline', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('NDJSON content-type uses header mode even with JSON-like body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_check', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-ndjson',
+        'X-Pipeline': syncParams,
+      },
+    })
+    expect(res.status).toBe(200)
+  })
+
+  it('no content-type defaults to header mode', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_check', {
+      method: 'POST',
+      headers: { 'X-Pipeline': syncParams },
+    })
+    expect(res.status).toBe(200)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // POST /internal/query
 // ---------------------------------------------------------------------------
 

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -104,7 +104,10 @@ async function* logApiStream<T>(
         logger.info({ ...context, eof: msg.eof }, formatEof(msg.eof as EofPayload))
       yield item
     }
-    logger.debug({ ...context, itemCount, durationMs: Date.now() - startedAt }, `${label} completed`)
+    logger.debug(
+      { ...context, itemCount, durationMs: Date.now() - startedAt },
+      `${label} completed`
+    )
   } catch (error) {
     logger.error(
       { ...context, itemCount, durationMs: Date.now() - startedAt, err: error },
@@ -348,6 +351,15 @@ export async function createApp(resolver: ConnectorResolver) {
     return false
   }
 
+  function isJsonBody(c: { req: { header: (name: string) => string | undefined } }): boolean {
+    return c.req.header('content-type')?.includes('application/json') ?? false
+  }
+
+  function required<T>(value: T | undefined, name: string): T {
+    if (value === undefined) throw new HTTPException(400, { message: `${name} is required` })
+    return value
+  }
+
   // ── Typed header schemas (transform + pipe for runtime validation,
   //    .meta({ param: { content } }) for OAS content encoding) ────
 
@@ -397,12 +409,41 @@ export async function createApp(resolver: ConnectorResolver) {
       param: { content: { 'application/json': {} } },
     })
 
-  const pipelineHeaders = z.object({ 'x-pipeline': xPipelineHeader })
-  const sourceHeaders = z.object({ 'x-source': xSourceHeader })
+  const pipelineHeaders = z.object({ 'x-pipeline': xPipelineHeader.optional() })
+  const sourceHeaders = z.object({ 'x-source': xSourceHeader.optional() })
   const allSyncHeaders = z.object({
-    'x-pipeline': xPipelineHeader,
+    'x-pipeline': xPipelineHeader.optional(),
     'x-state': xStateHeader,
   })
+
+  // ── JSON body schemas (native objects, no string-parse transform) ────
+
+  const pipelineBody = z
+    .object({
+      pipeline: TypedPipelineConfig.optional(),
+    })
+    .optional()
+
+  const syncBody = z
+    .object({
+      pipeline: TypedPipelineConfig.optional(),
+      state: SyncState.optional(),
+      body: z.array(z.unknown()).optional(),
+    })
+    .optional()
+
+  const writeBody = z
+    .object({
+      pipeline: TypedPipelineConfig.optional(),
+      body: z.array(z.unknown()).optional(),
+    })
+    .optional()
+
+  const sourceBody = z
+    .object({
+      source: z.object({ type: z.string() }).catchall(z.unknown()).optional(),
+    })
+    .optional()
 
   function parseLegacyStateHeader(raw: string | undefined) {
     if (!raw) return undefined
@@ -480,6 +521,10 @@ export async function createApp(resolver: ConnectorResolver) {
     description:
       'Validates the source/destination config and tests connectivity. Streams NDJSON messages (connection_status, log, trace) tagged with _emitted_by.',
     requestParams: { header: pipelineHeaders },
+    requestBody: {
+      required: false,
+      content: { 'application/json': { schema: pipelineBody } },
+    },
     responses: {
       200: {
         description: 'NDJSON stream of check messages',
@@ -489,7 +534,9 @@ export async function createApp(resolver: ConnectorResolver) {
     },
   })
   app.openapi(pipelineCheckRoute, (c) => {
-    const pipeline = c.req.valid('header')['x-pipeline']
+    const pipeline = isJsonBody(c)
+      ? required(c.req.valid('json')?.pipeline, 'pipeline')
+      : required(c.req.valid('header')['x-pipeline'], 'x-pipeline header')
     const context = { path: '/pipeline_check', ...syncRequestContext(pipeline) }
     return ndjsonResponse(
       logApiStream('Engine API /pipeline_check', engine.pipeline_check(pipeline), context)
@@ -514,6 +561,10 @@ export async function createApp(resolver: ConnectorResolver) {
       'Creates destination tables and applies migrations. Streams NDJSON messages (control, log, trace) tagged with _emitted_by. ' +
       'Pass ?only=destination to run destination setup alone (e.g. optimistic table creation) or ?only=source to isolate the source.',
     requestParams: { header: pipelineHeaders, query: onlyQueryParam },
+    requestBody: {
+      required: false,
+      content: { 'application/json': { schema: pipelineBody } },
+    },
     responses: {
       200: {
         description: 'NDJSON stream of setup messages',
@@ -523,7 +574,9 @@ export async function createApp(resolver: ConnectorResolver) {
     },
   })
   app.openapi(pipelineSetupRoute, (c) => {
-    const pipeline = c.req.valid('header')['x-pipeline']
+    const pipeline = isJsonBody(c)
+      ? required(c.req.valid('json')?.pipeline, 'pipeline')
+      : required(c.req.valid('header')['x-pipeline'], 'x-pipeline header')
     const only = c.req.valid('query').only
     const context = { path: '/pipeline_setup', ...syncRequestContext(pipeline) }
     return ndjsonResponse(
@@ -545,6 +598,10 @@ export async function createApp(resolver: ConnectorResolver) {
       'Drops destination tables. Streams NDJSON messages (log, trace) tagged with _emitted_by. ' +
       'Pass ?only=destination or ?only=source to run a single side.',
     requestParams: { header: pipelineHeaders, query: onlyQueryParam },
+    requestBody: {
+      required: false,
+      content: { 'application/json': { schema: pipelineBody } },
+    },
     responses: {
       200: {
         description: 'NDJSON stream of teardown messages',
@@ -554,7 +611,9 @@ export async function createApp(resolver: ConnectorResolver) {
     },
   })
   app.openapi(pipelineTeardownRoute, (c) => {
-    const pipeline = c.req.valid('header')['x-pipeline']
+    const pipeline = isJsonBody(c)
+      ? required(c.req.valid('json')?.pipeline, 'pipeline')
+      : required(c.req.valid('header')['x-pipeline'], 'x-pipeline header')
     const only = c.req.valid('query').only
     const context = { path: '/pipeline_teardown', ...syncRequestContext(pipeline) }
     return ndjsonResponse(
@@ -574,6 +633,10 @@ export async function createApp(resolver: ConnectorResolver) {
     summary: 'Discover available streams',
     description: 'Streams NDJSON messages (catalog, logs, traces) for the configured source.',
     requestParams: { header: sourceHeaders },
+    requestBody: {
+      required: false,
+      content: { 'application/json': { schema: sourceBody } },
+    },
     responses: {
       200: {
         description: 'NDJSON stream of discover messages',
@@ -583,7 +646,9 @@ export async function createApp(resolver: ConnectorResolver) {
     },
   })
   app.openapi(sourceDiscoverRoute, (c) => {
-    const source = c.req.valid('header')['x-source']
+    const source = isJsonBody(c)
+      ? required(c.req.valid('json')?.source, 'source')
+      : required(c.req.valid('header')['x-source'], 'x-source header')
     const context = { path: '/source_discover', sourceName: source.type }
     return ndjsonResponse(
       logApiStream('Engine API /source_discover', engine.source_discover(source), context)
@@ -597,7 +662,8 @@ export async function createApp(resolver: ConnectorResolver) {
     tags: ['Stateless Sync API'],
     summary: 'Read records from source',
     description:
-      'Streams NDJSON messages (records, state, catalog). Optional NDJSON body provides live events as input.',
+      'Streams NDJSON messages (records, state, catalog). Optional NDJSON body provides live events as input. ' +
+      'Alternatively, send Content-Type: application/json with {pipeline, state?, body?} to pass config in the body.',
     requestParams: { header: allSyncHeaders, query: syncQueryParams },
     requestBody: {
       required: false,
@@ -605,6 +671,7 @@ export async function createApp(resolver: ConnectorResolver) {
         'application/x-ndjson': {
           schema: SourceInputMessage ? ndjsonRef.SourceInputMessage : ndjsonRef.Message,
         },
+        'application/json': { schema: syncBody },
       },
     },
     responses: {
@@ -616,11 +683,57 @@ export async function createApp(resolver: ConnectorResolver) {
     },
   })
   app.openapi(pipelineReadRoute, async (c) => {
-    const pipeline = c.req.valid('header')['x-pipeline']
-    const state =
-      c.req.valid('header')['x-state'] ?? parseLegacyStateHeader(c.req.header('x-source-state'))
     const { state_limit, time_limit } = c.req.valid('query')
-    const inputPresent = hasBody(c)
+
+    let pipeline: z.infer<typeof TypedPipelineConfig>
+    let state: z.infer<typeof SyncState> | undefined
+    let input: AsyncIterable<unknown> | undefined
+
+    if (isJsonBody(c)) {
+      const json = c.req.valid('json')
+      pipeline = required(json?.pipeline, 'pipeline')
+      state = json?.state
+      const bodyMessages = json?.body
+      if (bodyMessages?.length) {
+        if (SourceInputMessage) {
+          input = (async function* () {
+            for (const msg of bodyMessages) {
+              if (dangerouslyVerbose) logger.debug({ msg }, 'pipeline_read input')
+              const parsed = SourceInputMessage.parse(msg)
+              yield (parsed as { source_input: unknown }).source_input
+            }
+          })()
+        } else {
+          input = (async function* () {
+            for (const msg of bodyMessages) {
+              if (dangerouslyVerbose) logger.debug({ msg }, 'pipeline_read input')
+              yield msg
+            }
+          })()
+        }
+      }
+    } else {
+      pipeline = required(c.req.valid('header')['x-pipeline'], 'x-pipeline header')
+      state =
+        c.req.valid('header')['x-state'] ?? parseLegacyStateHeader(c.req.header('x-source-state'))
+      if (hasBody(c)) {
+        if (SourceInputMessage) {
+          input = (async function* () {
+            for await (const msg of verboseInput(
+              'pipeline_read',
+              parseNdjsonStream(c.req.raw.body!)
+            )) {
+              const parsed = SourceInputMessage.parse(msg)
+              yield (parsed as { source_input: unknown }).source_input
+            }
+          })()
+        } else {
+          input = verboseInput('pipeline_read', parseNdjsonStream(c.req.raw.body!))
+        }
+      }
+    }
+
+    const inputPresent = !!input
     const context = { path: '/pipeline_read', inputPresent, ...syncRequestContext(pipeline) }
     const startedAt = Date.now()
     logger.info(context, 'Engine API /pipeline_read started')
@@ -632,22 +745,6 @@ export async function createApp(resolver: ConnectorResolver) {
       )
     const ac = createConnectionAbort(c, onDisconnect)
 
-    let input: AsyncIterable<unknown> | undefined
-    if (inputPresent) {
-      if (SourceInputMessage) {
-        input = (async function* () {
-          for await (const msg of verboseInput(
-            'pipeline_read',
-            parseNdjsonStream(c.req.raw.body!)
-          )) {
-            const parsed = SourceInputMessage.parse(msg)
-            yield (parsed as { source_input: unknown }).source_input
-          }
-        })()
-      } else {
-        input = verboseInput('pipeline_read', parseNdjsonStream(c.req.raw.body!))
-      }
-    }
     const output = engine.pipeline_read(
       pipeline,
       { state, state_limit, time_limit },
@@ -666,11 +763,15 @@ export async function createApp(resolver: ConnectorResolver) {
     tags: ['Stateless Sync API'],
     summary: 'Write records to destination',
     description:
-      'Reads NDJSON messages from the request body and writes them to the destination. Pipe /read output as input.',
+      'Reads NDJSON messages from the request body and writes them to the destination. Pipe /read output as input. ' +
+      'Alternatively, send Content-Type: application/json with {pipeline, body: [...messages]}.',
     requestParams: { header: pipelineHeaders },
     requestBody: {
       required: true,
-      content: { 'application/x-ndjson': { schema: ndjsonRef.Message } },
+      content: {
+        'application/x-ndjson': { schema: ndjsonRef.Message },
+        'application/json': { schema: writeBody },
+      },
     },
     responses: {
       200: {
@@ -681,12 +782,33 @@ export async function createApp(resolver: ConnectorResolver) {
     },
   })
   app.openapi(pipelineWriteRoute, async (c) => {
-    const pipeline = c.req.valid('header')['x-pipeline']
-    const context = { path: '/pipeline_write', ...syncRequestContext(pipeline) }
-    if (!hasBody(c)) {
-      logger.error(context, 'Engine API /write missing request body')
-      return c.json({ error: 'Request body required for /write' }, 400)
+    let pipeline: z.infer<typeof TypedPipelineConfig>
+    let messages: AsyncIterable<Message>
+
+    if (isJsonBody(c)) {
+      const json = c.req.valid('json')
+      pipeline = required(json?.pipeline, 'pipeline')
+      const bodyMessages = required(json?.body, 'body')
+      messages = (async function* () {
+        for (const msg of bodyMessages) {
+          if (dangerouslyVerbose) logger.debug({ msg }, 'pipeline_write input')
+          yield msg
+        }
+      })() as AsyncIterable<Message>
+    } else {
+      pipeline = required(c.req.valid('header')['x-pipeline'], 'x-pipeline header')
+      if (!hasBody(c)) {
+        const context = { path: '/pipeline_write', ...syncRequestContext(pipeline) }
+        logger.error(context, 'Engine API /write missing request body')
+        return c.json({ error: 'Request body required for /write' }, 400)
+      }
+      messages = verboseInput(
+        'pipeline_write',
+        parseNdjsonStream<Message>(c.req.raw.body!)
+      ) as AsyncIterable<Message>
     }
+
+    const context = { path: '/pipeline_write', ...syncRequestContext(pipeline) }
     const startedAt = Date.now()
     logger.info(context, 'Engine API /write started')
 
@@ -697,10 +819,6 @@ export async function createApp(resolver: ConnectorResolver) {
       )
     const ac = createConnectionAbort(c, onDisconnect)
 
-    const messages = verboseInput(
-      'pipeline_write',
-      parseNdjsonStream<Message>(c.req.raw.body!)
-    ) as AsyncIterable<Message>
     return ndjsonResponse(
       logApiStream(
         'Engine API /write',
@@ -720,7 +838,8 @@ export async function createApp(resolver: ConnectorResolver) {
     summary: 'Run sync pipeline (read → write)',
     description:
       'Without a request body, reads from the source connector and writes to the destination (backfill mode). ' +
-      'With an NDJSON request body, uses the provided messages as input instead of reading from the source (push mode — e.g. piped webhook events).',
+      'With an NDJSON request body, uses the provided messages as input instead of reading from the source (push mode — e.g. piped webhook events). ' +
+      'Alternatively, send Content-Type: application/json with {pipeline, state?, body?} to pass config in the body.',
     requestParams: { header: allSyncHeaders, query: syncQueryParams },
     requestBody: {
       required: false,
@@ -728,6 +847,7 @@ export async function createApp(resolver: ConnectorResolver) {
         'application/x-ndjson': {
           schema: SourceInputMessage ? ndjsonRef.SourceInputMessage : ndjsonRef.Message,
         },
+        'application/json': { schema: syncBody },
       },
     },
     responses: {
@@ -739,10 +859,34 @@ export async function createApp(resolver: ConnectorResolver) {
     },
   })
   app.openapi(pipelineSyncRoute, async (c) => {
-    const pipeline = c.req.valid('header')['x-pipeline']
-    const state =
-      c.req.valid('header')['x-state'] ?? parseLegacyStateHeader(c.req.header('x-source-state'))
     const { state_limit, time_limit } = c.req.valid('query')
+
+    let pipeline: z.infer<typeof TypedPipelineConfig>
+    let state: z.infer<typeof SyncState> | undefined
+    let input: AsyncIterable<unknown> | undefined
+
+    if (isJsonBody(c)) {
+      const json = c.req.valid('json')
+      pipeline = required(json?.pipeline, 'pipeline')
+      state = json?.state
+      const bodyMessages = json?.body
+      if (bodyMessages?.length) {
+        input = (async function* () {
+          for (const msg of bodyMessages) {
+            if (dangerouslyVerbose) logger.debug({ msg }, 'pipeline_sync input')
+            yield msg
+          }
+        })()
+      }
+    } else {
+      pipeline = required(c.req.valid('header')['x-pipeline'], 'x-pipeline header')
+      state =
+        c.req.valid('header')['x-state'] ?? parseLegacyStateHeader(c.req.header('x-source-state'))
+      if (hasBody(c)) {
+        input = verboseInput('pipeline_sync', parseNdjsonStream(c.req.raw.body!))
+      }
+    }
+
     const context = { path: '/pipeline_sync', ...syncRequestContext(pipeline) }
     const startedAt = Date.now()
 
@@ -753,9 +897,6 @@ export async function createApp(resolver: ConnectorResolver) {
       )
     const ac = createConnectionAbort(c, onDisconnect)
 
-    const input = hasBody(c)
-      ? verboseInput('pipeline_sync', parseNdjsonStream(c.req.raw.body!))
-      : undefined
     const output = engine.pipeline_sync(
       pipeline,
       { state, state_limit, time_limit },


### PR DESCRIPTION
## Summary

- Adds an alternative to passing config via `x-pipeline`/`x-state` headers: callers can now send `Content-Type: application/json` with a body like `{pipeline, state?, body?}` containing native JSON objects (no string escaping).
- The `Content-Type` header determines which mode is used — `application/json` for the new JSON body path, anything else for the existing header + NDJSON behavior.
- Purely additive and fully backward compatible — all existing header/NDJSON tests pass unchanged.

## Test plan

- [x] JSON body mode tests for all 7 POST endpoints (check, setup, teardown, discover, read, write, sync)
- [x] JSON body with `body` array for read/sync/write
- [x] Missing `pipeline` in JSON body returns 400
- [x] NDJSON content-type still routes to header mode
- [x] No content-type defaults to header mode
- [x] Existing header/NDJSON tests unchanged (207 tests pass)
- [x] Header-size tests pass (1MB, 10MB, 30MB headers)
- [x] Build passes (`tsc`)
- [x] Lint + format clean

Made with [Cursor](https://cursor.com)