### PR TITLE
Fix OOM caused by zombie pipelines.

### DIFF
--- a/apps/engine/src/lib/engine.ts
+++ b/apps/engine/src/lib/engine.ts
@@ -576,10 +576,20 @@ export async function createEngine(resolver: ConnectorResolver): Promise<Engine>
 
           const normalizedState = coerceSyncState(opts?.state)
 
-          yield* trackProgress({
-            initial_state: normalizedState,
-            recordCounter,
-          })(limited)
+          try {
+            yield* trackProgress({
+              initial_state: normalizedState,
+              recordCounter,
+            })(limited)
+          } finally {
+            // Ensure split channels + source are torn down (hard deadline is fire-and-forget).
+            const returnP = Promise.all([
+              dataStream[Symbol.asyncIterator]().return?.(),
+              sourceSignals[Symbol.asyncIterator]().return?.(),
+            ]).catch(() => {})
+            const timeoutP = new Promise<void>((r) => setTimeout(r, 2000))
+            await Promise.race([returnP, timeoutP])
+          }
         })()
       )
     },


### PR DESCRIPTION
## Summary

When takeLimits hits the hard deadline it fire-and-forgets iterator.return(), leaving the split() background IIFE still running (blocked on Stripe API calls). Each 30-second Temporal reconcile cycle stacks another leaked pipeline until the process exceeds the heap limit.

## How to test (optional)

Run a full backfill with non-empty Stripe account and verify that no OOM crash after 10+ reconcile cycles.
