### PR TITLE
refactor: move stream cancellation to iterator return

### DIFF
--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -214,25 +214,41 @@ function formatEof(eof: EofPayload): string {
 }
 
 /**
- * Create an AbortController that fires on client disconnect.
+ * AbortController that fires when the HTTP client disconnects.
  *
- * Under @hono/node-server the Node ServerResponse is at `c.env.outgoing` —
- * we listen for `close` while `writableFinished` is still false.
- * Under Bun.serve() the ReadableStream.cancel() callback handles this instead
- * (wired via ndjsonResponse cancel/return propagation).
+ * Primary: `Request.signal` — standard Web API, works in Bun, Deno, and any
+ * runtime that wires request lifetime to the signal.
+ *
+ * Fallback: `@hono/node-server` doesn't wire `Request.signal` to connection
+ * close, so we also listen on the Node.js `ServerResponse` close event.
+ *
+ * Whichever fires first wins; `fireOnce` ensures the abort only happens once.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function createConnectionAbort(c: any, onDisconnect?: () => void): AbortController {
   const ac = new AbortController()
+
+  const fireOnce = () => {
+    if (!ac.signal.aborted) {
+      onDisconnect?.()
+      ac.abort()
+    }
+  }
+
+  // Standard: Request.signal aborts on client disconnect
+  const reqSignal = c.req?.raw?.signal as AbortSignal | undefined
+  if (reqSignal && !reqSignal.aborted) {
+    reqSignal.addEventListener('abort', fireOnce, { once: true })
+  }
+
+  // Fallback: @hono/node-server exposes ServerResponse at c.env.outgoing
   const outgoing = c.env?.outgoing as import('node:http').ServerResponse | undefined
   if (outgoing && typeof outgoing.on === 'function') {
     outgoing.on('close', () => {
-      if (!ac.signal.aborted && outgoing.writableFinished === false) {
-        onDisconnect?.()
-        ac.abort()
-      }
+      if (outgoing.writableFinished === false) fireOnce()
     })
   }
+
   return ac
 }
 
@@ -650,7 +666,6 @@ export async function createApp(resolver: ConnectorResolver) {
     }
     const output = engine.pipeline_read(pipeline, { state, state_limit, time_limit }, input)
     return ndjsonResponse(logApiStream('Engine API /pipeline_read', output, context, startedAt), {
-      onCancel: onDisconnect,
       signal: ac.signal,
     })
   })
@@ -704,7 +719,7 @@ export async function createApp(resolver: ConnectorResolver) {
         context,
         startedAt
       ),
-      { onCancel: onDisconnect, signal: ac.signal }
+      { signal: ac.signal }
     )
   })
 
@@ -754,7 +769,6 @@ export async function createApp(resolver: ConnectorResolver) {
       : undefined
     const output = engine.pipeline_sync(pipeline, { state, state_limit, time_limit }, input)
     return ndjsonResponse(logApiStream('Engine API /pipeline_sync', output, context, startedAt), {
-      onCancel: onDisconnect,
       signal: ac.signal,
     })
   })

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -219,7 +219,7 @@ function formatEof(eof: EofPayload): string {
  * Under @hono/node-server the Node ServerResponse is at `c.env.outgoing` —
  * we listen for `close` while `writableFinished` is still false.
  * Under Bun.serve() the ReadableStream.cancel() callback handles this instead
- * (wired via ndjsonResponse onCancel).
+ * (wired via ndjsonResponse cancel/return propagation).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function createConnectionAbort(c: any, onDisconnect?: () => void): AbortController {
@@ -648,14 +648,10 @@ export async function createApp(resolver: ConnectorResolver) {
         input = verboseInput('pipeline_read', parseNdjsonStream(c.req.raw.body!))
       }
     }
-    const output = engine.pipeline_read(
-      pipeline,
-      { state, state_limit, time_limit },
-      input,
-      ac.signal
-    )
+    const output = engine.pipeline_read(pipeline, { state, state_limit, time_limit }, input)
     return ndjsonResponse(logApiStream('Engine API /pipeline_read', output, context, startedAt), {
       onCancel: onDisconnect,
+      signal: ac.signal,
     })
   })
 
@@ -704,11 +700,11 @@ export async function createApp(resolver: ConnectorResolver) {
     return ndjsonResponse(
       logApiStream(
         'Engine API /write',
-        engine.pipeline_write(pipeline, messages, ac.signal),
+        engine.pipeline_write(pipeline, messages),
         context,
         startedAt
       ),
-      { onCancel: onDisconnect }
+      { onCancel: onDisconnect, signal: ac.signal }
     )
   })
 
@@ -756,14 +752,10 @@ export async function createApp(resolver: ConnectorResolver) {
     const input = hasBody(c)
       ? verboseInput('pipeline_sync', parseNdjsonStream(c.req.raw.body!))
       : undefined
-    const output = engine.pipeline_sync(
-      pipeline,
-      { state, state_limit, time_limit },
-      input,
-      ac.signal
-    )
+    const output = engine.pipeline_sync(pipeline, { state, state_limit, time_limit }, input)
     return ndjsonResponse(logApiStream('Engine API /pipeline_sync', output, context, startedAt), {
       onCancel: onDisconnect,
+      signal: ac.signal,
     })
   })
 

--- a/apps/engine/src/lib/destination-exec.ts
+++ b/apps/engine/src/lib/destination-exec.ts
@@ -8,6 +8,7 @@ import type {
   DestinationInput,
   DestinationOutput,
 } from '@stripe/sync-protocol'
+import { withAbortOnReturn } from '@stripe/sync-protocol'
 import { splitCmd, spawnAndStream, spawnWithStdin } from './exec-helpers.js'
 
 /**
@@ -38,17 +39,20 @@ export function createDestinationFromExec(cmd: string): Destination {
       params: { config: Record<string, unknown>; catalog: ConfiguredCatalog },
       $stdin: AsyncIterable<DestinationInput>
     ): AsyncIterable<DestinationOutput> {
-      return spawnWithStdin<DestinationInput, DestinationOutput>(
-        bin,
-        [
-          ...baseArgs,
-          'write',
-          '--config',
-          JSON.stringify(params.config),
-          '--catalog',
-          JSON.stringify(params.catalog),
-        ],
-        $stdin
+      return withAbortOnReturn((signal) =>
+        spawnWithStdin<DestinationInput, DestinationOutput>(
+          bin,
+          [
+            ...baseArgs,
+            'write',
+            '--config',
+            JSON.stringify(params.config),
+            '--catalog',
+            JSON.stringify(params.catalog),
+          ],
+          $stdin,
+          signal
+        )
       )
     },
 

--- a/apps/engine/src/lib/engine.test.ts
+++ b/apps/engine/src/lib/engine.test.ts
@@ -20,6 +20,7 @@ import {
   SourceStateMessage,
   Stream,
   TraceMessage,
+  withAbortOnReturn,
 } from '@stripe/sync-protocol'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
@@ -1107,5 +1108,229 @@ describe('engine.pipeline_sync() pipeline', () => {
     expect(sourceSignals.length).toBeGreaterThan(0)
 
     vi.restoreAllMocks()
+  })
+})
+
+function waitForAbortOrRelease(
+  signal: AbortSignal,
+  onAbort: () => void,
+  setRelease: (release: () => void) => void
+): Promise<void> {
+  return new Promise((resolve) => {
+    const finish = () => {
+      signal.removeEventListener('abort', onSignalAbort)
+      setRelease(() => undefined)
+      resolve()
+    }
+
+    const onSignalAbort = () => {
+      onAbort()
+      finish()
+    }
+
+    setRelease(finish)
+
+    if (signal.aborted) {
+      onSignalAbort()
+      return
+    }
+
+    signal.addEventListener('abort', onSignalAbort, { once: true })
+  })
+}
+
+describe('engine cancellation integration', () => {
+  it('pipeline_read() return() aborts a blocked source read', async () => {
+    let sourceAborted = false
+    let releaseSource = () => undefined
+
+    const source: Source = {
+      async *spec() {
+        yield { type: 'spec', spec: { config: {} } as any }
+      },
+      async *discover() {
+        yield {
+          type: 'catalog',
+          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+        } as CatalogMessage
+      },
+      read() {
+        return withAbortOnReturn((signal) =>
+          (async function* () {
+            yield {
+              type: 'record',
+              record: {
+                stream: 'customers',
+                data: { id: 'cus_1' },
+                emitted_at: '2024-01-01T00:00:00.000Z',
+              },
+            } satisfies RecordMessage
+
+            await waitForAbortOrRelease(
+              signal,
+              () => {
+                sourceAborted = true
+              },
+              (release) => {
+                releaseSource = release
+              }
+            )
+          })()
+        )
+      },
+    }
+
+    const engine = await createEngine(makeResolver(source, destinationTest))
+    const iter = engine.pipeline_read(defaultPipeline)[Symbol.asyncIterator]()
+
+    expect(await iter.next()).toMatchObject({
+      value: { type: 'record', record: { stream: 'customers', data: { id: 'cus_1' } } },
+      done: false,
+    })
+
+    const blockedNext = iter.next()
+    void blockedNext.catch(() => undefined)
+
+    const returnPromise = iter.return?.()
+
+    try {
+      await expect(
+        Promise.race([
+          returnPromise!,
+          new Promise<never>((_, reject) => {
+            setTimeout(() => reject(new Error('timed out waiting for pipeline_read teardown')), 50)
+          }),
+        ])
+      ).resolves.toEqual({ value: undefined, done: true })
+    } finally {
+      releaseSource()
+      await Promise.race([
+        returnPromise?.catch(() => undefined) ?? Promise.resolve(),
+        new Promise((resolve) => setTimeout(resolve, 50)),
+      ])
+    }
+
+    expect(sourceAborted).toBe(true)
+  })
+
+  it('pipeline_sync() return() aborts both source and destination work', async () => {
+    let sourceAborted = false
+    let destinationAborted = false
+    let releaseSource = () => undefined
+    let releaseDestination = () => undefined
+    let markDestinationWaiting = () => undefined
+    const destinationWaiting = new Promise<void>((resolve) => {
+      markDestinationWaiting = resolve
+    })
+
+    const source: Source = {
+      async *spec() {
+        yield { type: 'spec', spec: { config: {} } as any }
+      },
+      async *discover() {
+        yield {
+          type: 'catalog',
+          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+        } as CatalogMessage
+      },
+      read() {
+        return withAbortOnReturn((signal) =>
+          (async function* () {
+            yield {
+              type: 'record',
+              record: {
+                stream: 'customers',
+                data: { id: 'cus_1' },
+                emitted_at: '2024-01-01T00:00:00.000Z',
+              },
+            } satisfies RecordMessage
+
+            await waitForAbortOrRelease(
+              signal,
+              () => {
+                sourceAborted = true
+              },
+              (release) => {
+                releaseSource = release
+              }
+            )
+          })()
+        )
+      },
+    }
+
+    const destination: Destination = {
+      async *spec() {
+        yield { type: 'spec', spec: { config: {} } as any }
+      },
+      write(_params, messages) {
+        return withAbortOnReturn((signal) =>
+          (async function* () {
+            for await (const msg of messages) {
+              if (msg.type !== 'record') continue
+
+              yield {
+                type: 'source_state',
+                source_state: {
+                  stream: 'customers',
+                  data: { cursor: 'cus_1' },
+                },
+              } satisfies SourceStateMessage
+
+              markDestinationWaiting()
+              await waitForAbortOrRelease(
+                signal,
+                () => {
+                  destinationAborted = true
+                },
+                (release) => {
+                  releaseDestination = release
+                }
+              )
+            }
+          })()
+        )
+      },
+    }
+
+    const engine = await createEngine(makeResolver(source, destination))
+    const iter = engine.pipeline_sync(defaultPipeline)[Symbol.asyncIterator]()
+
+    expect(await iter.next()).toMatchObject({
+      value: { type: 'source_state', source_state: { stream: 'customers', data: { cursor: 'cus_1' } } },
+      done: false,
+    })
+
+    const blockedNext = iter.next()
+    void blockedNext.catch(() => undefined)
+    await Promise.race([
+      destinationWaiting,
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('destination never entered the blocked section')), 50)
+      }),
+    ])
+
+    const returnPromise = iter.return?.()
+
+    try {
+      await expect(
+        Promise.race([
+          returnPromise!,
+          new Promise<never>((_, reject) => {
+            setTimeout(() => reject(new Error('timed out waiting for pipeline_sync teardown')), 50)
+          }),
+        ])
+      ).resolves.toEqual({ value: undefined, done: true })
+    } finally {
+      releaseSource()
+      releaseDestination()
+      await Promise.race([
+        returnPromise?.catch(() => undefined) ?? Promise.resolve(),
+        new Promise((resolve) => setTimeout(resolve, 50)),
+      ])
+    }
+
+    expect(sourceAborted).toBe(true)
+    expect(destinationAborted).toBe(true)
   })
 })

--- a/apps/engine/src/lib/engine.ts
+++ b/apps/engine/src/lib/engine.ts
@@ -19,6 +19,7 @@ import {
   split,
   merge,
   map,
+  withAbortOnReturn,
 } from '@stripe/sync-protocol'
 
 import { enforceCatalog, filterType, log, pipe, takeLimits } from './pipeline.js'
@@ -119,8 +120,7 @@ export interface Engine {
   pipeline_read(
     pipeline: PipelineConfig,
     opts?: SourceReadOptions,
-    input?: AsyncIterable<unknown>,
-    signal?: AbortSignal
+    input?: AsyncIterable<unknown>
   ): AsyncIterable<Message>
 
   /**
@@ -130,8 +130,7 @@ export interface Engine {
    */
   pipeline_write(
     pipeline: PipelineConfig,
-    messages: AsyncIterable<Message>,
-    signal?: AbortSignal
+    messages: AsyncIterable<Message>
   ): AsyncIterable<DestinationOutput>
 
   /**
@@ -142,8 +141,7 @@ export interface Engine {
   pipeline_sync(
     pipeline: PipelineConfig,
     opts?: SourceReadOptions,
-    input?: AsyncIterable<unknown>,
-    signal?: AbortSignal
+    input?: AsyncIterable<unknown>
   ): AsyncIterable<SyncOutput>
 }
 
@@ -156,26 +154,74 @@ function engineLogContext(pipeline: PipelineConfig): Record<string, unknown> {
   }
 }
 
-async function* withLoggedStream<T>(
+function withLoggedStream<T>(
   label: string,
   context: Record<string, unknown>,
   iter: AsyncIterable<T>
-): AsyncIterable<T> {
+): AsyncIterableIterator<T> {
+  const iterator = iter[Symbol.asyncIterator]()
   const startedAt = Date.now()
   let itemCount = 0
-  logger.info(context, `${label} started`)
-  try {
-    for await (const item of iter) {
-      itemCount++
-      yield item
-    }
+  let settled = false
+
+  const logCompleted = () => {
+    if (settled) return
+    settled = true
     logger.info({ ...context, itemCount, durationMs: Date.now() - startedAt }, `${label} completed`)
-  } catch (error) {
+  }
+
+  const logFailed = (error: unknown) => {
+    if (settled) return
+    settled = true
     logger.error(
       { ...context, itemCount, durationMs: Date.now() - startedAt, err: error },
       `${label} failed`
     )
-    throw error
+  }
+
+  logger.info(context, `${label} started`)
+
+  return {
+    [Symbol.asyncIterator]() {
+      return this
+    },
+    async next() {
+      try {
+        const result = await iterator.next()
+        if (result.done) {
+          logCompleted()
+          return result
+        }
+        itemCount++
+        return result
+      } catch (error) {
+        logFailed(error)
+        throw error
+      }
+    },
+    async return(value?: unknown) {
+      try {
+        if (iterator.return) {
+          await iterator.return(value)
+        }
+        logCompleted()
+        return { value: value as T, done: true }
+      } catch (error) {
+        logFailed(error)
+        throw error
+      }
+    },
+    async throw(error?: unknown) {
+      try {
+        if (iterator.throw) {
+          return await iterator.throw(error)
+        }
+        throw error
+      } catch (thrown) {
+        logFailed(thrown)
+        throw thrown
+      }
+    },
   }
 }
 
@@ -414,123 +460,128 @@ export async function createEngine(resolver: ConnectorResolver): Promise<Engine>
       )
     },
 
-    async *pipeline_read(pipeline, opts?, input?, signal?) {
+    pipeline_read(pipeline, opts?, input?) {
       const baseContext = engineLogContext(pipeline)
-      const connector = await resolver.resolveSource(pipeline.source.type)
-      const rawSrc = configPayload(pipeline.source)
-      const sourceConfig = await getSpecConfig(connector, rawSrc)
-      const { catalog } = await discoverCatalog(engine, pipeline)
-      const normalizedState = coerceSyncState(opts?.state)
-      const state = normalizedState?.source
+      return withAbortOnReturn((signal) =>
+        (async function* () {
+          const connector = await resolver.resolveSource(pipeline.source.type)
+          const rawSrc = configPayload(pipeline.source)
+          const sourceConfig = await getSpecConfig(connector, rawSrc)
+          const { catalog } = await discoverCatalog(engine, pipeline)
+          const normalizedState = coerceSyncState(opts?.state)
+          const state = normalizedState?.source
 
-      const raw = connector.read({ config: sourceConfig, catalog, state }, input, signal)
-      const logged = withLoggedStream(
-        'Engine source read',
-        {
-          ...baseContext,
-          inputProvided: input !== undefined,
-          stateProvided: state !== undefined,
-        },
-        raw
+          const raw = connector.read({ config: sourceConfig, catalog, state }, input)
+          const logged = withLoggedStream(
+            'Engine source read',
+            {
+              ...baseContext,
+              inputProvided: input !== undefined,
+              stateProvided: state !== undefined,
+            },
+            raw
+          )
+          const parsed = map(logged, (msg) => Message.parse(msg))
+          yield* takeLimits({
+            state_limit: opts?.state_limit,
+            time_limit: opts?.time_limit,
+            signal,
+          })(parsed)
+        })()
       )
-      const parsed: AsyncIterable<Message> = (async function* () {
-        for await (const msg of logged) {
-          yield Message.parse(msg)
-        }
-      })()
-      yield* takeLimits({
-        state_limit: opts?.state_limit,
-        time_limit: opts?.time_limit,
-        signal,
-      })(parsed)
     },
 
-    async *pipeline_write(pipeline, messages, signal?) {
+    pipeline_write(pipeline, messages) {
       const baseContext = engineLogContext(pipeline)
-      const connector = await resolver.resolveDestination(pipeline.destination.type)
-      const rawDest = configPayload(pipeline.destination)
-      const destConfig = await getSpecConfig(connector, rawDest)
-      const { filteredCatalog } = await discoverCatalog(engine, pipeline)
+      return withAbortOnReturn(() =>
+        (async function* () {
+          const connector = await resolver.resolveDestination(pipeline.destination.type)
+          const rawDest = configPayload(pipeline.destination)
+          const destConfig = await getSpecConfig(connector, rawDest)
+          const { filteredCatalog } = await discoverCatalog(engine, pipeline)
 
-      const destInput = pipe(
-        messages,
-        enforceCatalog(filteredCatalog),
-        log,
-        filterType('record', 'source_state')
+          const destInput = pipe(
+            messages,
+            enforceCatalog(filteredCatalog),
+            log,
+            filterType('record', 'source_state')
+          )
+          const destOutput = connector.write(
+            { config: destConfig, catalog: filteredCatalog },
+            destInput
+          )
+          for await (const msg of withLoggedStream(
+            'Engine destination write',
+            baseContext,
+            destOutput
+          )) {
+            yield DestinationOutput.parse(msg)
+          }
+        })()
       )
-      const destOutput = connector.write(
-        { config: destConfig, catalog: filteredCatalog },
-        destInput,
-        signal
-      )
-      for await (const msg of withLoggedStream(
-        'Engine destination write',
-        baseContext,
-        destOutput
-      )) {
-        if (signal?.aborted) return
-        yield DestinationOutput.parse(msg)
-      }
     },
 
-    async *pipeline_sync(pipeline, opts?, input?, signal?) {
+    pipeline_sync(pipeline, opts?, input?) {
       const baseContext = engineLogContext(pipeline)
       const sourceTag = `source/${pipeline.source.type}`
       const destTag = `destination/${pipeline.destination.type}`
       const now = () => new Date().toISOString()
+      return withAbortOnReturn((signal) =>
+        (async function* () {
+          // Read from source (pass state but not state_limit — state_limit controls sync output)
+          const readOutput = engine.pipeline_read(pipeline, { state: opts?.state }, input)
 
-      // Read from source (pass state + signal but not state_limit — state_limit controls sync output)
-      const readOutput = engine.pipeline_read(pipeline, { state: opts?.state }, input, signal)
+          // Split: data + eof → destination path, source signals → caller
+          // Eof from pipeline_read is excluded from source signals (pipeline_sync adds its own)
+          const isDataOrEof = (msg: Message): msg is RecordMessage | SourceStateMessage =>
+            msg.type === 'record' || msg.type === 'source_state' || msg.type === 'eof'
+          const [dataStream, sourceSignals] = split(readOutput, isDataOrEof)
 
-      // Split: data + eof → destination path, source signals → caller
-      // Eof from pipeline_read is excluded from source signals (pipeline_sync adds its own)
-      const isDataOrEof = (msg: Message): msg is RecordMessage | SourceStateMessage =>
-        msg.type === 'record' || msg.type === 'source_state' || msg.type === 'eof'
-      const [dataStream, sourceSignals] = split(readOutput, isDataOrEof)
+          // Set up destination inline — we need control of the stream split
+          const destConnector = await resolver.resolveDestination(pipeline.destination.type)
+          const rawDest = configPayload(pipeline.destination)
+          const destConfig = await getSpecConfig(destConnector, rawDest)
+          const { filteredCatalog } = await discoverCatalog(engine, pipeline)
 
-      // Set up destination inline — we need control of the stream split
-      const destConnector = await resolver.resolveDestination(pipeline.destination.type)
-      const rawDest = configPayload(pipeline.destination)
-      const destConfig = await getSpecConfig(destConnector, rawDest)
-      const { filteredCatalog } = await discoverCatalog(engine, pipeline)
+          const recordCounter = createRecordCounter()
+          const destInput = pipe(
+            dataStream,
+            enforceCatalog(filteredCatalog),
+            log,
+            recordCounter.tap.bind(recordCounter),
+            filterType('record', 'source_state')
+          )
+          const destOutput = destConnector.write(
+            { config: destConfig, catalog: filteredCatalog },
+            destInput
+          )
+          const parsedDest = withLoggedStream('Engine destination write', baseContext, destOutput)
 
-      const recordCounter = createRecordCounter()
-      const destInput = pipe(
-        dataStream,
-        enforceCatalog(filteredCatalog),
-        log,
-        recordCounter.tap.bind(recordCounter),
-        filterType('record', 'source_state')
+          // Tag origin on both streams, narrowing to SyncOutput
+          const taggedDest: AsyncIterable<SyncOutput> = map(parsedDest, (msg) => ({
+            ...DestinationOutput.parse(msg),
+            _emitted_by: destTag,
+            _ts: now(),
+          }))
+          const taggedSource: AsyncIterable<SyncOutput> = map(sourceSignals, (msg) =>
+            SyncOutput.parse({ ...msg, _emitted_by: sourceTag, _ts: now() })
+          )
+
+          // Merge both streams, apply limits, and track progress
+          const limited = takeLimits<SyncOutput>({
+            state_limit: opts?.state_limit,
+            time_limit: opts?.time_limit,
+            signal,
+          })(merge(taggedDest, taggedSource))
+
+          const normalizedState = coerceSyncState(opts?.state)
+
+          yield* trackProgress({
+            initial_state: normalizedState,
+            recordCounter,
+          })(limited)
+        })()
       )
-      const destOutput = destConnector.write(
-        { config: destConfig, catalog: filteredCatalog },
-        destInput
-      )
-      const parsedDest = withLoggedStream('Engine destination write', baseContext, destOutput)
-
-      // Tag origin on both streams, narrowing to SyncOutput
-      const taggedDest: AsyncIterable<SyncOutput> = map(parsedDest, (msg) => ({
-        ...DestinationOutput.parse(msg),
-        _emitted_by: destTag,
-        _ts: now(),
-      }))
-      const taggedSource: AsyncIterable<SyncOutput> = map(sourceSignals, (msg) =>
-        SyncOutput.parse({ ...msg, _emitted_by: sourceTag, _ts: now() })
-      )
-
-      // Merge both streams, apply limits, and track progress
-      const limited = takeLimits<SyncOutput>({
-        state_limit: opts?.state_limit,
-        time_limit: opts?.time_limit,
-        signal,
-      })(merge(taggedDest, taggedSource))
-
-      const normalizedState = coerceSyncState(opts?.state)
-
-      yield* trackProgress({
-        initial_state: normalizedState,
-        recordCounter,
-      })(limited)
     },
   }
   return engine

--- a/apps/engine/src/lib/exec.test.ts
+++ b/apps/engine/src/lib/exec.test.ts
@@ -34,7 +34,7 @@ describe('createSourceFromExec', () => {
 
   it('read() accepts $stdin parameter', () => {
     // Just check it accepts the parameter signature — no actual subprocess invocation
-    expect(source.read.length).toBe(3)
+    expect(source.read.length).toBe(2)
   })
 })
 

--- a/apps/engine/src/lib/pipeline.ts
+++ b/apps/engine/src/lib/pipeline.ts
@@ -207,7 +207,7 @@ export function takeLimits<T extends Message>(
     function closeIteratorInBackground() {
       if (iteratorClosed) return
       iteratorClosed = true
-      void iterator.return?.(undefined)
+      void iterator.return?.(undefined)?.catch(() => {})
     }
 
     // Create the abort promise once so we don't leak listeners per iteration

--- a/apps/engine/src/lib/pipeline.ts
+++ b/apps/engine/src/lib/pipeline.ts
@@ -192,9 +192,22 @@ export function takeLimits<T extends Message>(
     // Slow path: manual iterator + Promise.race for hard deadline / signal
     const iterator = messages[Symbol.asyncIterator]()
     let hardTimer: ReturnType<typeof setTimeout> | undefined
+    let iteratorClosed = false
 
     function cleanup() {
       if (hardTimer != null) clearTimeout(hardTimer)
+    }
+
+    async function closeIterator() {
+      if (iteratorClosed) return
+      iteratorClosed = true
+      await iterator.return?.(undefined)
+    }
+
+    function closeIteratorInBackground() {
+      if (iteratorClosed) return
+      iteratorClosed = true
+      void iterator.return?.(undefined)
     }
 
     // Create the abort promise once so we don't leak listeners per iteration
@@ -217,7 +230,7 @@ export function takeLimits<T extends Message>(
           cleanup()
           logger.warn({ elapsed_ms: Date.now() - startedAt, event: 'SYNC_ABORTED' }, 'SYNC_ABORTED')
           yield makeEof('aborted')
-          await iterator.return?.(undefined)
+          await closeIterator()
           return
         }
 
@@ -254,14 +267,14 @@ export function takeLimits<T extends Message>(
           )
           yield makeEof('time_limit', { cutoff: 'hard' })
           // Fire-and-forget: don't await return() since the iterator may be blocked
-          iterator.return?.(undefined)
+          closeIteratorInBackground()
           return
         }
 
         if (winner.kind === 'aborted') {
           logger.warn({ elapsed_ms: Date.now() - startedAt, event: 'SYNC_ABORTED' }, 'SYNC_ABORTED')
           yield makeEof('aborted')
-          iterator.return?.(undefined)
+          await closeIterator()
           return
         }
 
@@ -286,19 +299,20 @@ export function takeLimits<T extends Message>(
             'SYNC_TIME_LIMIT_SOFT'
           )
           yield makeEof('time_limit', { cutoff: 'soft' })
-          await iterator.return?.(undefined)
+          await closeIterator()
           return
         }
 
         // Check state limit
         if (msg.type === 'source_state' && opts.state_limit && ++stateCount >= opts.state_limit) {
           yield makeEof('state_limit')
-          await iterator.return?.(undefined)
+          await closeIterator()
           return
         }
       }
     } finally {
       cleanup()
+      await closeIterator()
     }
   }
 }

--- a/apps/engine/src/lib/remote-engine.ts
+++ b/apps/engine/src/lib/remote-engine.ts
@@ -12,6 +12,7 @@ import type {
   PipelineConfig,
   SyncOutput,
 } from '@stripe/sync-protocol'
+import { withAbortOnReturn } from '@stripe/sync-protocol'
 
 // openapi-typescript does not model NDJSON streaming bodies correctly:
 // - /read and /sync accept an optional NDJSON body but the generated types declare `requestBody?: never`
@@ -159,41 +160,50 @@ export function createRemoteEngine(engineUrl: string): Engine {
       yield* parseNdjsonStream<TeardownOutput>(res.body!)
     },
 
-    async *pipeline_read(
+    pipeline_read(
       pipeline: PipelineConfig,
       opts?: SourceReadOptions,
-      input?: AsyncIterable<unknown>,
-      signal?: AbortSignal
+      input?: AsyncIterable<unknown>
     ): AsyncIterable<Message> {
-      const body = input ? toNdjsonStream(input) : undefined
-      const res = await post('/pipeline_read', pipeline, opts, body, signal)
-      yield* parseNdjsonStream<Message>(res.body!)
-    },
-
-    async *pipeline_write(
-      pipeline: PipelineConfig,
-      messages: AsyncIterable<Message>,
-      signal?: AbortSignal
-    ): AsyncIterable<DestinationOutput> {
-      const res = await post(
-        '/pipeline_write',
-        pipeline,
-        undefined,
-        toNdjsonStream(messages),
-        signal
+      return withAbortOnReturn((signal) =>
+        (async function* () {
+          const body = input ? toNdjsonStream(input) : undefined
+          const res = await post('/pipeline_read', pipeline, opts, body, signal)
+          yield* parseNdjsonStream<Message>(res.body!)
+        })()
       )
-      yield* parseNdjsonStream<DestinationOutput>(res.body!)
     },
 
-    async *pipeline_sync(
+    pipeline_write(
+      pipeline: PipelineConfig,
+      messages: AsyncIterable<Message>
+    ): AsyncIterable<DestinationOutput> {
+      return withAbortOnReturn((signal) =>
+        (async function* () {
+          const res = await post(
+            '/pipeline_write',
+            pipeline,
+            undefined,
+            toNdjsonStream(messages),
+            signal
+          )
+          yield* parseNdjsonStream<DestinationOutput>(res.body!)
+        })()
+      )
+    },
+
+    pipeline_sync(
       pipeline: PipelineConfig,
       opts?: SourceReadOptions,
-      input?: AsyncIterable<unknown>,
-      signal?: AbortSignal
+      input?: AsyncIterable<unknown>
     ): AsyncIterable<SyncOutput> {
-      const body = input ? toNdjsonStream(input) : undefined
-      const res = await post('/pipeline_sync', pipeline, opts, body, signal)
-      yield* parseNdjsonStream<SyncOutput>(res.body!)
+      return withAbortOnReturn((signal) =>
+        (async function* () {
+          const body = input ? toNdjsonStream(input) : undefined
+          const res = await post('/pipeline_sync', pipeline, opts, body, signal)
+          yield* parseNdjsonStream<SyncOutput>(res.body!)
+        })()
+      )
     },
   }
 }

--- a/apps/engine/src/lib/source-exec.ts
+++ b/apps/engine/src/lib/source-exec.ts
@@ -8,6 +8,7 @@ import type {
   ConfiguredCatalog,
   Message,
 } from '@stripe/sync-protocol'
+import { withAbortOnReturn } from '@stripe/sync-protocol'
 import { splitCmd, spawnAndStream, spawnWithStdin } from './exec-helpers.js'
 
 /**
@@ -52,8 +53,7 @@ export function createSourceFromExec(cmd: string): Source {
         catalog: ConfiguredCatalog
         state?: Record<string, unknown>
       },
-      $stdin?: AsyncIterable<unknown>,
-      signal?: AbortSignal
+      $stdin?: AsyncIterable<unknown>
     ): AsyncIterable<Message> {
       const args = [
         ...baseArgs,
@@ -66,10 +66,12 @@ export function createSourceFromExec(cmd: string): Source {
       if (params.state) {
         args.push('--state', JSON.stringify(params.state))
       }
-      if ($stdin) {
-        return spawnWithStdin<unknown, Message>(bin, args, $stdin, signal)
-      }
-      return spawnAndStream<Message>(bin, args, signal)
+      return withAbortOnReturn((signal) => {
+        if ($stdin) {
+          return spawnWithStdin<unknown, Message>(bin, args, $stdin, signal)
+        }
+        return spawnAndStream<Message>(bin, args, signal)
+      })
     },
 
     async *setup(params: {

--- a/packages/protocol/src/async-iterable-utils.test.ts
+++ b/packages/protocol/src/async-iterable-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { channel, merge, split, map } from './async-iterable-utils.js'
+import { channel, merge, split, map, withAbortOnReturn } from './async-iterable-utils.js'
 
 async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
   const items: T[] = []
@@ -99,29 +99,46 @@ describe('merge', () => {
     let aClosed = false
     let bClosed = false
 
-    async function* a(): AsyncIterable<number> {
-      try {
-        yield 1
-        await new Promise(() => {})
-      } finally {
-        aClosed = true
-      }
-    }
+    const a = withAbortOnReturn((signal) =>
+      (async function* () {
+        try {
+          yield 1
+          await new Promise<void>((resolve) => {
+            if (signal.aborted) {
+              resolve()
+              return
+            }
+            signal.addEventListener('abort', () => resolve(), { once: true })
+          })
+        } finally {
+          aClosed = true
+        }
+      })()
+    )
 
-    async function* b(): AsyncIterable<number> {
-      try {
-        yield 2
-        await new Promise(() => {})
-      } finally {
-        bClosed = true
-      }
-    }
+    const b = withAbortOnReturn((signal) =>
+      (async function* () {
+        try {
+          yield 2
+          await new Promise<void>((resolve) => {
+            if (signal.aborted) {
+              resolve()
+              return
+            }
+            signal.addEventListener('abort', () => resolve(), { once: true })
+          })
+        } finally {
+          bClosed = true
+        }
+      })()
+    )
 
-    const iter = merge(a(), b())[Symbol.asyncIterator]()
+    const iter = merge(a, b)
     await iter.next()
     await iter.return?.()
     await new Promise((r) => setTimeout(r, 0))
-    expect(aClosed || bClosed).toBe(true)
+    expect(aClosed).toBe(true)
+    expect(bClosed).toBe(true)
   })
 })
 
@@ -214,5 +231,30 @@ describe('map', () => {
   it('handles empty iterable', async () => {
     const result = await collect(map(fromArray([]), (n) => n))
     expect(result).toEqual([])
+  })
+})
+
+describe('withAbortOnReturn', () => {
+  it('aborts the local signal before awaiting inner return()', async () => {
+    let abortedDuringReturn = false
+
+    const iter = withAbortOnReturn((signal) => ({
+      [Symbol.asyncIterator]() {
+        return {
+          next() {
+            return new Promise<IteratorResult<number>>(() => {})
+          },
+          async return() {
+            abortedDuringReturn = signal.aborted
+            return { value: undefined, done: true }
+          },
+        }
+      },
+    }))
+
+    const iterator = iter[Symbol.asyncIterator]()
+    void iterator.next()
+    await expect(iterator.return?.()).resolves.toEqual({ value: undefined, done: true })
+    expect(abortedDuringReturn).toBe(true)
   })
 })

--- a/packages/protocol/src/async-iterable-utils.ts
+++ b/packages/protocol/src/async-iterable-utils.ts
@@ -92,7 +92,7 @@ export function withAbortOnReturn<T>(
 
   function abortLocal() {
     if (!controller.signal.aborted) {
-      controller.abort()
+      controller.abort(new Error('iterator returned'))
     }
   }
 

--- a/packages/protocol/src/async-iterable-utils.ts
+++ b/packages/protocol/src/async-iterable-utils.ts
@@ -81,6 +81,46 @@ export function channel<T>(): AsyncIterable<T> & {
 }
 
 /**
+ * Create an async iterable that owns a local AbortController and aborts it
+ * when the consumer stops early via return()/throw().
+ */
+export function withAbortOnReturn<T>(
+  create: (signal: AbortSignal) => AsyncIterable<T>
+): AsyncIterableIterator<T> {
+  const controller = new AbortController()
+  const iterator = create(controller.signal)[Symbol.asyncIterator]()
+
+  function abortLocal() {
+    if (!controller.signal.aborted) {
+      controller.abort()
+    }
+  }
+
+  return {
+    [Symbol.asyncIterator]() {
+      return this
+    },
+    next(value?: unknown) {
+      return iterator.next(value)
+    },
+    async return(value?: unknown) {
+      abortLocal()
+      if (iterator.return) {
+        return await iterator.return(value)
+      }
+      return { value: value as T, done: true }
+    },
+    async throw(error?: unknown) {
+      abortLocal()
+      if (iterator.throw) {
+        return await iterator.throw(error)
+      }
+      throw error
+    },
+  }
+}
+
+/**
  * Merge multiple async iterables, yielding whichever produces next.
  * Falsy entries are ignored.
  *
@@ -91,13 +131,14 @@ export function channel<T>(): AsyncIterable<T> & {
  * Node's unhandled-rejection detector from crashing the process — the
  * rejection is still observed when `Promise.race` settles on it next.
  */
-export async function* merge<T>(
+export function merge<T>(
   ...iterables: (AsyncIterable<T> | false | null | undefined)[]
-): AsyncIterable<T> {
+): AsyncIterableIterator<T> {
   const iterators = iterables
     .filter((x): x is AsyncIterable<T> => !!x)
     .map((it) => it[Symbol.asyncIterator]())
   const pending = new Map<number, Promise<{ index: number; result: IteratorResult<T> }>>()
+  let closed = false
 
   const suppress = (p: Promise<unknown>) => {
     p.catch(() => {})
@@ -113,19 +154,47 @@ export async function* merge<T>(
     enqueue(i)
   }
 
-  try {
-    while (pending.size > 0) {
-      const { index, result } = await Promise.race(pending.values())
-      if (result.done) {
-        pending.delete(index)
-      } else {
-        yield result.value
-        enqueue(index)
-      }
+  function closeAll() {
+    if (closed) return
+    closed = true
+    pending.clear()
+    void Promise.allSettled(iterators.map((it) => it.return?.()))
+  }
+
+  return {
+    [Symbol.asyncIterator]() {
+      return this
+    },
+    async next() {
+      if (closed) {
+        return { value: undefined as T, done: true }
     }
-  } finally {
-    for (const it of iterators) {
-      it.return?.()
+
+      while (pending.size > 0) {
+        try {
+          const { index, result } = await Promise.race(pending.values())
+          pending.delete(index)
+          if (result.done) {
+            continue
+          }
+          enqueue(index)
+          return { value: result.value, done: false }
+        } catch (error) {
+          closeAll()
+          throw error
+        }
+      }
+
+      closed = true
+      return { value: undefined as T, done: true }
+    },
+    async return(value?: unknown) {
+      closeAll()
+      return { value: value as T, done: true }
+    },
+    async throw(error?: unknown) {
+      closeAll()
+      throw error
     }
   }
 }
@@ -189,11 +258,38 @@ export function split<T, U extends T>(
  * machinery is needed because `map` is a simple pass-through generator with
  * a single consumer.
  */
-export async function* map<T, U>(
+export function map<T, U>(
   iterable: AsyncIterable<T>,
   fn: (item: T) => U | Promise<U>
-): AsyncIterable<U> {
-  for await (const item of iterable) {
-    yield await fn(item)
+): AsyncIterableIterator<U> {
+  const iterator = iterable[Symbol.asyncIterator]()
+
+  return {
+    [Symbol.asyncIterator]() {
+      return this
+    },
+    async next() {
+      const result = await iterator.next()
+      if (result.done) {
+        return { value: undefined as U, done: true }
+      }
+      return { value: await fn(result.value), done: false }
+    },
+    async return(value?: unknown) {
+      if (iterator.return) {
+        await iterator.return(value)
+      }
+      return { value: value as U, done: true }
+    },
+    async throw(error?: unknown) {
+      if (iterator.throw) {
+        const result = await iterator.throw(error)
+        if (result.done) {
+          return { value: undefined as U, done: true }
+        }
+        return { value: await fn(result.value), done: false }
+      }
+      throw error
+    },
   }
 }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -34,4 +34,4 @@ export {
   drain,
 } from './helpers.js'
 export { parseNdjsonChunks, writeLine } from './ndjson.js'
-export { channel, merge, split, map } from './async-iterable-utils.js'
+export { channel, merge, split, map, withAbortOnReturn } from './async-iterable-utils.js'

--- a/packages/protocol/src/protocol.ts
+++ b/packages/protocol/src/protocol.ts
@@ -680,15 +680,19 @@ export interface Source<
   /** Discover available streams. */
   discover(params: { config: TConfig }): AsyncIterable<DiscoverOutput>
 
-  /** Emit messages (record, state, log, trace). Finite for backfill, infinite for live. */
+  /**
+   * Emit messages (record, state, log, trace). Finite for backfill, infinite for live.
+   *
+   * Cancellation is cooperative and iterator-driven: consumers stop work by
+   * calling `return()` (for example via early exit from `for await`).
+   */
   read(
     params: {
       config: TConfig
       catalog: ConfiguredCatalog
       state?: SourceState
     },
-    $stdin?: AsyncIterable<TInput>,
-    signal?: AbortSignal
+    $stdin?: AsyncIterable<TInput>
   ): AsyncIterable<Message>
 
   /** Provision external resources (webhook endpoints, replication slots, etc.). */
@@ -731,8 +735,7 @@ export interface Destination<TConfig extends Record<string, unknown> = Record<st
    */
   write(
     params: { config: TConfig; catalog: ConfiguredCatalog },
-    $stdin: AsyncIterable<DestinationInput>,
-    signal?: AbortSignal
+    $stdin: AsyncIterable<DestinationInput>
   ): AsyncIterable<DestinationOutput>
 
   /** Provision downstream resources (schemas, tables, etc.). */

--- a/packages/source-stripe/src/client.test.ts
+++ b/packages/source-stripe/src/client.test.ts
@@ -81,6 +81,50 @@ describe('makeClient', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
+  it('stops retrying when the pipeline signal aborts during backoff', async () => {
+    vi.useFakeTimers()
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: { type: 'api_error', message: 'Temporary outage' },
+          }),
+          { status: 500 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'acct_test', object: 'account', created: 123 }), {
+          status: 200,
+        })
+      )
+    globalThis.fetch = fetchMock
+
+    const ac = new AbortController()
+    const client = makeClient(
+      { api_key: 'sk_test_fake', api_version: '2025-04-30.basil', base_url: 'http://stripe.test' },
+      {},
+      ac.signal
+    )
+
+    const pending = client.getAccount()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const settled = vi.fn()
+    pending.then(
+      (value) => settled(value),
+      (error) => settled(error)
+    )
+
+    ac.abort()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(settled).toHaveBeenCalledTimes(1)
+    expect(settled.mock.calls[0]?.[0]).toMatchObject({ name: 'AbortError' })
+  })
+
   it('does not retry auth failures on GET requests', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
       new Response(

--- a/packages/source-stripe/src/client.ts
+++ b/packages/source-stripe/src/client.ts
@@ -91,7 +91,7 @@ export function makeClient(
     params?: Record<string, unknown>
   ): Promise<unknown> {
     if (method === 'GET') {
-      return withHttpRetry(() => request(method, path, params))
+      return withHttpRetry(() => request(method, path, params), { signal: pipelineSignal })
     }
     return request(method, path, params)
   }

--- a/packages/source-stripe/src/index.test.ts
+++ b/packages/source-stripe/src/index.test.ts
@@ -129,6 +129,10 @@ beforeEach(() => {
   consoleError.mockClear()
 })
 
+afterEach(() => {
+  vi.useRealTimers()
+})
+
 describe('StripeSource', () => {
   describe('discover()', () => {
     it('returns a CatalogMessage with known streams', async () => {
@@ -1889,6 +1893,62 @@ describe('StripeSource', () => {
       await iter.return()
     })
 
+    it('return() stops an idle websocket stream without waiting for another event', async () => {
+      const listFn = vi.fn().mockResolvedValue({ data: [], has_more: false })
+      const registry: Record<string, ResourceConfig> = {
+        customers: makeConfig({ order: 1, tableName: 'customers', listFn }),
+      }
+      vi.mocked(buildResourceRegistry).mockReturnValue(registry as any)
+
+      const iter = source
+        .read({
+          config: {
+            api_key: 'sk_test_fake',
+            api_version: '2025-04-30.basil' as const,
+            websocket: true,
+          },
+          catalog: catalog({ name: 'customers' }),
+          state: { streams: {}, global: {} },
+        })
+        [Symbol.asyncIterator]()
+
+      for (let i = 0; i < 3; i++) {
+        await iter.next()
+      }
+
+      const blockedNext = iter.next()
+      void blockedNext.catch(() => undefined)
+
+      const returnPromise = iter.return()
+
+      try {
+        await expect(
+          Promise.race([
+            returnPromise,
+            new Promise<never>((_, reject) => {
+              setTimeout(() => reject(new Error('timed out waiting for websocket teardown')), 50)
+            }),
+          ])
+        ).resolves.toEqual({ value: undefined, done: true })
+      } finally {
+        capturedOnEvent?.({
+          event_payload: JSON.stringify(
+            makeEvent({
+              id: 'evt_teardown_cleanup',
+              type: 'customer.updated',
+              dataObject: { id: 'cus_cleanup', object: 'customer' },
+            })
+          ),
+        })
+        await Promise.race([
+          returnPromise.catch(() => undefined),
+          new Promise((resolve) => setTimeout(resolve, 50)),
+        ])
+      }
+
+      expect(mockClose).toHaveBeenCalled()
+    })
+
     it('teardown() is safe when no websocket was configured', async () => {
       vi.mocked(buildResourceRegistry).mockReturnValue(registry as any)
       // No setup() call — teardown should not throw
@@ -2408,6 +2468,55 @@ describe('StripeSource', () => {
       )
 
       expect(rateLimiterSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('return() interrupts a pending rate-limit wait before the next page fetch', async () => {
+      vi.useFakeTimers()
+
+      const externalLimiter = vi.fn().mockResolvedValue(60) as unknown as RateLimiter
+      const customSource = createStripeSource({ rateLimiter: externalLimiter })
+      const listFn = vi.fn().mockResolvedValue({
+        data: [{ id: 'cus_1' }],
+        has_more: false,
+      })
+
+      const registry: Record<string, ResourceConfig> = {
+        customers: makeConfig({
+          order: 1,
+          tableName: 'customers',
+          listFn: listFn as ResourceConfig['listFn'],
+        }),
+      }
+
+      vi.mocked(buildResourceRegistry).mockReturnValue(registry as any)
+
+      const iter = customSource
+        .read({
+          config: { api_key: 'sk_test_fake', api_version: '2025-04-30.basil' as const },
+          catalog: catalog({ name: 'customers', primary_key: [['id']] }),
+          state: { streams: {}, global: {} },
+        })
+        [Symbol.asyncIterator]()
+
+      expect((await iter.next()).value).toMatchObject({
+        type: 'trace',
+        trace: { trace_type: 'stream_status', stream_status: { stream: 'customers', status: 'started' } },
+      })
+
+      const blockedNext = iter.next()
+      void blockedNext.catch(() => undefined)
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(listFn).not.toHaveBeenCalled()
+
+      const settled = vi.fn()
+      const returnPromise = iter.return()
+      returnPromise.then((result) => settled(result))
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(settled).toHaveBeenCalledWith({ value: undefined, done: true })
+      expect(listFn).not.toHaveBeenCalled()
     })
 
     it('createStripeSource uses external rate limiter when provided via deps', async () => {

--- a/packages/source-stripe/src/index.ts
+++ b/packages/source-stripe/src/index.ts
@@ -7,7 +7,7 @@ import type {
   SetupOutput,
   TeardownOutput,
 } from '@stripe/sync-protocol'
-import { sourceControlMsg } from '@stripe/sync-protocol'
+import { sourceControlMsg, withAbortOnReturn } from '@stripe/sync-protocol'
 import { z } from 'zod'
 import defaultSpec, { configSchema } from './spec.js'
 import type { Config } from './spec.js'
@@ -33,8 +33,20 @@ import { createInMemoryRateLimiter, DEFAULT_MAX_RPS } from './rate-limiter.js'
 import { fetchWithProxy } from './transport.js'
 import { stripeEventSchema } from './spec.js'
 
-const apiFetch: typeof globalThis.fetch = (input, init) =>
-  fetchWithProxy(input as URL | string, init ?? {})
+function combineSignals(...signals: Array<AbortSignal | null | undefined>): AbortSignal | undefined {
+  const activeSignals = signals.filter((signal): signal is AbortSignal => signal != null)
+  if (activeSignals.length === 0) return undefined
+  if (activeSignals.length === 1) return activeSignals[0]
+  return AbortSignal.any(activeSignals)
+}
+
+function makeApiFetch(signal?: AbortSignal): typeof globalThis.fetch {
+  return (input, init) =>
+    fetchWithProxy(input as URL | string, {
+      ...(init ?? {}),
+      signal: combineSignals(init?.signal, signal),
+    })
+}
 
 /** In-memory cache of discover results keyed by api_version. */
 export const discoverCache = new Map<string, CatalogPayload>()
@@ -140,7 +152,7 @@ export function createStripeSource(
         return
       }
 
-      const resolved = await resolveOpenApiSpec({ apiVersion }, apiFetch)
+      const resolved = await resolveOpenApiSpec({ apiVersion }, makeApiFetch())
       const registry = buildResourceRegistry(
         resolved.spec,
         config.api_key,
@@ -235,114 +247,35 @@ export function createStripeSource(
       }
     },
 
-    async *read({ config, catalog, state }, $stdin?, signal?) {
-      const apiVersion = config.api_version ?? BUNDLED_API_VERSION
-      const rateLimiter =
-        externalRateLimiter ?? createInMemoryRateLimiter(config.rate_limit ?? DEFAULT_MAX_RPS)
-      const client = makeClient({ ...config, api_version: apiVersion }, undefined, signal)
-      const resolved = await resolveOpenApiSpec({ apiVersion }, apiFetch)
-      const registry = buildResourceRegistry(
-        resolved.spec,
-        config.api_key,
-        resolved.apiVersion,
-        config.base_url
-      )
-      const streamNames = new Set(catalog.streams.map((s) => s.stream.name))
-      let accountId: string
-      try {
-        accountId = await resolveAccountId(config, client)
-      } catch (err) {
-        yield errorToTrace(err, catalog.streams[0]?.stream.name ?? 'unknown')
-        return
-      }
-
-      // Event-driven mode: iterate over incoming webhook inputs
-      if ($stdin) {
-        for await (const input of $stdin) {
-          if ('body' in (input as object)) {
-            yield* processWebhookInput(
-              input as WebhookInput,
-              config,
-              catalog,
-              registry,
-              streamNames,
-              accountId
-            )
-          } else {
-            yield* processStripeEvent(
-              input as StripeEvent,
-              config,
-              catalog,
-              registry,
-              streamNames,
-              accountId
-            )
+    read({ config, catalog, state }, $stdin?) {
+      return withAbortOnReturn((signal) =>
+        (async function* () {
+          const apiVersion = config.api_version ?? BUNDLED_API_VERSION
+          const rateLimiter =
+            externalRateLimiter ?? createInMemoryRateLimiter(config.rate_limit ?? DEFAULT_MAX_RPS)
+          const client = makeClient({ ...config, api_version: apiVersion }, undefined, signal)
+          const resolved = await resolveOpenApiSpec({ apiVersion }, makeApiFetch(signal))
+          const registry = buildResourceRegistry(
+            resolved.spec,
+            config.api_key,
+            resolved.apiVersion,
+            config.base_url
+          )
+          const streamNames = new Set(catalog.streams.map((s) => s.stream.name))
+          let accountId: string
+          try {
+            accountId = await resolveAccountId(config, client)
+          } catch (err) {
+            yield errorToTrace(err, catalog.streams[0]?.stream.name ?? 'unknown')
+            return
           }
-        }
-        return
-      }
 
-      const inputQueue = createInputQueue()
-
-      let wsClient: StripeWebSocketClient | null = null
-      if (config.websocket) {
-        wsClient = await createStripeWebSocketClient({
-          stripeApiKey: config.api_key,
-          onEvent: (wsEvent: StripeWebhookEvent) => {
-            const event = stripeEventSchema.parse(JSON.parse(wsEvent.event_payload))
-            inputQueue.push({ data: event })
-          },
-        })
-      }
-
-      let httpServer: ReturnType<typeof startWebhookServer> | null = null
-
-      try {
-        const startTimestamp = Math.floor(Date.now() / 1000)
-
-        // Backfill: paginate through each configured stream
-        yield* listApiBackfill({
-          catalog,
-          state: state?.streams as Parameters<typeof listApiBackfill>[0]['state'],
-          registry,
-          rateLimiter,
-          client,
-          accountId,
-          backfillLimit: config.backfill_limit,
-          drainQueue: wsClient
-            ? () => inputQueue.drain(config, catalog, registry, streamNames, accountId)
-            : undefined,
-        })
-
-        // Events polling: incremental sync via /v1/events after backfill
-        yield* pollEvents({
-          config,
-          client,
-          catalog,
-          registry,
-          streamNames,
-          state: state?.streams as Record<string, StripeStreamState> | undefined,
-          startTimestamp,
-          accountId,
-        })
-
-        // Start HTTP server for live mode if configured
-        if (config.webhook_port) {
-          httpServer = startWebhookServer(config.webhook_port, inputQueue.push)
-        }
-
-        // After backfill: stream live events from WebSocket and/or HTTP
-        if (wsClient || httpServer) {
-          // Drain anything that arrived during backfill
-          yield* inputQueue.drain(config, catalog, registry, streamNames, accountId)
-
-          // Block on new events (infinite loop until all live sources close)
-          while (wsClient || httpServer) {
-            const queued = await inputQueue.wait()
-            try {
-              if ('body' in queued.data) {
+          // Event-driven mode: iterate over incoming webhook inputs
+          if ($stdin) {
+            for await (const input of $stdin) {
+              if ('body' in (input as object)) {
                 yield* processWebhookInput(
-                  queued.data,
+                  input as WebhookInput,
                   config,
                   catalog,
                   registry,
@@ -351,7 +284,7 @@ export function createStripeSource(
                 )
               } else {
                 yield* processStripeEvent(
-                  queued.data,
+                  input as StripeEvent,
                   config,
                   catalog,
                   registry,
@@ -359,22 +292,106 @@ export function createStripeSource(
                   accountId
                 )
               }
-              queued.resolve?.()
-            } catch (err) {
-              queued.reject?.(err instanceof Error ? err : new Error(String(err)))
+            }
+            return
+          }
+
+          const inputQueue = createInputQueue()
+
+          let wsClient: StripeWebSocketClient | null = null
+          if (config.websocket) {
+            wsClient = await createStripeWebSocketClient({
+              stripeApiKey: config.api_key,
+              onEvent: (wsEvent: StripeWebhookEvent) => {
+                const event = stripeEventSchema.parse(JSON.parse(wsEvent.event_payload))
+                inputQueue.push({ data: event })
+              },
+            })
+          }
+
+          let httpServer: ReturnType<typeof startWebhookServer> | null = null
+
+          try {
+            const startTimestamp = Math.floor(Date.now() / 1000)
+
+            // Backfill: paginate through each configured stream
+            yield* listApiBackfill({
+              catalog,
+              state: state?.streams as Parameters<typeof listApiBackfill>[0]['state'],
+              registry,
+              rateLimiter,
+              client,
+              accountId,
+              backfillLimit: config.backfill_limit,
+              signal,
+              drainQueue: wsClient
+                ? () => inputQueue.drain(config, catalog, registry, streamNames, accountId)
+                : undefined,
+            })
+
+            // Events polling: incremental sync via /v1/events after backfill
+            yield* pollEvents({
+              config,
+              client,
+              catalog,
+              registry,
+              streamNames,
+              state: state?.streams as Record<string, StripeStreamState> | undefined,
+              startTimestamp,
+              accountId,
+            })
+
+            // Start HTTP server for live mode if configured
+            if (config.webhook_port) {
+              httpServer = startWebhookServer(config.webhook_port, inputQueue.push)
+            }
+
+            // After backfill: stream live events from WebSocket and/or HTTP
+            if (wsClient || httpServer) {
+              // Drain anything that arrived during backfill
+              yield* inputQueue.drain(config, catalog, registry, streamNames, accountId)
+
+              // Block on new events (infinite loop until all live sources close)
+              while (wsClient || httpServer) {
+                const queued = await inputQueue.wait(signal)
+                try {
+                  if ('body' in queued.data) {
+                    yield* processWebhookInput(
+                      queued.data,
+                      config,
+                      catalog,
+                      registry,
+                      streamNames,
+                      accountId
+                    )
+                  } else {
+                    yield* processStripeEvent(
+                      queued.data,
+                      config,
+                      catalog,
+                      registry,
+                      streamNames,
+                      accountId
+                    )
+                  }
+                  queued.resolve?.()
+                } catch (err) {
+                  queued.reject?.(err instanceof Error ? err : new Error(String(err)))
+                }
+              }
+            }
+          } finally {
+            if (wsClient) {
+              wsClient.close()
+              wsClient = null
+            }
+            if (httpServer) {
+              httpServer.close()
+              httpServer = null
             }
           }
-        }
-      } finally {
-        if (wsClient) {
-          wsClient.close()
-          wsClient = null
-        }
-        if (httpServer) {
-          httpServer.close()
-          httpServer = null
-        }
-      }
+        })()
+      )
     },
   }
 }

--- a/packages/source-stripe/src/retry.ts
+++ b/packages/source-stripe/src/retry.ts
@@ -87,18 +87,8 @@ export function isRetryableHttpError(err: unknown): boolean {
   )
 }
 
-function getAbortError(signal: AbortSignal): unknown {
-  return signal.reason ?? new DOMException('This operation was aborted', 'AbortError')
-}
-
-function throwIfAborted(signal?: AbortSignal) {
-  if (signal?.aborted) {
-    throw getAbortError(signal)
-  }
-}
-
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  throwIfAborted(signal)
+  signal?.throwIfAborted()
 
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
@@ -109,7 +99,7 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
     const onAbort = () => {
       clearTimeout(timeout)
       signal?.removeEventListener('abort', onAbort)
-      reject(getAbortError(signal!))
+      reject(signal!.reason)
     }
 
     signal?.addEventListener('abort', onAbort, { once: true })
@@ -125,7 +115,7 @@ export async function withHttpRetry<T>(
   let delayMs = opts.baseDelayMs ?? BACKOFF_BASE_MS
 
   for (let attempt = 0; ; attempt++) {
-    throwIfAborted(opts.signal)
+    opts.signal?.throwIfAborted()
 
     try {
       return await fn()

--- a/packages/source-stripe/src/retry.ts
+++ b/packages/source-stripe/src/retry.ts
@@ -18,6 +18,7 @@ export type HttpRetryOptions = {
   maxRetries?: number
   baseDelayMs?: number
   maxDelayMs?: number
+  signal?: AbortSignal
 }
 
 export function getHttpErrorStatus(err: unknown): number | undefined {
@@ -86,8 +87,33 @@ export function isRetryableHttpError(err: unknown): boolean {
   )
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+function getAbortError(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException('This operation was aborted', 'AbortError')
+}
+
+function throwIfAborted(signal?: AbortSignal) {
+  if (signal?.aborted) {
+    throw getAbortError(signal)
+  }
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  throwIfAborted(signal)
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+
+    const onAbort = () => {
+      clearTimeout(timeout)
+      signal?.removeEventListener('abort', onAbort)
+      reject(getAbortError(signal!))
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
 }
 
 export async function withHttpRetry<T>(
@@ -99,6 +125,8 @@ export async function withHttpRetry<T>(
   let delayMs = opts.baseDelayMs ?? BACKOFF_BASE_MS
 
   for (let attempt = 0; ; attempt++) {
+    throwIfAborted(opts.signal)
+
     try {
       return await fn()
     } catch (err) {
@@ -112,7 +140,7 @@ export async function withHttpRetry<T>(
         `[source-stripe] retry attempt=${attempt + 1}/${maxRetries} delay=${delayMs}ms status=${status ?? 'n/a'} error=${errName}`
       )
 
-      await sleep(delayMs)
+      await sleep(delayMs, opts.signal)
       delayMs = Math.min(delayMs * 2, maxDelayMs)
     }
   }

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -10,13 +10,9 @@ import type { StripeClient } from './client.js'
 
 // MARK: - Rate-limit wrapper
 
-function getAbortError(signal: AbortSignal): unknown {
-  return signal.reason ?? new DOMException('This operation was aborted', 'AbortError')
-}
-
 function waitForRateLimit(ms: number, signal?: AbortSignal): Promise<void> {
   if (signal?.aborted) {
-    return Promise.reject(getAbortError(signal))
+    return Promise.reject(signal.reason)
   }
 
   return new Promise((resolve, reject) => {
@@ -28,7 +24,7 @@ function waitForRateLimit(ms: number, signal?: AbortSignal): Promise<void> {
     const onAbort = () => {
       clearTimeout(timeout)
       signal?.removeEventListener('abort', onAbort)
-      reject(getAbortError(signal!))
+      reject(signal!.reason)
     }
 
     signal?.addEventListener('abort', onAbort, { once: true })

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -10,10 +10,35 @@ import type { StripeClient } from './client.js'
 
 // MARK: - Rate-limit wrapper
 
-function withRateLimit(listFn: ListFn, rateLimiter: RateLimiter): ListFn {
+function getAbortError(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException('This operation was aborted', 'AbortError')
+}
+
+function waitForRateLimit(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(getAbortError(signal))
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+
+    const onAbort = () => {
+      clearTimeout(timeout)
+      signal?.removeEventListener('abort', onAbort)
+      reject(getAbortError(signal!))
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+function withRateLimit(listFn: ListFn, rateLimiter: RateLimiter, signal?: AbortSignal): ListFn {
   return async (params) => {
     const wait = await rateLimiter()
-    if (wait > 0) await new Promise((r) => setTimeout(r, wait * 1000))
+    if (wait > 0) await waitForRateLimit(wait * 1000, signal)
     return listFn(params)
   }
 }
@@ -484,6 +509,7 @@ export async function* listApiBackfill(opts: {
   rateLimiter: RateLimiter
   backfillLimit?: number
   drainQueue?: () => AsyncGenerator<Message>
+  signal?: AbortSignal
 }): AsyncGenerator<Message> {
   const { catalog, state, registry, client, accountId, rateLimiter, backfillLimit, drainQueue } =
     opts
@@ -535,7 +561,7 @@ export async function* listApiBackfill(opts: {
     } satisfies TraceMessage
 
     try {
-      const rateLimitedListFn = withRateLimit(resourceConfig.listFn!, rateLimiter)
+      const rateLimitedListFn = withRateLimit(resourceConfig.listFn!, rateLimiter, opts.signal)
 
       // Parallel path: streams that support created filter
       if (resourceConfig.supportsCreatedFilter) {

--- a/packages/source-stripe/src/src-webhook.test.ts
+++ b/packages/source-stripe/src/src-webhook.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { createInputQueue } from './src-webhook.js'
+
+describe('createInputQueue', () => {
+  it('rejects wait() when the abort signal fires', async () => {
+    const queue = createInputQueue()
+    const ac = new AbortController()
+
+    const pending = queue.wait(ac.signal)
+    ac.abort()
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+  })
+})

--- a/packages/source-stripe/src/src-webhook.ts
+++ b/packages/source-stripe/src/src-webhook.ts
@@ -43,10 +43,6 @@ export function createInputQueue() {
   let inputWaiter: ((input: LiveInput) => void) | null = null
   const queue: LiveInput[] = []
 
-  function getAbortError(signal: AbortSignal): unknown {
-    return signal.reason ?? new DOMException('This operation was aborted', 'AbortError')
-  }
-
   function push(input: LiveInput) {
     if (inputWaiter) {
       const waiter = inputWaiter
@@ -63,7 +59,7 @@ export function createInputQueue() {
     }
 
     if (signal?.aborted) {
-      return Promise.reject(getAbortError(signal))
+      return Promise.reject(signal.reason)
     }
 
     return new Promise<LiveInput>((resolve, reject) => {
@@ -76,7 +72,7 @@ export function createInputQueue() {
         if (inputWaiter === waiter) {
           inputWaiter = null
         }
-        reject(getAbortError(signal!))
+        reject(signal!.reason)
       }
 
       inputWaiter = waiter

--- a/packages/source-stripe/src/src-webhook.ts
+++ b/packages/source-stripe/src/src-webhook.ts
@@ -43,6 +43,10 @@ export function createInputQueue() {
   let inputWaiter: ((input: LiveInput) => void) | null = null
   const queue: LiveInput[] = []
 
+  function getAbortError(signal: AbortSignal): unknown {
+    return signal.reason ?? new DOMException('This operation was aborted', 'AbortError')
+  }
+
   function push(input: LiveInput) {
     if (inputWaiter) {
       const waiter = inputWaiter
@@ -53,9 +57,30 @@ export function createInputQueue() {
     }
   }
 
-  function wait(): Promise<LiveInput> {
-    return new Promise<LiveInput>((resolve) => {
-      inputWaiter = resolve
+  function wait(signal?: AbortSignal): Promise<LiveInput> {
+    if (queue.length > 0) {
+      return Promise.resolve(queue.shift()!)
+    }
+
+    if (signal?.aborted) {
+      return Promise.reject(getAbortError(signal))
+    }
+
+    return new Promise<LiveInput>((resolve, reject) => {
+      const waiter = (input: LiveInput) => {
+        signal?.removeEventListener('abort', onAbort)
+        resolve(input)
+      }
+
+      const onAbort = () => {
+        if (inputWaiter === waiter) {
+          inputWaiter = null
+        }
+        reject(getAbortError(signal!))
+      }
+
+      inputWaiter = waiter
+      signal?.addEventListener('abort', onAbort, { once: true })
     })
   }
 

--- a/packages/ts-cli/src/__tests__/ndjson.test.ts
+++ b/packages/ts-cli/src/__tests__/ndjson.test.ts
@@ -44,4 +44,52 @@ describe('ndjsonResponse', () => {
     // Only the item before the error — no error message emitted
     expect(lines).toEqual([{ type: 'ok' }])
   })
+
+  it('cancels the underlying iterator when the response body is cancelled', async () => {
+    let returned = false
+
+    const res = ndjsonResponse({
+      [Symbol.asyncIterator]() {
+        return {
+          next() {
+            return new Promise<IteratorResult<unknown>>(() => {})
+          },
+          async return() {
+            returned = true
+            return { value: undefined, done: true }
+          },
+        }
+      },
+    })
+
+    await res.body!.cancel()
+    expect(returned).toBe(true)
+  })
+
+  it('cancels the underlying iterator when an external signal aborts', async () => {
+    let returned = false
+    const ac = new AbortController()
+
+    const res = ndjsonResponse(
+      {
+        [Symbol.asyncIterator]() {
+          return {
+            next() {
+              return new Promise<IteratorResult<unknown>>(() => {})
+            },
+            async return() {
+              returned = true
+              return { value: undefined, done: true }
+            },
+          }
+        },
+      },
+      { signal: ac.signal }
+    )
+
+    ac.abort()
+    await Promise.resolve()
+    expect(returned).toBe(true)
+    await res.body!.cancel().catch(() => undefined)
+  })
 })

--- a/packages/ts-cli/src/ndjson.ts
+++ b/packages/ts-cli/src/ndjson.ts
@@ -18,8 +18,7 @@ export function writeLine(obj: unknown) {
  * type `T` before closing the stream. The callback must return a valid `T` —
  * this keeps protocol-specific error shapes out of this generic helper.
  *
- * If `onCancel` is provided it is called when the ReadableStream is cancelled
- * (e.g. client disconnect under Bun.serve()). Cancellation also calls
+ * Cancellation (e.g. client disconnect under Bun.serve()) calls
  * `iterator.return()` on the wrapped iterable so normal async-iterator teardown
  * can propagate upstream.
  */
@@ -29,12 +28,10 @@ export function ndjsonResponse<T>(
     | ((err: unknown) => T)
     | {
         onError?: (err: unknown) => T
-        onCancel?: () => void
         signal?: AbortSignal
       }
 ): Response {
   const onError = typeof opts === 'function' ? opts : opts?.onError
-  const onCancel = typeof opts === 'object' ? opts?.onCancel : undefined
   const signal = typeof opts === 'object' ? opts?.signal : undefined
 
   const encoder = new TextEncoder()
@@ -71,7 +68,6 @@ export function ndjsonResponse<T>(
       }
     },
     async cancel() {
-      onCancel?.()
       await stop()
     },
   })

--- a/packages/ts-cli/src/ndjson.ts
+++ b/packages/ts-cli/src/ndjson.ts
@@ -19,8 +19,9 @@ export function writeLine(obj: unknown) {
  * this keeps protocol-specific error shapes out of this generic helper.
  *
  * If `onCancel` is provided it is called when the ReadableStream is cancelled
- * (e.g. client disconnect under Bun.serve()). Use this to trigger an
- * AbortController that propagates through the pipeline.
+ * (e.g. client disconnect under Bun.serve()). Cancellation also calls
+ * `iterator.return()` on the wrapped iterable so normal async-iterator teardown
+ * can propagate upstream.
  */
 export function ndjsonResponse<T>(
   iterable: AsyncIterable<T>,
@@ -29,17 +30,36 @@ export function ndjsonResponse<T>(
     | {
         onError?: (err: unknown) => T
         onCancel?: () => void
+        signal?: AbortSignal
       }
 ): Response {
   const onError = typeof opts === 'function' ? opts : opts?.onError
   const onCancel = typeof opts === 'object' ? opts?.onCancel : undefined
+  const signal = typeof opts === 'object' ? opts?.signal : undefined
 
   const encoder = new TextEncoder()
+  const iterator = iterable[Symbol.asyncIterator]()
+  const stop = async () => {
+    await iterator.return?.()
+  }
 
   const stream = new ReadableStream({
     async start(controller) {
+      if (signal) {
+        if (signal.aborted) {
+          await stop()
+          controller.close()
+          return
+        }
+        signal.addEventListener('abort', () => {
+          void stop()
+        }, { once: true })
+      }
       try {
-        for await (const item of iterable) {
+        while (true) {
+          const { done, value } = await iterator.next()
+          if (done) break
+          const item = value
           controller.enqueue(encoder.encode(JSON.stringify(item) + '\n'))
         }
       } catch (err) {
@@ -50,8 +70,9 @@ export function ndjsonResponse<T>(
         controller.close()
       }
     },
-    cancel() {
+    async cancel() {
       onCancel?.()
+      await stop()
     },
   })
 

--- a/packages/ts-cli/src/ndjson.ts
+++ b/packages/ts-cli/src/ndjson.ts
@@ -49,7 +49,7 @@ export function ndjsonResponse<T>(
           return
         }
         signal.addEventListener('abort', () => {
-          void stop()
+          void stop().catch(() => {})
         }, { once: true })
       }
       try {


### PR DESCRIPTION
## Summary
- make `AsyncIterator.return()` the public stream cancellation contract across the protocol, engine, exec wrappers, and remote engine client
- keep blocking waits abortable internally by wiring local abort signals through retry backoff, rate-limit sleeps, webhook queue waits, OpenAPI fetches, and NDJSON disconnect teardown
- add regression tests proving early stop interrupts in-flight work in protocol helpers, Stripe source flows, and engine `pipeline_read()` / `pipeline_sync()` paths

## Test plan
- [x] `pnpm --filter @stripe/sync-protocol test`
- [x] `pnpm --filter @stripe/sync-ts-cli test`
- [x] `pnpm --filter @stripe/sync-source-stripe test`
- [x] `pnpm --filter @stripe/sync-engine test`
- [x] `pnpm build`


Made with [Cursor](https://cursor.com)