### PR TITLE
feat: add JSON body mode for engine API endpoints

### DIFF
--- a/apps/engine/src/__generated__/openapi.d.ts
+++ b/apps/engine/src/__generated__/openapi.d.ts
@@ -112,7 +112,7 @@ export interface paths {
         put?: never;
         /**
          * Read records from source
-         * @description Streams NDJSON messages (records, state, catalog). Optional NDJSON body provides live events as input.
+         * @description Streams NDJSON messages (records, state, catalog). Optional NDJSON body provides live events as input. Alternatively, send Content-Type: application/json with {pipeline, state?, body?} to pass config in the body.
          */
         post: operations["pipeline_read"];
         delete?: never;
@@ -132,7 +132,7 @@ export interface paths {
         put?: never;
         /**
          * Write records to destination
-         * @description Reads NDJSON messages from the request body and writes them to the destination. Pipe /read output as input.
+         * @description Reads NDJSON messages from the request body and writes them to the destination. Pipe /read output as input. Alternatively, send Content-Type: application/json with {pipeline, body: [...messages]}.
          */
         post: operations["pipeline_write"];
         delete?: never;
@@ -152,7 +152,7 @@ export interface paths {
         put?: never;
         /**
          * Run sync pipeline (read → write)
-         * @description Without a request body, reads from the source connector and writes to the destination (backfill mode). With an NDJSON request body, uses the provided messages as input instead of reading from the source (push mode — e.g. piped webhook events).
+         * @description Without a request body, reads from the source connector and writes to the destination (backfill mode). With an NDJSON request body, uses the provided messages as input instead of reading from the source (push mode — e.g. piped webhook events). Alternatively, send Content-Type: application/json with {pipeline, state?, body?} to pass config in the body.
          */
         post: operations["pipeline_sync"];
         delete?: never;
@@ -233,6 +233,111 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        SourceConfig: {
+            /** @constant */
+            type: "stripe";
+            stripe: components["schemas"]["SourceStripeConfig"];
+        };
+        SourceStripeConfig: {
+            /** @description Stripe API key (sk_test_... or sk_live_...) */
+            api_key: string;
+            /** @description Stripe account ID (resolved from API if omitted) */
+            account_id?: string;
+            /** @description Whether this is a live mode sync */
+            livemode?: boolean;
+            /** @enum {string} */
+            api_version?: "2026-03-25.dahlia" | "2026-02-25.clover" | "2026-01-28.clover" | "2025-12-15.clover" | "2025-11-17.clover" | "2025-10-29.clover" | "2025-09-30.clover" | "2025-08-27.basil" | "2025-07-30.basil" | "2025-06-30.basil" | "2025-05-28.basil" | "2025-04-30.basil" | "2025-03-31.basil" | "2025-02-24.acacia" | "2025-01-27.acacia" | "2024-12-18.acacia" | "2024-11-20.acacia" | "2024-10-28.acacia" | "2024-09-30.acacia" | "2024-06-20" | "2024-04-10" | "2024-04-03" | "2023-10-16" | "2023-08-16" | "2022-11-15" | "2022-08-01" | "2020-08-27" | "2020-03-02" | "2019-12-03" | "2019-11-05" | "2019-10-17" | "2019-10-08" | "2019-09-09" | "2019-08-14" | "2019-05-16" | "2019-03-14" | "2019-02-19" | "2019-02-11" | "2018-11-08" | "2018-10-31" | "2018-09-24" | "2018-09-06" | "2018-08-23" | "2018-07-27" | "2018-05-21" | "2018-02-28" | "2018-02-06" | "2018-02-05" | "2018-01-23" | "2017-12-14" | "2017-08-15";
+            /**
+             * Format: uri
+             * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
+             */
+            base_url?: string;
+            /**
+             * Format: uri
+             * @description URL for managed webhook endpoint registration
+             */
+            webhook_url?: string;
+            /** @description Webhook signing secret (whsec_...) for signature verification */
+            webhook_secret?: string;
+            /** @description Enable WebSocket streaming for live events */
+            websocket?: boolean;
+            /** @description Enable events API polling for incremental sync after backfill */
+            poll_events?: boolean;
+            /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
+            webhook_port?: number;
+            /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
+            revalidate_objects?: string[];
+            /** @description Max objects to backfill per stream (useful for testing) */
+            backfill_limit?: number;
+            /** @description Max Stripe API requests per second (default: 25) */
+            rate_limit?: number;
+        };
+        DestinationConfig: {
+            /** @constant */
+            type: "postgres";
+            postgres: components["schemas"]["DestinationPostgresConfig"];
+        } | {
+            /** @constant */
+            type: "google_sheets";
+            google_sheets: components["schemas"]["DestinationGoogleSheetsConfig"];
+        };
+        DestinationPostgresConfig: {
+            /** @description Postgres connection string (alias for connection_string) */
+            url?: string;
+            /** @description Postgres connection string */
+            connection_string?: string;
+            /** @description Postgres host (required for AWS IAM) */
+            host?: string;
+            /**
+             * @description Postgres port
+             * @default 5432
+             */
+            port: number;
+            /** @description Database name (required for AWS IAM) */
+            database?: string;
+            /** @description Database user (required for AWS IAM) */
+            user?: string;
+            /** @description Target schema name (e.g. "stripe_sync") */
+            schema: string;
+            /**
+             * @description Records to buffer before flushing
+             * @default 100
+             */
+            batch_size: number;
+            /** @description AWS RDS IAM authentication config */
+            aws?: {
+                /** @description AWS region for RDS instance */
+                region: string;
+                /** @description IAM role ARN to assume (cross-account) */
+                role_arn?: string;
+                /** @description External ID for STS AssumeRole */
+                external_id?: string;
+            };
+            /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
+            ssl_ca_pem?: string;
+        };
+        DestinationGoogleSheetsConfig: {
+            /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
+            client_id?: string;
+            /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
+            client_secret?: string;
+            /** @description OAuth2 access token */
+            access_token: string;
+            /** @description OAuth2 refresh token */
+            refresh_token: string;
+            /** @description Target spreadsheet ID (created if omitted) */
+            spreadsheet_id?: string;
+            /**
+             * @description Title when creating a new spreadsheet
+             * @default Stripe Sync
+             */
+            spreadsheet_title: string;
+            /**
+             * @description Rows per Sheets API append call
+             * @default 50
+             */
+            batch_size: number;
+        };
         RecordMessage: {
             /** @description Who emitted this message: "source/{type}", "destination/{type}", or "engine". Set by the engine. */
             _emitted_by?: string;
@@ -609,110 +714,22 @@ export interface components {
             /** @description Description of the event (for example, `invoice.created` or `charge.refunded`). */
             type: string;
         };
-        SourceConfig: {
-            /** @constant */
-            type: "stripe";
-            stripe: components["schemas"]["SourceStripeConfig"];
-        };
-        SourceStripeConfig: {
-            /** @description Stripe API key (sk_test_... or sk_live_...) */
-            api_key: string;
-            /** @description Stripe account ID (resolved from API if omitted) */
-            account_id?: string;
-            /** @description Whether this is a live mode sync */
-            livemode?: boolean;
-            /** @enum {string} */
-            api_version?: "2026-03-25.dahlia" | "2026-02-25.clover" | "2026-01-28.clover" | "2025-12-15.clover" | "2025-11-17.clover" | "2025-10-29.clover" | "2025-09-30.clover" | "2025-08-27.basil" | "2025-07-30.basil" | "2025-06-30.basil" | "2025-05-28.basil" | "2025-04-30.basil" | "2025-03-31.basil" | "2025-02-24.acacia" | "2025-01-27.acacia" | "2024-12-18.acacia" | "2024-11-20.acacia" | "2024-10-28.acacia" | "2024-09-30.acacia" | "2024-06-20" | "2024-04-10" | "2024-04-03" | "2023-10-16" | "2023-08-16" | "2022-11-15" | "2022-08-01" | "2020-08-27" | "2020-03-02" | "2019-12-03" | "2019-11-05" | "2019-10-17" | "2019-10-08" | "2019-09-09" | "2019-08-14" | "2019-05-16" | "2019-03-14" | "2019-02-19" | "2019-02-11" | "2018-11-08" | "2018-10-31" | "2018-09-24" | "2018-09-06" | "2018-08-23" | "2018-07-27" | "2018-05-21" | "2018-02-28" | "2018-02-06" | "2018-02-05" | "2018-01-23" | "2017-12-14" | "2017-08-15";
-            /**
-             * Format: uri
-             * @description Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)
-             */
-            base_url?: string;
-            /**
-             * Format: uri
-             * @description URL for managed webhook endpoint registration
-             */
-            webhook_url?: string;
-            /** @description Webhook signing secret (whsec_...) for signature verification */
-            webhook_secret?: string;
-            /** @description Enable WebSocket streaming for live events */
-            websocket?: boolean;
-            /** @description Enable events API polling for incremental sync after backfill */
-            poll_events?: boolean;
-            /** @description Port for built-in webhook HTTP listener (e.g. 4242) */
-            webhook_port?: number;
-            /** @description Object types to re-fetch from Stripe API on webhook (e.g. ["subscription"]) */
-            revalidate_objects?: string[];
-            /** @description Max objects to backfill per stream (useful for testing) */
-            backfill_limit?: number;
-            /** @description Max Stripe API requests per second (default: 25) */
-            rate_limit?: number;
-        };
-        DestinationConfig: {
-            /** @constant */
-            type: "postgres";
-            postgres: components["schemas"]["DestinationPostgresConfig"];
-        } | {
-            /** @constant */
-            type: "google_sheets";
-            google_sheets: components["schemas"]["DestinationGoogleSheetsConfig"];
-        };
-        DestinationPostgresConfig: {
-            /** @description Postgres connection string (alias for connection_string) */
-            url?: string;
-            /** @description Postgres connection string */
-            connection_string?: string;
-            /** @description Postgres host (required for AWS IAM) */
-            host?: string;
-            /**
-             * @description Postgres port
-             * @default 5432
-             */
-            port: number;
-            /** @description Database name (required for AWS IAM) */
-            database?: string;
-            /** @description Database user (required for AWS IAM) */
-            user?: string;
-            /** @description Target schema name (e.g. "stripe_sync") */
-            schema: string;
-            /**
-             * @description Records to buffer before flushing
-             * @default 100
-             */
-            batch_size: number;
-            /** @description AWS RDS IAM authentication config */
-            aws?: {
-                /** @description AWS region for RDS instance */
-                region: string;
-                /** @description IAM role ARN to assume (cross-account) */
-                role_arn?: string;
-                /** @description External ID for STS AssumeRole */
-                external_id?: string;
-            };
-            /** @description PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA) */
-            ssl_ca_pem?: string;
-        };
-        DestinationGoogleSheetsConfig: {
-            /** @description Google OAuth2 client ID (env: GOOGLE_CLIENT_ID) */
-            client_id?: string;
-            /** @description Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET) */
-            client_secret?: string;
-            /** @description OAuth2 access token */
-            access_token: string;
-            /** @description OAuth2 refresh token */
-            refresh_token: string;
-            /** @description Target spreadsheet ID (created if omitted) */
-            spreadsheet_id?: string;
-            /**
-             * @description Title when creating a new spreadsheet
-             * @default Stripe Sync
-             */
-            spreadsheet_title: string;
-            /**
-             * @description Rows per Sheets API append call
-             * @default 50
-             */
-            batch_size: number;
+        PipelineConfig: {
+            source: components["schemas"]["SourceConfig"];
+            destination: components["schemas"]["DestinationConfig"];
+            streams?: {
+                /** @description Stream (table) name to sync. */
+                name: string;
+                /**
+                 * @description How the source reads this stream. Defaults to full_refresh.
+                 * @enum {string}
+                 */
+                sync_mode?: "incremental" | "full_refresh";
+                /** @description If set, only these fields are synced. */
+                fields?: string[];
+                /** @description Cap backfill to this many records, then mark the stream complete. */
+                backfill_limit?: number;
+            }[];
         };
         /** @description Full sync checkpoint with separate sections for source, destination, and engine. Connectors only see their own section; the engine manages routing. */
         SyncState: {
@@ -762,23 +779,6 @@ export interface components {
             type: "source_input";
             source_input: components["schemas"]["SourceStripeInput"];
         };
-        PipelineConfig: {
-            source: components["schemas"]["SourceConfig"];
-            destination: components["schemas"]["DestinationConfig"];
-            streams?: {
-                /** @description Stream (table) name to sync. */
-                name: string;
-                /**
-                 * @description How the source reads this stream. Defaults to full_refresh.
-                 * @enum {string}
-                 */
-                sync_mode?: "incremental" | "full_refresh";
-                /** @description If set, only these fields are synced. */
-                fields?: string[];
-                /** @description Cap backfill to this many records, then mark the stream complete. */
-                backfill_limit?: number;
-            }[];
-        };
     };
     responses: never;
     parameters: never;
@@ -818,14 +818,20 @@ export interface operations {
     pipeline_check: {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description JSON-encoded PipelineConfig */
-                "x-pipeline": string;
+                "x-pipeline"?: string;
             };
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": {
+                    pipeline: components["schemas"]["PipelineConfig"];
+                };
+            };
+        };
         responses: {
             /** @description NDJSON stream of check messages */
             200: {
@@ -855,14 +861,20 @@ export interface operations {
                 /** @description Run only the source or destination side. Useful for optimistic destination setup (e.g. creating tables early in a UI) or isolating a connector when debugging. */
                 only?: "source" | "destination";
             };
-            header: {
+            header?: {
                 /** @description JSON-encoded PipelineConfig */
-                "x-pipeline": string;
+                "x-pipeline"?: string;
             };
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": {
+                    pipeline: components["schemas"]["PipelineConfig"];
+                };
+            };
+        };
         responses: {
             /** @description NDJSON stream of setup messages */
             200: {
@@ -892,14 +904,20 @@ export interface operations {
                 /** @description Run only the source or destination side. Useful for optimistic destination setup (e.g. creating tables early in a UI) or isolating a connector when debugging. */
                 only?: "source" | "destination";
             };
-            header: {
+            header?: {
                 /** @description JSON-encoded PipelineConfig */
-                "x-pipeline": string;
+                "x-pipeline"?: string;
             };
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": {
+                    pipeline: components["schemas"]["PipelineConfig"];
+                };
+            };
+        };
         responses: {
             /** @description NDJSON stream of teardown messages */
             200: {
@@ -926,14 +944,24 @@ export interface operations {
     source_discover: {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description JSON-encoded source config ({ type, ...config }) */
-                "x-source": string;
+                "x-source"?: string;
             };
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": {
+                    source: {
+                        type: string;
+                    } & {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+        };
         responses: {
             /** @description NDJSON stream of discover messages */
             200: {
@@ -965,9 +993,9 @@ export interface operations {
                 /** @description Stop streaming after N seconds. */
                 time_limit?: number;
             };
-            header: {
+            header?: {
                 /** @description JSON-encoded PipelineConfig */
-                "x-pipeline": string;
+                "x-pipeline"?: string;
                 /** @description JSON-encoded SyncState ({ source, destination, engine }) or legacy SourceState/flat formats */
                 "x-state"?: string;
             };
@@ -977,6 +1005,11 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/x-ndjson": components["schemas"]["SourceInputMessage"];
+                "application/json": {
+                    pipeline: components["schemas"]["PipelineConfig"];
+                    state?: components["schemas"]["SyncState"];
+                    body?: unknown[];
+                };
             };
         };
         responses: {
@@ -1005,9 +1038,9 @@ export interface operations {
     pipeline_write: {
         parameters: {
             query?: never;
-            header: {
+            header?: {
                 /** @description JSON-encoded PipelineConfig */
-                "x-pipeline": string;
+                "x-pipeline"?: string;
             };
             path?: never;
             cookie?: never;
@@ -1015,6 +1048,10 @@ export interface operations {
         requestBody: {
             content: {
                 "application/x-ndjson": components["schemas"]["Message"];
+                "application/json": {
+                    pipeline: components["schemas"]["PipelineConfig"];
+                    body: unknown[];
+                };
             };
         };
         responses: {
@@ -1048,9 +1085,9 @@ export interface operations {
                 /** @description Stop streaming after N seconds. */
                 time_limit?: number;
             };
-            header: {
+            header?: {
                 /** @description JSON-encoded PipelineConfig */
-                "x-pipeline": string;
+                "x-pipeline"?: string;
                 /** @description JSON-encoded SyncState ({ source, destination, engine }) or legacy SourceState/flat formats */
                 "x-state"?: string;
             };
@@ -1060,6 +1097,11 @@ export interface operations {
         requestBody?: {
             content: {
                 "application/x-ndjson": components["schemas"]["SourceInputMessage"];
+                "application/json": {
+                    pipeline: components["schemas"]["PipelineConfig"];
+                    state?: components["schemas"]["SyncState"];
+                    body?: unknown[];
+                };
             };
         };
         responses: {

--- a/apps/engine/src/__generated__/openapi.json
+++ b/apps/engine/src/__generated__/openapi.json
@@ -62,7 +62,7 @@
           {
             "in": "header",
             "name": "x-pipeline",
-            "required": true,
+            "required": false,
             "description": "JSON-encoded PipelineConfig",
             "content": {
               "application/json": {
@@ -73,6 +73,24 @@
             }
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pipeline": {
+                    "$ref": "#/components/schemas/PipelineConfig"
+                  }
+                },
+                "required": [
+                  "pipeline"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "NDJSON stream of check messages",
@@ -130,7 +148,7 @@
           {
             "in": "header",
             "name": "x-pipeline",
-            "required": true,
+            "required": false,
             "description": "JSON-encoded PipelineConfig",
             "content": {
               "application/json": {
@@ -141,6 +159,24 @@
             }
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pipeline": {
+                    "$ref": "#/components/schemas/PipelineConfig"
+                  }
+                },
+                "required": [
+                  "pipeline"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "NDJSON stream of setup messages",
@@ -198,7 +234,7 @@
           {
             "in": "header",
             "name": "x-pipeline",
-            "required": true,
+            "required": false,
             "description": "JSON-encoded PipelineConfig",
             "content": {
               "application/json": {
@@ -209,6 +245,24 @@
             }
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pipeline": {
+                    "$ref": "#/components/schemas/PipelineConfig"
+                  }
+                },
+                "required": [
+                  "pipeline"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "NDJSON stream of teardown messages",
@@ -252,7 +306,7 @@
           {
             "in": "header",
             "name": "x-source",
-            "required": true,
+            "required": false,
             "description": "JSON-encoded source config ({ type, ...config })",
             "content": {
               "application/json": {
@@ -272,6 +326,33 @@
             }
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": {}
+                  }
+                },
+                "required": [
+                  "source"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "NDJSON stream of discover messages",
@@ -310,7 +391,7 @@
           "Stateless Sync API"
         ],
         "summary": "Read records from source",
-        "description": "Streams NDJSON messages (records, state, catalog). Optional NDJSON body provides live events as input.",
+        "description": "Streams NDJSON messages (records, state, catalog). Optional NDJSON body provides live events as input. Alternatively, send Content-Type: application/json with {pipeline, state?, body?} to pass config in the body.",
         "parameters": [
           {
             "in": "query",
@@ -338,7 +419,7 @@
           {
             "in": "header",
             "name": "x-pipeline",
-            "required": true,
+            "required": false,
             "description": "JSON-encoded PipelineConfig",
             "content": {
               "application/json": {
@@ -368,6 +449,26 @@
             "application/x-ndjson": {
               "schema": {
                 "$ref": "#/components/schemas/SourceInputMessage"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pipeline": {
+                    "$ref": "#/components/schemas/PipelineConfig"
+                  },
+                  "state": {
+                    "$ref": "#/components/schemas/SyncState"
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {}
+                  }
+                },
+                "required": [
+                  "pipeline"
+                ]
               }
             }
           }
@@ -410,12 +511,12 @@
           "Stateless Sync API"
         ],
         "summary": "Write records to destination",
-        "description": "Reads NDJSON messages from the request body and writes them to the destination. Pipe /read output as input.",
+        "description": "Reads NDJSON messages from the request body and writes them to the destination. Pipe /read output as input. Alternatively, send Content-Type: application/json with {pipeline, body: [...messages]}.",
         "parameters": [
           {
             "in": "header",
             "name": "x-pipeline",
-            "required": true,
+            "required": false,
             "description": "JSON-encoded PipelineConfig",
             "content": {
               "application/json": {
@@ -432,6 +533,24 @@
             "application/x-ndjson": {
               "schema": {
                 "$ref": "#/components/schemas/Message"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pipeline": {
+                    "$ref": "#/components/schemas/PipelineConfig"
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {}
+                  }
+                },
+                "required": [
+                  "pipeline",
+                  "body"
+                ]
               }
             }
           }
@@ -474,7 +593,7 @@
           "Stateless Sync API"
         ],
         "summary": "Run sync pipeline (read → write)",
-        "description": "Without a request body, reads from the source connector and writes to the destination (backfill mode). With an NDJSON request body, uses the provided messages as input instead of reading from the source (push mode — e.g. piped webhook events).",
+        "description": "Without a request body, reads from the source connector and writes to the destination (backfill mode). With an NDJSON request body, uses the provided messages as input instead of reading from the source (push mode — e.g. piped webhook events). Alternatively, send Content-Type: application/json with {pipeline, state?, body?} to pass config in the body.",
         "parameters": [
           {
             "in": "query",
@@ -502,7 +621,7 @@
           {
             "in": "header",
             "name": "x-pipeline",
-            "required": true,
+            "required": false,
             "description": "JSON-encoded PipelineConfig",
             "content": {
               "application/json": {
@@ -532,6 +651,26 @@
             "application/x-ndjson": {
               "schema": {
                 "$ref": "#/components/schemas/SourceInputMessage"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pipeline": {
+                    "$ref": "#/components/schemas/PipelineConfig"
+                  },
+                  "state": {
+                    "$ref": "#/components/schemas/SyncState"
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {}
+                  }
+                },
+                "required": [
+                  "pipeline"
+                ]
               }
             }
           }
@@ -764,6 +903,303 @@
   },
   "components": {
     "schemas": {
+      "SourceConfig": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "stripe"
+              },
+              "stripe": {
+                "$ref": "#/components/schemas/SourceStripeConfig"
+              }
+            },
+            "required": [
+              "type",
+              "stripe"
+            ]
+          }
+        ],
+        "type": "object",
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
+      "SourceStripeConfig": {
+        "type": "object",
+        "properties": {
+          "api_key": {
+            "type": "string",
+            "description": "Stripe API key (sk_test_... or sk_live_...)"
+          },
+          "account_id": {
+            "type": "string",
+            "description": "Stripe account ID (resolved from API if omitted)"
+          },
+          "livemode": {
+            "type": "boolean",
+            "description": "Whether this is a live mode sync"
+          },
+          "api_version": {
+            "type": "string",
+            "enum": [
+              "2026-03-25.dahlia",
+              "2026-02-25.clover",
+              "2026-01-28.clover",
+              "2025-12-15.clover",
+              "2025-11-17.clover",
+              "2025-10-29.clover",
+              "2025-09-30.clover",
+              "2025-08-27.basil",
+              "2025-07-30.basil",
+              "2025-06-30.basil",
+              "2025-05-28.basil",
+              "2025-04-30.basil",
+              "2025-03-31.basil",
+              "2025-02-24.acacia",
+              "2025-01-27.acacia",
+              "2024-12-18.acacia",
+              "2024-11-20.acacia",
+              "2024-10-28.acacia",
+              "2024-09-30.acacia",
+              "2024-06-20",
+              "2024-04-10",
+              "2024-04-03",
+              "2023-10-16",
+              "2023-08-16",
+              "2022-11-15",
+              "2022-08-01",
+              "2020-08-27",
+              "2020-03-02",
+              "2019-12-03",
+              "2019-11-05",
+              "2019-10-17",
+              "2019-10-08",
+              "2019-09-09",
+              "2019-08-14",
+              "2019-05-16",
+              "2019-03-14",
+              "2019-02-19",
+              "2019-02-11",
+              "2018-11-08",
+              "2018-10-31",
+              "2018-09-24",
+              "2018-09-06",
+              "2018-08-23",
+              "2018-07-27",
+              "2018-05-21",
+              "2018-02-28",
+              "2018-02-06",
+              "2018-02-05",
+              "2018-01-23",
+              "2017-12-14",
+              "2017-08-15"
+            ]
+          },
+          "base_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)"
+          },
+          "webhook_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL for managed webhook endpoint registration"
+          },
+          "webhook_secret": {
+            "type": "string",
+            "description": "Webhook signing secret (whsec_...) for signature verification"
+          },
+          "websocket": {
+            "type": "boolean",
+            "description": "Enable WebSocket streaming for live events"
+          },
+          "poll_events": {
+            "type": "boolean",
+            "description": "Enable events API polling for incremental sync after backfill"
+          },
+          "webhook_port": {
+            "type": "integer",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991,
+            "description": "Port for built-in webhook HTTP listener (e.g. 4242)"
+          },
+          "revalidate_objects": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Object types to re-fetch from Stripe API on webhook (e.g. [\"subscription\"])"
+          },
+          "backfill_limit": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "description": "Max objects to backfill per stream (useful for testing)"
+          },
+          "rate_limit": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "description": "Max Stripe API requests per second (default: 25)"
+          }
+        },
+        "required": [
+          "api_key"
+        ],
+        "additionalProperties": false
+      },
+      "DestinationConfig": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "postgres"
+              },
+              "postgres": {
+                "$ref": "#/components/schemas/DestinationPostgresConfig"
+              }
+            },
+            "required": [
+              "type",
+              "postgres"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "google_sheets"
+              },
+              "google_sheets": {
+                "$ref": "#/components/schemas/DestinationGoogleSheetsConfig"
+              }
+            },
+            "required": [
+              "type",
+              "google_sheets"
+            ]
+          }
+        ],
+        "type": "object",
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
+      "DestinationPostgresConfig": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Postgres connection string (alias for connection_string)"
+          },
+          "connection_string": {
+            "type": "string",
+            "description": "Postgres connection string"
+          },
+          "host": {
+            "type": "string",
+            "description": "Postgres host (required for AWS IAM)"
+          },
+          "port": {
+            "default": 5432,
+            "type": "number",
+            "description": "Postgres port"
+          },
+          "database": {
+            "type": "string",
+            "description": "Database name (required for AWS IAM)"
+          },
+          "user": {
+            "type": "string",
+            "description": "Database user (required for AWS IAM)"
+          },
+          "schema": {
+            "type": "string",
+            "description": "Target schema name (e.g. \"stripe_sync\")"
+          },
+          "batch_size": {
+            "default": 100,
+            "type": "number",
+            "description": "Records to buffer before flushing"
+          },
+          "aws": {
+            "type": "object",
+            "properties": {
+              "region": {
+                "type": "string",
+                "description": "AWS region for RDS instance"
+              },
+              "role_arn": {
+                "type": "string",
+                "description": "IAM role ARN to assume (cross-account)"
+              },
+              "external_id": {
+                "type": "string",
+                "description": "External ID for STS AssumeRole"
+              }
+            },
+            "required": [
+              "region"
+            ],
+            "additionalProperties": false,
+            "description": "AWS RDS IAM authentication config"
+          },
+          "ssl_ca_pem": {
+            "type": "string",
+            "description": "PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA)"
+          }
+        },
+        "required": [
+          "schema"
+        ],
+        "additionalProperties": false
+      },
+      "DestinationGoogleSheetsConfig": {
+        "type": "object",
+        "properties": {
+          "client_id": {
+            "type": "string",
+            "description": "Google OAuth2 client ID (env: GOOGLE_CLIENT_ID)"
+          },
+          "client_secret": {
+            "type": "string",
+            "description": "Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET)"
+          },
+          "access_token": {
+            "type": "string",
+            "description": "OAuth2 access token"
+          },
+          "refresh_token": {
+            "type": "string",
+            "description": "OAuth2 refresh token"
+          },
+          "spreadsheet_id": {
+            "type": "string",
+            "description": "Target spreadsheet ID (created if omitted)"
+          },
+          "spreadsheet_title": {
+            "default": "Stripe Sync",
+            "type": "string",
+            "description": "Title when creating a new spreadsheet"
+          },
+          "batch_size": {
+            "default": 50,
+            "type": "number",
+            "description": "Rows per Sheets API append call"
+          }
+        },
+        "required": [
+          "access_token",
+          "refresh_token"
+        ],
+        "additionalProperties": false
+      },
       "RecordMessage": {
         "type": "object",
         "properties": {
@@ -1699,302 +2135,56 @@
         ],
         "additionalProperties": false
       },
-      "SourceConfig": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "stripe"
-              },
-              "stripe": {
-                "$ref": "#/components/schemas/SourceStripeConfig"
-              }
-            },
-            "required": [
-              "type",
-              "stripe"
-            ]
-          }
-        ],
-        "type": "object",
-        "discriminator": {
-          "propertyName": "type"
-        }
-      },
-      "SourceStripeConfig": {
+      "PipelineConfig": {
         "type": "object",
         "properties": {
-          "api_key": {
-            "type": "string",
-            "description": "Stripe API key (sk_test_... or sk_live_...)"
+          "source": {
+            "$ref": "#/components/schemas/SourceConfig"
           },
-          "account_id": {
-            "type": "string",
-            "description": "Stripe account ID (resolved from API if omitted)"
+          "destination": {
+            "$ref": "#/components/schemas/DestinationConfig"
           },
-          "livemode": {
-            "type": "boolean",
-            "description": "Whether this is a live mode sync"
-          },
-          "api_version": {
-            "type": "string",
-            "enum": [
-              "2026-03-25.dahlia",
-              "2026-02-25.clover",
-              "2026-01-28.clover",
-              "2025-12-15.clover",
-              "2025-11-17.clover",
-              "2025-10-29.clover",
-              "2025-09-30.clover",
-              "2025-08-27.basil",
-              "2025-07-30.basil",
-              "2025-06-30.basil",
-              "2025-05-28.basil",
-              "2025-04-30.basil",
-              "2025-03-31.basil",
-              "2025-02-24.acacia",
-              "2025-01-27.acacia",
-              "2024-12-18.acacia",
-              "2024-11-20.acacia",
-              "2024-10-28.acacia",
-              "2024-09-30.acacia",
-              "2024-06-20",
-              "2024-04-10",
-              "2024-04-03",
-              "2023-10-16",
-              "2023-08-16",
-              "2022-11-15",
-              "2022-08-01",
-              "2020-08-27",
-              "2020-03-02",
-              "2019-12-03",
-              "2019-11-05",
-              "2019-10-17",
-              "2019-10-08",
-              "2019-09-09",
-              "2019-08-14",
-              "2019-05-16",
-              "2019-03-14",
-              "2019-02-19",
-              "2019-02-11",
-              "2018-11-08",
-              "2018-10-31",
-              "2018-09-24",
-              "2018-09-06",
-              "2018-08-23",
-              "2018-07-27",
-              "2018-05-21",
-              "2018-02-28",
-              "2018-02-06",
-              "2018-02-05",
-              "2018-01-23",
-              "2017-12-14",
-              "2017-08-15"
-            ]
-          },
-          "base_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "Override the Stripe API base URL (e.g. http://localhost:12111 for stripe-mock)"
-          },
-          "webhook_url": {
-            "type": "string",
-            "format": "uri",
-            "description": "URL for managed webhook endpoint registration"
-          },
-          "webhook_secret": {
-            "type": "string",
-            "description": "Webhook signing secret (whsec_...) for signature verification"
-          },
-          "websocket": {
-            "type": "boolean",
-            "description": "Enable WebSocket streaming for live events"
-          },
-          "poll_events": {
-            "type": "boolean",
-            "description": "Enable events API polling for incremental sync after backfill"
-          },
-          "webhook_port": {
-            "type": "integer",
-            "minimum": -9007199254740991,
-            "maximum": 9007199254740991,
-            "description": "Port for built-in webhook HTTP listener (e.g. 4242)"
-          },
-          "revalidate_objects": {
+          "streams": {
             "type": "array",
             "items": {
-              "type": "string"
-            },
-            "description": "Object types to re-fetch from Stripe API on webhook (e.g. [\"subscription\"])"
-          },
-          "backfill_limit": {
-            "type": "integer",
-            "exclusiveMinimum": 0,
-            "maximum": 9007199254740991,
-            "description": "Max objects to backfill per stream (useful for testing)"
-          },
-          "rate_limit": {
-            "type": "integer",
-            "exclusiveMinimum": 0,
-            "maximum": 9007199254740991,
-            "description": "Max Stripe API requests per second (default: 25)"
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Stream (table) name to sync."
+                },
+                "sync_mode": {
+                  "description": "How the source reads this stream. Defaults to full_refresh.",
+                  "type": "string",
+                  "enum": [
+                    "incremental",
+                    "full_refresh"
+                  ]
+                },
+                "fields": {
+                  "description": "If set, only these fields are synced.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "backfill_limit": {
+                  "description": "Cap backfill to this many records, then mark the stream complete.",
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                }
+              },
+              "required": [
+                "name"
+              ]
+            }
           }
         },
         "required": [
-          "api_key"
-        ],
-        "additionalProperties": false
-      },
-      "DestinationConfig": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "postgres"
-              },
-              "postgres": {
-                "$ref": "#/components/schemas/DestinationPostgresConfig"
-              }
-            },
-            "required": [
-              "type",
-              "postgres"
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "const": "google_sheets"
-              },
-              "google_sheets": {
-                "$ref": "#/components/schemas/DestinationGoogleSheetsConfig"
-              }
-            },
-            "required": [
-              "type",
-              "google_sheets"
-            ]
-          }
-        ],
-        "type": "object",
-        "discriminator": {
-          "propertyName": "type"
-        }
-      },
-      "DestinationPostgresConfig": {
-        "type": "object",
-        "properties": {
-          "url": {
-            "type": "string",
-            "description": "Postgres connection string (alias for connection_string)"
-          },
-          "connection_string": {
-            "type": "string",
-            "description": "Postgres connection string"
-          },
-          "host": {
-            "type": "string",
-            "description": "Postgres host (required for AWS IAM)"
-          },
-          "port": {
-            "default": 5432,
-            "type": "number",
-            "description": "Postgres port"
-          },
-          "database": {
-            "type": "string",
-            "description": "Database name (required for AWS IAM)"
-          },
-          "user": {
-            "type": "string",
-            "description": "Database user (required for AWS IAM)"
-          },
-          "schema": {
-            "type": "string",
-            "description": "Target schema name (e.g. \"stripe_sync\")"
-          },
-          "batch_size": {
-            "default": 100,
-            "type": "number",
-            "description": "Records to buffer before flushing"
-          },
-          "aws": {
-            "type": "object",
-            "properties": {
-              "region": {
-                "type": "string",
-                "description": "AWS region for RDS instance"
-              },
-              "role_arn": {
-                "type": "string",
-                "description": "IAM role ARN to assume (cross-account)"
-              },
-              "external_id": {
-                "type": "string",
-                "description": "External ID for STS AssumeRole"
-              }
-            },
-            "required": [
-              "region"
-            ],
-            "additionalProperties": false,
-            "description": "AWS RDS IAM authentication config"
-          },
-          "ssl_ca_pem": {
-            "type": "string",
-            "description": "PEM-encoded CA certificate for SSL verification (required for verify-ca / verify-full with a private CA)"
-          }
-        },
-        "required": [
-          "schema"
-        ],
-        "additionalProperties": false
-      },
-      "DestinationGoogleSheetsConfig": {
-        "type": "object",
-        "properties": {
-          "client_id": {
-            "type": "string",
-            "description": "Google OAuth2 client ID (env: GOOGLE_CLIENT_ID)"
-          },
-          "client_secret": {
-            "type": "string",
-            "description": "Google OAuth2 client secret (env: GOOGLE_CLIENT_SECRET)"
-          },
-          "access_token": {
-            "type": "string",
-            "description": "OAuth2 access token"
-          },
-          "refresh_token": {
-            "type": "string",
-            "description": "OAuth2 refresh token"
-          },
-          "spreadsheet_id": {
-            "type": "string",
-            "description": "Target spreadsheet ID (created if omitted)"
-          },
-          "spreadsheet_title": {
-            "default": "Stripe Sync",
-            "type": "string",
-            "description": "Title when creating a new spreadsheet"
-          },
-          "batch_size": {
-            "default": 50,
-            "type": "number",
-            "description": "Rows per Sheets API append call"
-          }
-        },
-        "required": [
-          "access_token",
-          "refresh_token"
-        ],
-        "additionalProperties": false
+          "source",
+          "destination"
+        ]
       },
       "SyncState": {
         "type": "object",
@@ -2285,59 +2475,6 @@
         "required": [
           "type",
           "source_input"
-        ],
-        "additionalProperties": false
-      },
-      "PipelineConfig": {
-        "type": "object",
-        "properties": {
-          "source": {
-            "$ref": "#/components/schemas/SourceConfig"
-          },
-          "destination": {
-            "$ref": "#/components/schemas/DestinationConfig"
-          },
-          "streams": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Stream (table) name to sync."
-                },
-                "sync_mode": {
-                  "description": "How the source reads this stream. Defaults to full_refresh.",
-                  "type": "string",
-                  "enum": [
-                    "incremental",
-                    "full_refresh"
-                  ]
-                },
-                "fields": {
-                  "description": "If set, only these fields are synced.",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "backfill_limit": {
-                  "description": "Cap backfill to this many records, then mark the stream complete.",
-                  "type": "integer",
-                  "exclusiveMinimum": 0,
-                  "maximum": 9007199254740991
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "additionalProperties": false
-            }
-          }
-        },
-        "required": [
-          "source",
-          "destination"
         ],
         "additionalProperties": false
       }

--- a/apps/engine/src/api/app.test.ts
+++ b/apps/engine/src/api/app.test.ts
@@ -868,6 +868,207 @@ describe('POST /source_discover', () => {
 })
 
 // ---------------------------------------------------------------------------
+// JSON body mode (Content-Type: application/json)
+// ---------------------------------------------------------------------------
+
+const syncParamsObj = JSON.parse(syncParams)
+
+describe('JSON body mode', () => {
+  it('POST /pipeline_check accepts pipeline in JSON body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pipeline: syncParamsObj }),
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('application/x-ndjson')
+    const events = await readNdjson<Record<string, unknown>>(res)
+    const statuses = events.filter((e) => e.type === 'connection_status')
+    expect(statuses).toHaveLength(2)
+  })
+
+  it('POST /pipeline_setup accepts pipeline in JSON body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_setup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pipeline: syncParamsObj }),
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('application/x-ndjson')
+  })
+
+  it('POST /pipeline_teardown accepts pipeline in JSON body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_teardown', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pipeline: syncParamsObj }),
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('application/x-ndjson')
+  })
+
+  it('POST /source_discover accepts source in JSON body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/source_discover', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        source: { type: 'test', test: { streams: { customers: {} } } },
+      }),
+    })
+    expect(res.status).toBe(200)
+    const events = await readNdjson<Record<string, unknown>>(res)
+    expect(events.some((e) => e.type === 'catalog')).toBe(true)
+  })
+
+  it('POST /pipeline_read accepts pipeline + state + body array in JSON body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_read', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        pipeline: syncParamsObj,
+        body: [
+          {
+            type: 'record',
+            record: {
+              stream: 'customers',
+              data: { id: 'cus_1', name: 'Alice' },
+              emitted_at: new Date().toISOString(),
+            },
+          },
+          {
+            type: 'source_state',
+            source_state: { stream: 'customers', data: { status: 'complete' } },
+          },
+        ],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const events = await readNdjson<Message>(res)
+    expect(events).toHaveLength(3)
+    expect(events[0]!.type).toBe('record')
+    expect(events[1]!.type).toBe('source_state')
+    expect(events[2]).toMatchObject({ type: 'eof', eof: { reason: 'complete' } })
+  })
+
+  it('POST /pipeline_read accepts pipeline in JSON body without input', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_read', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pipeline: syncParamsObj }),
+    })
+    expect(res.status).toBe(200)
+    const events = await readNdjson<Message>(res)
+    expect(events.some((e) => e.type === 'eof')).toBe(true)
+  })
+
+  it('POST /pipeline_write accepts pipeline + body array in JSON body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_write', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        pipeline: syncParamsObj,
+        body: [
+          {
+            type: 'record',
+            record: {
+              stream: 'customers',
+              data: { id: 'cus_1' },
+              emitted_at: '2024-01-01T00:00:00.000Z',
+            },
+          },
+          {
+            type: 'source_state',
+            source_state: { stream: 'customers', data: { cursor: 'cus_1' } },
+          },
+        ],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const events = await readNdjson<Record<string, unknown>>(res)
+    expect(events.some((e) => e.type === 'source_state')).toBe(true)
+  })
+
+  it('POST /pipeline_sync accepts pipeline + state + body array in JSON body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        pipeline: syncParamsObj,
+        body: [
+          {
+            type: 'record',
+            record: {
+              stream: 'customers',
+              data: { id: 'cus_1', name: 'Alice' },
+              emitted_at: new Date().toISOString(),
+            },
+          },
+          {
+            type: 'source_state',
+            source_state: { stream: 'customers', data: { status: 'complete' } },
+          },
+        ],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const events = await readNdjson<Record<string, unknown>>(res)
+    expect(events.some((e) => e.type === 'source_state')).toBe(true)
+    expect(events.some((e) => e.type === 'eof')).toBe(true)
+  })
+
+  it('POST /pipeline_sync without body array runs backfill mode', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pipeline: syncParamsObj }),
+    })
+    expect(res.status).toBe(200)
+    const events = await readNdjson<Record<string, unknown>>(res)
+    expect(events.some((e) => e.type === 'eof')).toBe(true)
+  })
+
+  it('returns 400 when JSON body is missing pipeline', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('NDJSON content-type uses header mode even with JSON-like body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_check', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-ndjson',
+        'X-Pipeline': syncParams,
+      },
+    })
+    expect(res.status).toBe(200)
+  })
+
+  it('no content-type defaults to header mode', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_check', {
+      method: 'POST',
+      headers: { 'X-Pipeline': syncParams },
+    })
+    expect(res.status).toBe(200)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // POST /internal/query
 // ---------------------------------------------------------------------------
 

--- a/apps/engine/src/api/app.test.ts
+++ b/apps/engine/src/api/app.test.ts
@@ -1066,6 +1066,29 @@ describe('JSON body mode', () => {
     })
     expect(res.status).toBe(200)
   })
+
+  it('mixed-case Content-Type is accepted as JSON body mode', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'Application/JSON; charset=utf-8' },
+      body: JSON.stringify({ pipeline: syncParamsObj }),
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('application/x-ndjson')
+  })
+
+  it('application/json-seq falls back to header mode, not JSON body', async () => {
+    const app = await createApp(resolver)
+    const res = await app.request('/pipeline_check', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json-seq',
+        'X-Pipeline': syncParams,
+      },
+    })
+    expect(res.status).toBe(200)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -104,7 +104,10 @@ async function* logApiStream<T>(
         logger.info({ ...context, eof: msg.eof }, formatEof(msg.eof as EofPayload))
       yield item
     }
-    logger.debug({ ...context, itemCount, durationMs: Date.now() - startedAt }, `${label} completed`)
+    logger.debug(
+      { ...context, itemCount, durationMs: Date.now() - startedAt },
+      `${label} completed`
+    )
   } catch (error) {
     logger.error(
       { ...context, itemCount, durationMs: Date.now() - startedAt, err: error },
@@ -348,6 +351,10 @@ export async function createApp(resolver: ConnectorResolver) {
     return false
   }
 
+  function isJsonBody(c: { req: { header: (name: string) => string | undefined } }): boolean {
+    return c.req.header('content-type')?.includes('application/json') ?? false
+  }
+
   // ── Typed header schemas (transform + pipe for runtime validation,
   //    .meta({ param: { content } }) for OAS content encoding) ────
 
@@ -397,11 +404,35 @@ export async function createApp(resolver: ConnectorResolver) {
       param: { content: { 'application/json': {} } },
     })
 
-  const pipelineHeaders = z.object({ 'x-pipeline': xPipelineHeader })
-  const sourceHeaders = z.object({ 'x-source': xSourceHeader })
+  const pipelineHeaders = z.object({ 'x-pipeline': xPipelineHeader.optional() })
+  const sourceHeaders = z.object({ 'x-source': xSourceHeader.optional() })
   const allSyncHeaders = z.object({
-    'x-pipeline': xPipelineHeader,
+    'x-pipeline': xPipelineHeader.optional(),
     'x-state': xStateHeader,
+  })
+
+  // ── JSON body schemas (native objects, no string-parse transform) ────
+  // Registered in route definitions for both OpenAPI docs and runtime validation.
+  // OpenAPIHono's content-type-aware validator skips JSON body parsing for
+  // non-JSON requests, so these strict schemas coexist safely with NDJSON routes.
+
+  const pipelineBody = z.object({
+    pipeline: TypedPipelineConfig,
+  })
+
+  const syncBody = z.object({
+    pipeline: TypedPipelineConfig,
+    state: SyncState.optional(),
+    body: z.array(z.unknown()).optional(),
+  })
+
+  const writeBody = z.object({
+    pipeline: TypedPipelineConfig,
+    body: z.array(z.unknown()),
+  })
+
+  const sourceBody = z.object({
+    source: z.object({ type: z.string() }).catchall(z.unknown()),
   })
 
   function parseLegacyStateHeader(raw: string | undefined) {
@@ -480,6 +511,10 @@ export async function createApp(resolver: ConnectorResolver) {
     description:
       'Validates the source/destination config and tests connectivity. Streams NDJSON messages (connection_status, log, trace) tagged with _emitted_by.',
     requestParams: { header: pipelineHeaders },
+    requestBody: {
+      required: false,
+      content: { 'application/json': { schema: pipelineBody } },
+    },
     responses: {
       200: {
         description: 'NDJSON stream of check messages',
@@ -488,8 +523,11 @@ export async function createApp(resolver: ConnectorResolver) {
       400: errorResponse,
     },
   })
-  app.openapi(pipelineCheckRoute, (c) => {
-    const pipeline = c.req.valid('header')['x-pipeline']
+  app.openapi(pipelineCheckRoute, async (c) => {
+    const pipeline = isJsonBody(c)
+      ? c.req.valid('json').pipeline
+      : c.req.valid('header')['x-pipeline']
+    if (!pipeline) throw new HTTPException(400, { message: 'x-pipeline header is required' })
     const context = { path: '/pipeline_check', ...syncRequestContext(pipeline) }
     return ndjsonResponse(
       logApiStream('Engine API /pipeline_check', engine.pipeline_check(pipeline), context)
@@ -514,6 +552,10 @@ export async function createApp(resolver: ConnectorResolver) {
       'Creates destination tables and applies migrations. Streams NDJSON messages (control, log, trace) tagged with _emitted_by. ' +
       'Pass ?only=destination to run destination setup alone (e.g. optimistic table creation) or ?only=source to isolate the source.',
     requestParams: { header: pipelineHeaders, query: onlyQueryParam },
+    requestBody: {
+      required: false,
+      content: { 'application/json': { schema: pipelineBody } },
+    },
     responses: {
       200: {
         description: 'NDJSON stream of setup messages',
@@ -522,8 +564,11 @@ export async function createApp(resolver: ConnectorResolver) {
       400: errorResponse,
     },
   })
-  app.openapi(pipelineSetupRoute, (c) => {
-    const pipeline = c.req.valid('header')['x-pipeline']
+  app.openapi(pipelineSetupRoute, async (c) => {
+    const pipeline = isJsonBody(c)
+      ? c.req.valid('json').pipeline
+      : c.req.valid('header')['x-pipeline']
+    if (!pipeline) throw new HTTPException(400, { message: 'x-pipeline header is required' })
     const only = c.req.valid('query').only
     const context = { path: '/pipeline_setup', ...syncRequestContext(pipeline) }
     return ndjsonResponse(
@@ -545,6 +590,10 @@ export async function createApp(resolver: ConnectorResolver) {
       'Drops destination tables. Streams NDJSON messages (log, trace) tagged with _emitted_by. ' +
       'Pass ?only=destination or ?only=source to run a single side.',
     requestParams: { header: pipelineHeaders, query: onlyQueryParam },
+    requestBody: {
+      required: false,
+      content: { 'application/json': { schema: pipelineBody } },
+    },
     responses: {
       200: {
         description: 'NDJSON stream of teardown messages',
@@ -553,8 +602,11 @@ export async function createApp(resolver: ConnectorResolver) {
       400: errorResponse,
     },
   })
-  app.openapi(pipelineTeardownRoute, (c) => {
-    const pipeline = c.req.valid('header')['x-pipeline']
+  app.openapi(pipelineTeardownRoute, async (c) => {
+    const pipeline = isJsonBody(c)
+      ? c.req.valid('json').pipeline
+      : c.req.valid('header')['x-pipeline']
+    if (!pipeline) throw new HTTPException(400, { message: 'x-pipeline header is required' })
     const only = c.req.valid('query').only
     const context = { path: '/pipeline_teardown', ...syncRequestContext(pipeline) }
     return ndjsonResponse(
@@ -574,6 +626,10 @@ export async function createApp(resolver: ConnectorResolver) {
     summary: 'Discover available streams',
     description: 'Streams NDJSON messages (catalog, logs, traces) for the configured source.',
     requestParams: { header: sourceHeaders },
+    requestBody: {
+      required: false,
+      content: { 'application/json': { schema: sourceBody } },
+    },
     responses: {
       200: {
         description: 'NDJSON stream of discover messages',
@@ -582,8 +638,11 @@ export async function createApp(resolver: ConnectorResolver) {
       400: errorResponse,
     },
   })
-  app.openapi(sourceDiscoverRoute, (c) => {
-    const source = c.req.valid('header')['x-source']
+  app.openapi(sourceDiscoverRoute, async (c) => {
+    const source = isJsonBody(c)
+      ? c.req.valid('json').source
+      : c.req.valid('header')['x-source']
+    if (!source) throw new HTTPException(400, { message: 'x-source header is required' })
     const context = { path: '/source_discover', sourceName: source.type }
     return ndjsonResponse(
       logApiStream('Engine API /source_discover', engine.source_discover(source), context)
@@ -597,7 +656,8 @@ export async function createApp(resolver: ConnectorResolver) {
     tags: ['Stateless Sync API'],
     summary: 'Read records from source',
     description:
-      'Streams NDJSON messages (records, state, catalog). Optional NDJSON body provides live events as input.',
+      'Streams NDJSON messages (records, state, catalog). Optional NDJSON body provides live events as input. ' +
+      'Alternatively, send Content-Type: application/json with {pipeline, state?, body?} to pass config in the body.',
     requestParams: { header: allSyncHeaders, query: syncQueryParams },
     requestBody: {
       required: false,
@@ -605,6 +665,7 @@ export async function createApp(resolver: ConnectorResolver) {
         'application/x-ndjson': {
           schema: SourceInputMessage ? ndjsonRef.SourceInputMessage : ndjsonRef.Message,
         },
+        'application/json': { schema: syncBody },
       },
     },
     responses: {
@@ -616,11 +677,59 @@ export async function createApp(resolver: ConnectorResolver) {
     },
   })
   app.openapi(pipelineReadRoute, async (c) => {
-    const pipeline = c.req.valid('header')['x-pipeline']
-    const state =
-      c.req.valid('header')['x-state'] ?? parseLegacyStateHeader(c.req.header('x-source-state'))
     const { state_limit, time_limit } = c.req.valid('query')
-    const inputPresent = hasBody(c)
+
+    let pipeline: z.infer<typeof TypedPipelineConfig>
+    let state: z.infer<typeof SyncState> | undefined
+    let input: AsyncIterable<unknown> | undefined
+
+    if (isJsonBody(c)) {
+      const json = c.req.valid('json')
+      pipeline = json.pipeline
+      state = json.state
+      const bodyMessages = json.body
+      if (bodyMessages?.length) {
+        if (SourceInputMessage) {
+          input = (async function* () {
+            for (const msg of bodyMessages) {
+              if (dangerouslyVerbose) logger.debug({ msg }, 'pipeline_read input')
+              const parsed = SourceInputMessage.parse(msg)
+              yield (parsed as { source_input: unknown }).source_input
+            }
+          })()
+        } else {
+          input = (async function* () {
+            for (const msg of bodyMessages) {
+              if (dangerouslyVerbose) logger.debug({ msg }, 'pipeline_read input')
+              yield msg
+            }
+          })()
+        }
+      }
+    } else {
+      const header = c.req.valid('header')['x-pipeline']
+      if (!header) throw new HTTPException(400, { message: 'x-pipeline header is required' })
+      pipeline = header
+      state =
+        c.req.valid('header')['x-state'] ?? parseLegacyStateHeader(c.req.header('x-source-state'))
+      if (hasBody(c)) {
+        if (SourceInputMessage) {
+          input = (async function* () {
+            for await (const msg of verboseInput(
+              'pipeline_read',
+              parseNdjsonStream(c.req.raw.body!)
+            )) {
+              const parsed = SourceInputMessage.parse(msg)
+              yield (parsed as { source_input: unknown }).source_input
+            }
+          })()
+        } else {
+          input = verboseInput('pipeline_read', parseNdjsonStream(c.req.raw.body!))
+        }
+      }
+    }
+
+    const inputPresent = !!input
     const context = { path: '/pipeline_read', inputPresent, ...syncRequestContext(pipeline) }
     const startedAt = Date.now()
     logger.info(context, 'Engine API /pipeline_read started')
@@ -632,22 +741,6 @@ export async function createApp(resolver: ConnectorResolver) {
       )
     const ac = createConnectionAbort(c, onDisconnect)
 
-    let input: AsyncIterable<unknown> | undefined
-    if (inputPresent) {
-      if (SourceInputMessage) {
-        input = (async function* () {
-          for await (const msg of verboseInput(
-            'pipeline_read',
-            parseNdjsonStream(c.req.raw.body!)
-          )) {
-            const parsed = SourceInputMessage.parse(msg)
-            yield (parsed as { source_input: unknown }).source_input
-          }
-        })()
-      } else {
-        input = verboseInput('pipeline_read', parseNdjsonStream(c.req.raw.body!))
-      }
-    }
     const output = engine.pipeline_read(
       pipeline,
       { state, state_limit, time_limit },
@@ -666,11 +759,15 @@ export async function createApp(resolver: ConnectorResolver) {
     tags: ['Stateless Sync API'],
     summary: 'Write records to destination',
     description:
-      'Reads NDJSON messages from the request body and writes them to the destination. Pipe /read output as input.',
+      'Reads NDJSON messages from the request body and writes them to the destination. Pipe /read output as input. ' +
+      'Alternatively, send Content-Type: application/json with {pipeline, body: [...messages]}.',
     requestParams: { header: pipelineHeaders },
     requestBody: {
       required: true,
-      content: { 'application/x-ndjson': { schema: ndjsonRef.Message } },
+      content: {
+        'application/x-ndjson': { schema: ndjsonRef.Message },
+        'application/json': { schema: writeBody },
+      },
     },
     responses: {
       200: {
@@ -681,12 +778,34 @@ export async function createApp(resolver: ConnectorResolver) {
     },
   })
   app.openapi(pipelineWriteRoute, async (c) => {
-    const pipeline = c.req.valid('header')['x-pipeline']
-    const context = { path: '/pipeline_write', ...syncRequestContext(pipeline) }
-    if (!hasBody(c)) {
-      logger.error(context, 'Engine API /write missing request body')
-      return c.json({ error: 'Request body required for /write' }, 400)
+    let pipeline: z.infer<typeof TypedPipelineConfig>
+    let messages: AsyncIterable<Message>
+
+    if (isJsonBody(c)) {
+      const json = c.req.valid('json')
+      pipeline = json.pipeline
+      messages = (async function* () {
+        for (const msg of json.body) {
+          if (dangerouslyVerbose) logger.debug({ msg }, 'pipeline_write input')
+          yield msg
+        }
+      })() as AsyncIterable<Message>
+    } else {
+      const header = c.req.valid('header')['x-pipeline']
+      if (!header) throw new HTTPException(400, { message: 'x-pipeline header is required' })
+      pipeline = header
+      if (!hasBody(c)) {
+        const context = { path: '/pipeline_write', ...syncRequestContext(pipeline) }
+        logger.error(context, 'Engine API /write missing request body')
+        return c.json({ error: 'Request body required for /write' }, 400)
+      }
+      messages = verboseInput(
+        'pipeline_write',
+        parseNdjsonStream<Message>(c.req.raw.body!)
+      ) as AsyncIterable<Message>
     }
+
+    const context = { path: '/pipeline_write', ...syncRequestContext(pipeline) }
     const startedAt = Date.now()
     logger.info(context, 'Engine API /write started')
 
@@ -697,10 +816,6 @@ export async function createApp(resolver: ConnectorResolver) {
       )
     const ac = createConnectionAbort(c, onDisconnect)
 
-    const messages = verboseInput(
-      'pipeline_write',
-      parseNdjsonStream<Message>(c.req.raw.body!)
-    ) as AsyncIterable<Message>
     return ndjsonResponse(
       logApiStream(
         'Engine API /write',
@@ -720,7 +835,8 @@ export async function createApp(resolver: ConnectorResolver) {
     summary: 'Run sync pipeline (read → write)',
     description:
       'Without a request body, reads from the source connector and writes to the destination (backfill mode). ' +
-      'With an NDJSON request body, uses the provided messages as input instead of reading from the source (push mode — e.g. piped webhook events).',
+      'With an NDJSON request body, uses the provided messages as input instead of reading from the source (push mode — e.g. piped webhook events). ' +
+      'Alternatively, send Content-Type: application/json with {pipeline, state?, body?} to pass config in the body.',
     requestParams: { header: allSyncHeaders, query: syncQueryParams },
     requestBody: {
       required: false,
@@ -728,6 +844,7 @@ export async function createApp(resolver: ConnectorResolver) {
         'application/x-ndjson': {
           schema: SourceInputMessage ? ndjsonRef.SourceInputMessage : ndjsonRef.Message,
         },
+        'application/json': { schema: syncBody },
       },
     },
     responses: {
@@ -739,10 +856,36 @@ export async function createApp(resolver: ConnectorResolver) {
     },
   })
   app.openapi(pipelineSyncRoute, async (c) => {
-    const pipeline = c.req.valid('header')['x-pipeline']
-    const state =
-      c.req.valid('header')['x-state'] ?? parseLegacyStateHeader(c.req.header('x-source-state'))
     const { state_limit, time_limit } = c.req.valid('query')
+
+    let pipeline: z.infer<typeof TypedPipelineConfig>
+    let state: z.infer<typeof SyncState> | undefined
+    let input: AsyncIterable<unknown> | undefined
+
+    if (isJsonBody(c)) {
+      const json = c.req.valid('json')
+      pipeline = json.pipeline
+      state = json.state
+      const bodyMessages = json.body
+      if (bodyMessages?.length) {
+        input = (async function* () {
+          for (const msg of bodyMessages) {
+            if (dangerouslyVerbose) logger.debug({ msg }, 'pipeline_sync input')
+            yield msg
+          }
+        })()
+      }
+    } else {
+      const header = c.req.valid('header')['x-pipeline']
+      if (!header) throw new HTTPException(400, { message: 'x-pipeline header is required' })
+      pipeline = header
+      state =
+        c.req.valid('header')['x-state'] ?? parseLegacyStateHeader(c.req.header('x-source-state'))
+      if (hasBody(c)) {
+        input = verboseInput('pipeline_sync', parseNdjsonStream(c.req.raw.body!))
+      }
+    }
+
     const context = { path: '/pipeline_sync', ...syncRequestContext(pipeline) }
     const startedAt = Date.now()
 
@@ -753,9 +896,6 @@ export async function createApp(resolver: ConnectorResolver) {
       )
     const ac = createConnectionAbort(c, onDisconnect)
 
-    const input = hasBody(c)
-      ? verboseInput('pipeline_sync', parseNdjsonStream(c.req.raw.body!))
-      : undefined
     const output = engine.pipeline_sync(
       pipeline,
       { state, state_limit, time_limit },

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -445,6 +445,48 @@ export async function createApp(resolver: ConnectorResolver) {
     }
   }
 
+  function requireHeaderValue<T>(value: T | undefined, message: string): T {
+    if (value === undefined) throw new HTTPException(400, { message })
+    return value
+  }
+
+  // Hono's `req.valid()` typing is route-specific and doesn't compose cleanly across
+  // helpers, so we keep the helper signatures loose and return strongly typed values.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function getPipeline(c: any): z.infer<typeof TypedPipelineConfig> {
+    if (isJsonBody(c)) return c.req.valid('json').pipeline
+    return requireHeaderValue(
+      c.req.valid('header')['x-pipeline'],
+      'x-pipeline header is required'
+    )
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function getPipelineAndState(c: any): {
+    pipeline: z.infer<typeof TypedPipelineConfig>
+    state: z.infer<typeof SyncState> | undefined
+  } {
+    if (isJsonBody(c)) {
+      const { pipeline, state } = c.req.valid('json')
+      return { pipeline, state }
+    }
+
+    return {
+      pipeline: requireHeaderValue(
+        c.req.valid('header')['x-pipeline'],
+        'x-pipeline header is required'
+      ),
+      state:
+        c.req.valid('header')['x-state'] ?? parseLegacyStateHeader(c.req.header('x-source-state')),
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function getSource(c: any): z.infer<typeof sourceBody>['source'] {
+    if (isJsonBody(c)) return c.req.valid('json').source
+    return requireHeaderValue(c.req.valid('header')['x-source'], 'x-source header is required')
+  }
+
   const syncQueryParams = z.object({
     state_limit: z.coerce.number().int().positive().optional().meta({
       description: 'Stop streaming after N state messages.',
@@ -524,10 +566,7 @@ export async function createApp(resolver: ConnectorResolver) {
     },
   })
   app.openapi(pipelineCheckRoute, async (c) => {
-    const pipeline = isJsonBody(c)
-      ? c.req.valid('json').pipeline
-      : c.req.valid('header')['x-pipeline']
-    if (!pipeline) throw new HTTPException(400, { message: 'x-pipeline header is required' })
+    const pipeline = getPipeline(c)
     const context = { path: '/pipeline_check', ...syncRequestContext(pipeline) }
     return ndjsonResponse(
       logApiStream('Engine API /pipeline_check', engine.pipeline_check(pipeline), context)
@@ -565,10 +604,7 @@ export async function createApp(resolver: ConnectorResolver) {
     },
   })
   app.openapi(pipelineSetupRoute, async (c) => {
-    const pipeline = isJsonBody(c)
-      ? c.req.valid('json').pipeline
-      : c.req.valid('header')['x-pipeline']
-    if (!pipeline) throw new HTTPException(400, { message: 'x-pipeline header is required' })
+    const pipeline = getPipeline(c)
     const only = c.req.valid('query').only
     const context = { path: '/pipeline_setup', ...syncRequestContext(pipeline) }
     return ndjsonResponse(
@@ -603,10 +639,7 @@ export async function createApp(resolver: ConnectorResolver) {
     },
   })
   app.openapi(pipelineTeardownRoute, async (c) => {
-    const pipeline = isJsonBody(c)
-      ? c.req.valid('json').pipeline
-      : c.req.valid('header')['x-pipeline']
-    if (!pipeline) throw new HTTPException(400, { message: 'x-pipeline header is required' })
+    const pipeline = getPipeline(c)
     const only = c.req.valid('query').only
     const context = { path: '/pipeline_teardown', ...syncRequestContext(pipeline) }
     return ndjsonResponse(
@@ -639,10 +672,7 @@ export async function createApp(resolver: ConnectorResolver) {
     },
   })
   app.openapi(sourceDiscoverRoute, async (c) => {
-    const source = isJsonBody(c)
-      ? c.req.valid('json').source
-      : c.req.valid('header')['x-source']
-    if (!source) throw new HTTPException(400, { message: 'x-source header is required' })
+    const source = getSource(c)
     const context = { path: '/source_discover', sourceName: source.type }
     return ndjsonResponse(
       logApiStream('Engine API /source_discover', engine.source_discover(source), context)
@@ -679,14 +709,11 @@ export async function createApp(resolver: ConnectorResolver) {
   app.openapi(pipelineReadRoute, async (c) => {
     const { state_limit, time_limit } = c.req.valid('query')
 
-    let pipeline: z.infer<typeof TypedPipelineConfig>
-    let state: z.infer<typeof SyncState> | undefined
+    const { pipeline, state } = getPipelineAndState(c)
     let input: AsyncIterable<unknown> | undefined
 
     if (isJsonBody(c)) {
       const json = c.req.valid('json')
-      pipeline = json.pipeline
-      state = json.state
       const bodyMessages = json.body
       if (bodyMessages?.length) {
         if (SourceInputMessage) {
@@ -706,26 +733,19 @@ export async function createApp(resolver: ConnectorResolver) {
           })()
         }
       }
-    } else {
-      const header = c.req.valid('header')['x-pipeline']
-      if (!header) throw new HTTPException(400, { message: 'x-pipeline header is required' })
-      pipeline = header
-      state =
-        c.req.valid('header')['x-state'] ?? parseLegacyStateHeader(c.req.header('x-source-state'))
-      if (hasBody(c)) {
-        if (SourceInputMessage) {
-          input = (async function* () {
-            for await (const msg of verboseInput(
-              'pipeline_read',
-              parseNdjsonStream(c.req.raw.body!)
-            )) {
-              const parsed = SourceInputMessage.parse(msg)
-              yield (parsed as { source_input: unknown }).source_input
-            }
-          })()
-        } else {
-          input = verboseInput('pipeline_read', parseNdjsonStream(c.req.raw.body!))
-        }
+    } else if (hasBody(c)) {
+      if (SourceInputMessage) {
+        input = (async function* () {
+          for await (const msg of verboseInput(
+            'pipeline_read',
+            parseNdjsonStream(c.req.raw.body!)
+          )) {
+            const parsed = SourceInputMessage.parse(msg)
+            yield (parsed as { source_input: unknown }).source_input
+          }
+        })()
+      } else {
+        input = verboseInput('pipeline_read', parseNdjsonStream(c.req.raw.body!))
       }
     }
 
@@ -778,12 +798,11 @@ export async function createApp(resolver: ConnectorResolver) {
     },
   })
   app.openapi(pipelineWriteRoute, async (c) => {
-    let pipeline: z.infer<typeof TypedPipelineConfig>
+    const pipeline = getPipeline(c)
     let messages: AsyncIterable<Message>
 
     if (isJsonBody(c)) {
       const json = c.req.valid('json')
-      pipeline = json.pipeline
       messages = (async function* () {
         for (const msg of json.body) {
           if (dangerouslyVerbose) logger.debug({ msg }, 'pipeline_write input')
@@ -791,18 +810,16 @@ export async function createApp(resolver: ConnectorResolver) {
         }
       })() as AsyncIterable<Message>
     } else {
-      const header = c.req.valid('header')['x-pipeline']
-      if (!header) throw new HTTPException(400, { message: 'x-pipeline header is required' })
-      pipeline = header
-      if (!hasBody(c)) {
+      if (hasBody(c)) {
+        messages = verboseInput(
+          'pipeline_write',
+          parseNdjsonStream<Message>(c.req.raw.body!)
+        ) as AsyncIterable<Message>
+      } else {
         const context = { path: '/pipeline_write', ...syncRequestContext(pipeline) }
         logger.error(context, 'Engine API /write missing request body')
         return c.json({ error: 'Request body required for /write' }, 400)
       }
-      messages = verboseInput(
-        'pipeline_write',
-        parseNdjsonStream<Message>(c.req.raw.body!)
-      ) as AsyncIterable<Message>
     }
 
     const context = { path: '/pipeline_write', ...syncRequestContext(pipeline) }
@@ -858,14 +875,11 @@ export async function createApp(resolver: ConnectorResolver) {
   app.openapi(pipelineSyncRoute, async (c) => {
     const { state_limit, time_limit } = c.req.valid('query')
 
-    let pipeline: z.infer<typeof TypedPipelineConfig>
-    let state: z.infer<typeof SyncState> | undefined
+    const { pipeline, state } = getPipelineAndState(c)
     let input: AsyncIterable<unknown> | undefined
 
     if (isJsonBody(c)) {
       const json = c.req.valid('json')
-      pipeline = json.pipeline
-      state = json.state
       const bodyMessages = json.body
       if (bodyMessages?.length) {
         input = (async function* () {
@@ -875,15 +889,8 @@ export async function createApp(resolver: ConnectorResolver) {
           }
         })()
       }
-    } else {
-      const header = c.req.valid('header')['x-pipeline']
-      if (!header) throw new HTTPException(400, { message: 'x-pipeline header is required' })
-      pipeline = header
-      state =
-        c.req.valid('header')['x-state'] ?? parseLegacyStateHeader(c.req.header('x-source-state'))
-      if (hasBody(c)) {
-        input = verboseInput('pipeline_sync', parseNdjsonStream(c.req.raw.body!))
-      }
+    } else if (hasBody(c)) {
+      input = verboseInput('pipeline_sync', parseNdjsonStream(c.req.raw.body!))
     }
 
     const context = { path: '/pipeline_sync', ...syncRequestContext(pipeline) }

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -1,5 +1,9 @@
 import os from 'node:os'
-import { OpenAPIHono, createRoute } from '@stripe/sync-hono-zod-openapi'
+import {
+  OpenAPIHono,
+  createRoute,
+  isApplicationJsonContentType,
+} from '@stripe/sync-hono-zod-openapi'
 import { z } from 'zod'
 import { apiReference } from '@scalar/hono-api-reference'
 import { HTTPException } from 'hono/http-exception'
@@ -352,7 +356,7 @@ export async function createApp(resolver: ConnectorResolver) {
   }
 
   function isJsonBody(c: { req: { header: (name: string) => string | undefined } }): boolean {
-    return c.req.header('content-type')?.includes('application/json') ?? false
+    return isApplicationJsonContentType(c.req.header('content-type'))
   }
 
   // ── Typed header schemas (transform + pipe for runtime validation,

--- a/packages/hono-zod-openapi/src/__tests__/json-content-header.test.ts
+++ b/packages/hono-zod-openapi/src/__tests__/json-content-header.test.ts
@@ -251,6 +251,11 @@ describe('JSON content header — OAS spec', () => {
 // ── Content-type-aware JSON body validation ──────────────────────
 
 describe('JSON body validation — content-type-aware', () => {
+  function isApplicationJsonContentType(contentType?: string): boolean {
+    const mediaType = contentType?.split(';', 1)[0]?.trim().toLowerCase()
+    return mediaType === 'application/json'
+  }
+
   function createMultiContentApp() {
     const app = new OpenAPIHono({
       defaultHook: (result, c) => {
@@ -284,11 +289,84 @@ describe('JSON body validation — content-type-aware', () => {
       }),
       (c) => {
         const ct = c.req.header('content-type')
-        if (ct?.includes('application/json')) {
+        if (isApplicationJsonContentType(ct)) {
           const body = c.req.valid('json')
           return c.json({ mode: 'json', pipeline: body.pipeline }, 200)
         }
         return c.json({ mode: 'header', pipeline: c.req.valid('header')['x-pipeline'] }, 200)
+      }
+    )
+
+    return app
+  }
+
+  function createJsonOnlyApp() {
+    const app = new OpenAPIHono({
+      defaultHook: (result, c) => {
+        if (!result.success) return c.json({ error: result.error.issues }, 400)
+      },
+    })
+
+    app.openapi(
+      createRoute({
+        operationId: 'json_only',
+        method: 'post',
+        path: '/json-only',
+        summary: 'Route with only JSON request bodies',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: z.object({ name: z.string() }) },
+          },
+        },
+        responses: { 200: { description: 'ok' } },
+      }),
+      (c) => {
+        const body = c.req.valid('json')
+        return c.json({ name: body.name }, 200)
+      }
+    )
+
+    return app
+  }
+
+  function createHeaderAlternativeApp() {
+    const app = new OpenAPIHono({
+      defaultHook: (result, c) => {
+        if (!result.success) return c.json({ error: result.error.issues }, 400)
+      },
+    })
+
+    app.openapi(
+      createRoute({
+        operationId: 'header_or_body',
+        method: 'post',
+        path: '/header-or-body',
+        summary: 'Route with JSON body or JSON header config',
+        requestParams: {
+          header: z.object({
+            'x-data': z
+              .string()
+              .transform(jsonParse)
+              .pipe(ItemSchema)
+              .optional()
+              .meta({ param: { content: { 'application/json': {} } } }),
+          }),
+        },
+        requestBody: {
+          required: false,
+          content: {
+            'application/json': { schema: z.object({ data: ItemSchema }) },
+          },
+        },
+        responses: { 200: { description: 'ok' } },
+      }),
+      (c) => {
+        if (isApplicationJsonContentType(c.req.header('content-type'))) {
+          const body = c.req.valid('json')
+          return c.json({ mode: 'json', data: body.data }, 200)
+        }
+        return c.json({ mode: 'header', data: c.req.valid('header')['x-data'] }, 200)
       }
     )
 
@@ -300,6 +378,19 @@ describe('JSON body validation — content-type-aware', () => {
     const res = await app.request('/sync', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pipeline: { source: { type: 'stripe' } } }),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.mode).toBe('json')
+    expect(body.pipeline.source.type).toBe('stripe')
+  })
+
+  it('accepts application/json content types with parameters and mixed case', async () => {
+    const app = createMultiContentApp()
+    const res = await app.request('/sync', {
+      method: 'POST',
+      headers: { 'content-type': 'Application/JSON; charset=utf-8' },
       body: JSON.stringify({ pipeline: { source: { type: 'stripe' } } }),
     })
     expect(res.status).toBe(200)
@@ -343,6 +434,43 @@ describe('JSON body validation — content-type-aware', () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.mode).toBe('header')
+  })
+
+  it('does not treat application/json-seq as application/json', async () => {
+    const app = createMultiContentApp()
+    const res = await app.request('/sync', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json-seq',
+        'x-pipeline': 'test',
+      },
+      body: 'not-json',
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.mode).toBe('header')
+  })
+
+  it('keeps strict validation for JSON-only routes with non-JSON content type', async () => {
+    const app = createJsonOnlyApp()
+    const res = await app.request('/json-only', {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      body: JSON.stringify({ name: 'widget' }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('skips JSON validation for routes that can use JSON headers instead', async () => {
+    const app = createHeaderAlternativeApp()
+    const res = await app.request('/header-or-body', {
+      method: 'POST',
+      headers: { 'x-data': JSON.stringify({ name: 'widget', count: 5 }) },
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.mode).toBe('header')
+    expect(body.data).toEqual({ name: 'widget', count: 5 })
   })
 
   it('includes JSON body schema in OpenAPI spec alongside NDJSON', async () => {

--- a/packages/hono-zod-openapi/src/__tests__/json-content-header.test.ts
+++ b/packages/hono-zod-openapi/src/__tests__/json-content-header.test.ts
@@ -247,3 +247,113 @@ describe('JSON content header — OAS spec', () => {
     expect(xData.content['application/json'].schema.$ref).toBe('#/components/schemas/Item')
   })
 })
+
+// ── Content-type-aware JSON body validation ──────────────────────
+
+describe('JSON body validation — content-type-aware', () => {
+  function createMultiContentApp() {
+    const app = new OpenAPIHono({
+      defaultHook: (result, c) => {
+        if (!result.success) return c.json({ error: result.error.issues }, 400)
+      },
+    })
+
+    const PipelineSchema = z.object({
+      source: z.object({ type: z.string() }),
+    }).meta({ id: 'Pipeline' })
+
+    app.openapi(
+      createRoute({
+        operationId: 'multi_content',
+        method: 'post',
+        path: '/sync',
+        summary: 'Route with both JSON and NDJSON content types',
+        requestParams: {
+          header: z.object({
+            'x-pipeline': z.string().optional(),
+          }),
+        },
+        requestBody: {
+          required: false,
+          content: {
+            'application/json': { schema: z.object({ pipeline: PipelineSchema }) },
+            'application/x-ndjson': { schema: z.object({}) },
+          },
+        },
+        responses: { 200: { description: 'ok' } },
+      }),
+      (c) => {
+        const ct = c.req.header('content-type')
+        if (ct?.includes('application/json')) {
+          const body = c.req.valid('json')
+          return c.json({ mode: 'json', pipeline: body.pipeline }, 200)
+        }
+        return c.json({ mode: 'header', pipeline: c.req.valid('header')['x-pipeline'] }, 200)
+      }
+    )
+
+    return app
+  }
+
+  it('validates JSON body when Content-Type is application/json', async () => {
+    const app = createMultiContentApp()
+    const res = await app.request('/sync', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pipeline: { source: { type: 'stripe' } } }),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.mode).toBe('json')
+    expect(body.pipeline.source.type).toBe('stripe')
+  })
+
+  it('returns 400 for invalid JSON body when Content-Type is application/json', async () => {
+    const app = createMultiContentApp()
+    const res = await app.request('/sync', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pipeline: { missing: 'source' } }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('skips JSON validation for NDJSON content type', async () => {
+    const app = createMultiContentApp()
+    const ndjson = '{"type":"record","data":{}}\n{"type":"state","data":{}}\n'
+    const res = await app.request('/sync', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-ndjson',
+        'x-pipeline': 'test',
+      },
+      body: ndjson,
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.mode).toBe('header')
+  })
+
+  it('skips JSON validation when no Content-Type is set', async () => {
+    const app = createMultiContentApp()
+    const res = await app.request('/sync', {
+      method: 'POST',
+      headers: { 'x-pipeline': 'test' },
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.mode).toBe('header')
+  })
+
+  it('includes JSON body schema in OpenAPI spec alongside NDJSON', async () => {
+    const app = createMultiContentApp()
+    const spec = app.getOpenAPI31Document({
+      info: { title: 'test', version: '1' },
+    }) as any
+
+    const content = spec.paths['/sync'].post.requestBody.content
+    expect(content['application/json']).toBeDefined()
+    expect(content['application/x-ndjson']).toBeDefined()
+    expect(content['application/json'].schema.properties.pipeline).toBeDefined()
+  })
+})

--- a/packages/hono-zod-openapi/src/index.ts
+++ b/packages/hono-zod-openapi/src/index.ts
@@ -15,6 +15,7 @@
 
 import { Hono } from 'hono'
 import { zValidator } from '@hono/zod-validator'
+import { HTTPException } from 'hono/http-exception'
 import { createDocument, createSchema } from 'zod-openapi'
 import type { Hook } from '@hono/zod-validator'
 import type {
@@ -171,6 +172,20 @@ function getParamContentType(schema: AnyZod): string | undefined {
   return undefined
 }
 
+function isApplicationJsonContentType(contentType?: string): boolean {
+  const mediaType = normalizeMediaType(contentType)
+  return mediaType === 'application/json'
+}
+
+function normalizeMediaType(contentType?: string): string | undefined {
+  return contentType?.split(';', 1)[0]?.trim().toLowerCase()
+}
+
+function isJsonLikeContentType(contentType?: string): boolean {
+  const mediaType = normalizeMediaType(contentType)
+  return mediaType != null && /^application\/([a-z0-9!#$&^_.+-]+\+)?json$/.test(mediaType)
+}
+
 /**
  * For spec generation, separate header fields into plain (use schema) and
  * JSON content (use content encoding). Returns a modified op with JSON content
@@ -253,22 +268,73 @@ function processJsonContentHeaders(op: ZodOpenApiOperationObject): {
   }
 }
 
+function hasJsonContentHeaders(schema: AnyZod | undefined): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const shape = (schema as any)?._zod?.def?.shape as Record<string, AnyZod> | undefined
+  if (!shape) return false
+  return Object.values(shape).some((fieldSchema) => getParamContentType(fieldSchema) !== undefined)
+}
+
 // ── Content-type-aware JSON body validator ───────────────────────
 //
-// Standard zValidator('json', schema) calls c.req.json() unconditionally,
-// which fails for NDJSON bodies or missing bodies. This middleware only
-// runs the JSON validator when Content-Type is application/json.
+// Hono's built-in JSON validator is good for pure-JSON routes, but mixed-content
+// endpoints need stricter media-type routing and case-insensitive matching. We
+// validate JSON bodies here so multi-content routes can opt into exact
+// `application/json` handling without affecting NDJSON or header-only requests.
 
-function contentTypeGuardedJsonValidator(
+async function parseJsonBody(c: Context): Promise<unknown> {
+  try {
+    return await c.req.json()
+  } catch {
+    throw new HTTPException(400, { message: 'Malformed JSON in request body' })
+  }
+}
+
+async function validateJsonBody(
+  c: Context,
   schema: AnyZod,
-  hook?: DefaultHook
-): MiddlewareHandler {
-  const jsonValidator = zValidator('json', schema, hook as never)
-  return async (c, next) => {
-    if (c.req.header('content-type')?.includes('application/json')) {
-      return jsonValidator(c, next)
+  value: unknown,
+  hook: DefaultHook | undefined,
+  next: () => Promise<void>
+): Promise<Response | void> {
+  const result = await schema.safeParseAsync(value)
+  if (hook) {
+    const hookResult = await hook({ data: value, ...result, target: 'json' }, c)
+    if (hookResult) {
+      if (hookResult instanceof Response) return hookResult
+      if (typeof hookResult === 'object' && hookResult !== null && 'response' in hookResult) {
+        return (hookResult as { response: Response }).response
+      }
     }
-    await next()
+  }
+
+  if (!result.success) return c.json(result, 400)
+
+  ;(
+    c.req as typeof c.req & {
+      addValidatedData: (target: 'json', data: z.output<AnyZod>) => void
+    }
+  ).addValidatedData('json', result.data)
+  await next()
+}
+
+function strictJsonBodyValidator(schema: AnyZod, hook?: DefaultHook): MiddlewareHandler {
+  return async (c, next) => {
+    const contentType = c.req.header('content-type')
+    const value = isJsonLikeContentType(contentType) ? await parseJsonBody(c) : {}
+    return validateJsonBody(c, schema, value, hook, next)
+  }
+}
+
+function contentTypeGuardedJsonValidator(schema: AnyZod, hook?: DefaultHook): MiddlewareHandler {
+  return async (c, next) => {
+    if (!isApplicationJsonContentType(c.req.header('content-type'))) {
+      await next()
+      return
+    }
+
+    const value = await parseJsonBody(c)
+    return validateJsonBody(c, schema, value, hook, next)
   }
 }
 
@@ -349,10 +415,17 @@ export class OpenAPIHono<
     // content types are not parsed as a single JSON value.
     // Crucially, skip JSON body parsing entirely when the request's Content-Type
     // is not application/json, so NDJSON/header-only requests aren't affected.
-    const jsonSchema = op.requestBody?.content?.['application/json']?.schema
+    const requestBodyContent = op.requestBody?.content ?? {}
+    const jsonSchema = requestBodyContent['application/json']?.schema
+    const hasNonJsonRequestBody = Object.keys(requestBodyContent).some(
+      (contentType) => contentType !== 'application/json'
+    )
+    const hasJsonHeaderAlternatives = hasJsonContentHeaders(op.requestParams?.header as AnyZod)
     if (jsonSchema instanceof Object && 'parse' in (jsonSchema as object)) {
       middlewares.push(
-        contentTypeGuardedJsonValidator(jsonSchema as AnyZod, this._defaultHook)
+        hasNonJsonRequestBody || hasJsonHeaderAlternatives
+          ? contentTypeGuardedJsonValidator(jsonSchema as AnyZod, this._defaultHook)
+          : strictJsonBodyValidator(jsonSchema as AnyZod, this._defaultHook)
       )
     }
 

--- a/packages/hono-zod-openapi/src/index.ts
+++ b/packages/hono-zod-openapi/src/index.ts
@@ -162,6 +162,12 @@ function getParamContentType(schema: AnyZod): string | undefined {
   const content = (meta?.param as any)?.content
   if (typeof content === 'string') return content
   if (content && typeof content === 'object') return Object.keys(content)[0]
+  // Unwrap optional/nullable to find meta on the inner schema
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const def = (schema as any)._zod?.def
+  if ((def?.type === 'optional' || def?.type === 'nullable') && def.innerType) {
+    return getParamContentType(def.innerType)
+  }
   return undefined
 }
 
@@ -209,8 +215,13 @@ function processJsonContentHeaders(op: ZodOpenApiOperationObject): {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const isOptional = (fieldSchema as any)._zod?.def?.type === 'optional'
+    // Look up description from the field schema or its inner schema (for optional wrappers)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const meta = z.globalRegistry.get(fieldSchema as any) as Record<string, unknown> | undefined
+    const fieldDef = (fieldSchema as any)._zod?.def
+    const innerSchema = (fieldDef?.type === 'optional' || fieldDef?.type === 'nullable')
+      ? fieldDef.innerType : fieldSchema
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const meta = (z.globalRegistry.get(fieldSchema as any) ?? z.globalRegistry.get(innerSchema as any)) as Record<string, unknown> | undefined
     const description = meta?.description as string | undefined
 
     jsonParams.push({
@@ -239,6 +250,25 @@ function processJsonContentHeaders(op: ZodOpenApiOperationObject): {
       parameters: [...((op.parameters as unknown[]) ?? []), ...jsonParams],
     },
     pipeOutputSchemas,
+  }
+}
+
+// ── Content-type-aware JSON body validator ───────────────────────
+//
+// Standard zValidator('json', schema) calls c.req.json() unconditionally,
+// which fails for NDJSON bodies or missing bodies. This middleware only
+// runs the JSON validator when Content-Type is application/json.
+
+function contentTypeGuardedJsonValidator(
+  schema: AnyZod,
+  hook?: DefaultHook
+): MiddlewareHandler {
+  const jsonValidator = zValidator('json', schema, hook as never)
+  return async (c, next) => {
+    if (c.req.header('content-type')?.includes('application/json')) {
+      return jsonValidator(c, next)
+    }
+    await next()
   }
 }
 
@@ -317,9 +347,13 @@ export class OpenAPIHono<
 
     // Only auto-validate application/json bodies — NDJSON and other streaming
     // content types are not parsed as a single JSON value.
+    // Crucially, skip JSON body parsing entirely when the request's Content-Type
+    // is not application/json, so NDJSON/header-only requests aren't affected.
     const jsonSchema = op.requestBody?.content?.['application/json']?.schema
     if (jsonSchema instanceof Object && 'parse' in (jsonSchema as object)) {
-      middlewares.push(zValidator('json', jsonSchema as AnyZod, this._defaultHook as never))
+      middlewares.push(
+        contentTypeGuardedJsonValidator(jsonSchema as AnyZod, this._defaultHook)
+      )
     }
 
     // Use Hono's generic `on()` to avoid indexing by Method (which doesn't include `head`

--- a/packages/hono-zod-openapi/src/index.ts
+++ b/packages/hono-zod-openapi/src/index.ts
@@ -515,6 +515,8 @@ export function createRoute<R extends RouteConfig>(config: R): R {
   return config
 }
 
+export { isApplicationJsonContentType }
+
 // ── Re-exports ───────────────────────────────────────────────────
 
 // zod-openapi types consumers will need for route definitions

--- a/packages/ts-cli/src/openapi/command.test.ts
+++ b/packages/ts-cli/src/openapi/command.test.ts
@@ -215,6 +215,40 @@ describe('buildCommand', () => {
     expect(flags).toContain('--source')
   })
 
+  it('does not require a JSON body flag when an equivalent JSON header exists', () => {
+    const op: ParsedOperation = {
+      method: 'post',
+      path: '/pipeline-check',
+      operationId: 'pipelineCheck',
+      tags: [],
+      pathParams: [],
+      queryParams: [],
+      headerParams: [
+        {
+          name: 'x-pipeline',
+          in: 'header',
+          required: false,
+          content: { 'application/json': { schema: { type: 'object' } } },
+        },
+      ],
+      bodySchema: {
+        type: 'object',
+        properties: {
+          pipeline: { type: 'object' },
+        },
+        required: ['pipeline'],
+      },
+      bodyRequired: false,
+      ndjsonResponse: false,
+      ndjsonRequest: false,
+      noContent: false,
+    }
+
+    const handler = vi.fn()
+    const cmd = buildCommand(op, handler)
+    expect(cmd.args?.['pipeline']?.required).toBe(false)
+  })
+
   it('creates --body for complex/nested body', () => {
     const op: ParsedOperation = {
       method: 'post',
@@ -338,6 +372,68 @@ describe('createCliFromSpec', () => {
     })
     const names = subCommandNames(root)
     expect(names).toContain('GET:/syncs')
+  })
+
+  it('allows header-mode invocation when JSON body is an alternative transport', async () => {
+    const spec: OpenAPISpec = {
+      paths: {
+        '/pipeline_check': {
+          post: {
+            operationId: 'pipeline_check',
+            parameters: [
+              {
+                name: 'x-pipeline',
+                in: 'header',
+                required: false,
+                description: 'JSON-encoded PipelineConfig',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        source: { type: 'object' },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+            requestBody: {
+              required: false,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      pipeline: { type: 'object', description: 'Pipeline config' },
+                    },
+                    required: ['pipeline'],
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+    }
+
+    const capturedRequests: Request[] = []
+    const handler = vi.fn().mockImplementation((req: Request) => {
+      capturedRequests.push(req)
+      return Promise.resolve(new Response('{}', { headers: { 'content-type': 'application/json' } }))
+    })
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    const root = createCliFromSpec({ spec, handler })
+    await runCommand(root, {
+      rawArgs: ['pipeline-check', '--x-pipeline', '{"source":{"type":"stripe"}}'],
+    })
+
+    writeSpy.mockRestore()
+
+    expect(capturedRequests).toHaveLength(1)
+    expect(capturedRequests[0]!.headers.get('x-pipeline')).toContain('"source"')
   })
 })
 

--- a/packages/ts-cli/src/openapi/command.ts
+++ b/packages/ts-cli/src/openapi/command.ts
@@ -116,6 +116,14 @@ function getOpName(
     : defaultOperationName(op.method, op.path, rawOp)
 }
 
+function hasAlternativeJsonHeader(operation: ParsedOperation, propName: string): boolean {
+  const normalizedProp = toCliFlag(propName)
+  return operation.headerParams.some((param) => {
+    if (!param.content?.['application/json']) return false
+    return toCliFlag(param.name).replace(/^x-/, '') === normalizedProp
+  })
+}
+
 /** Build a single citty CommandDef from a ParsedOperation. */
 export function buildCommand(
   operation: ParsedOperation,
@@ -180,7 +188,8 @@ export function buildCommand(
         const key = toOptName(propName)
         args[key] = {
           type: 'string',
-          required: requiredFields.includes(propName),
+          required:
+            requiredFields.includes(propName) && !hasAlternativeJsonHeader(operation, propName),
           description: propSchema.description ?? '',
         }
       }

--- a/packages/ts-cli/src/openapi/parse.test.ts
+++ b/packages/ts-cli/src/openapi/parse.test.ts
@@ -104,6 +104,41 @@ describe('parseSpec', () => {
     expect(createSync.bodyRequired).toBe(true)
   })
 
+  it('prefers NDJSON request bodies when both NDJSON and JSON are available', () => {
+    const spec: OpenAPISpec = {
+      paths: {
+        '/sync': {
+          post: {
+            operationId: 'pipelineSync',
+            requestBody: {
+              required: false,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      pipeline: { type: 'object' },
+                    },
+                    required: ['pipeline'],
+                  },
+                },
+                'application/x-ndjson': {
+                  schema: { type: 'string' },
+                },
+              },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+    }
+
+    const ops = parseSpec(spec)
+    const sync = ops.find((o) => o.operationId === 'pipelineSync')!
+    expect(sync.ndjsonRequest).toBe(true)
+    expect(sync.bodySchema).toEqual({ type: 'string' })
+  })
+
   it('detects NDJSON response', () => {
     const ops = parseSpec(basicSpec)
     const runSync = ops.find((o) => o.operationId === 'runSync')!

--- a/packages/ts-cli/src/openapi/parse.ts
+++ b/packages/ts-cli/src/openapi/parse.ts
@@ -32,12 +32,14 @@ export function parseSpec(spec: OpenAPISpec): ParsedOperation[] {
       const queryParams = params.filter((p: OpenAPIParameter) => p.in === 'query')
       const headerParams = params.filter((p: OpenAPIParameter) => p.in === 'header')
 
-      // Extract body schema from application/json or application/x-ndjson
+      // Prefer NDJSON when both content types are available so the generated CLI
+      // preserves streaming stdin behavior instead of flattening the JSON-body
+      // alternative into required --flags.
       const content = operation.requestBody?.content ?? {}
       const jsonContent = content['application/json']
       const ndjsonContent = content['application/x-ndjson']
-      const bodySchema = jsonContent?.schema ?? ndjsonContent?.schema
-      const ndjsonRequest = !!ndjsonContent && !jsonContent
+      const bodySchema = ndjsonContent?.schema ?? jsonContent?.schema
+      const ndjsonRequest = !!ndjsonContent
 
       operations.push({
         method,

--- a/packages/ts-cli/src/openapi/types.ts
+++ b/packages/ts-cli/src/openapi/types.ts
@@ -22,6 +22,7 @@ export interface OpenAPIParameter {
   in: 'path' | 'query' | 'header' | 'cookie'
   required?: boolean
   schema?: OpenAPISchema
+  content?: Record<string, { schema?: OpenAPISchema }>
   description?: string
 }
 


### PR DESCRIPTION
## Summary

- Add an `application/json` request mode for engine POST routes so callers can send typed config in the body (`pipeline`, optional `state`, optional input `body`, and `source` for discover) while preserving the existing header and NDJSON flows.
- Update `sync-hono-zod-openapi` to validate JSON bodies only for exact `application/json` requests, keep JSON-only routes strict, and preserve correct OpenAPI output for JSON-content headers and mixed request modes.
- Update `sync-ts-cli` and regenerate the engine OpenAPI artifacts so header-based CLI usage keeps working when routes also expose JSON body alternatives.

## Test plan

- [x] `pnpm --filter @stripe/sync-hono-zod-openapi build`
- [x] `pnpm --filter @stripe/sync-hono-zod-openapi test`
- [x] `pnpm --filter sync-engine exec vitest run src/api/app.test.ts src/lib/remote-engine.test.ts`
- [x] GitHub Actions checks passed