### PR TITLE
avoid duplicates in sheets

### DIFF
--- a/packages/destination-google-sheets/src/index.test.ts
+++ b/packages/destination-google-sheets/src/index.test.ts
@@ -496,6 +496,60 @@ describe('native upsert', () => {
     ])
   })
 
+  it('duplicate key within same batch — deduped before flush', async () => {
+    const { sheets, getData } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWith()
+
+    // Both records land in the same batch (default batch_size=50), so no flush in between
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: cat },
+        toAsyncIter([
+          record('customers', { id: 'cus_1', name: 'Alice' }),
+          record('customers', { id: 'cus_1', name: 'Alice Updated' }),
+        ])
+      )
+    )
+
+    const rows = getData(dest.spreadsheetId!, 'customers')!
+    expect(rows).toEqual([
+      ['id', 'name'],
+      ['cus_1', 'Alice Updated'],
+    ])
+  })
+
+  it('concurrent writes — flush-time refresh prevents duplicates', async () => {
+    const { sheets, getData } = createMemorySheets()
+    const dest1 = createDestination(sheets)
+    const cat = catalogWith()
+
+    // dest1 writes cus_1
+    await collect(
+      dest1.write(
+        { config: cfg(), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice' })])
+      )
+    )
+
+    // dest2 simulates a concurrent write() call (e.g. from reconcileLoop)
+    // that has cus_1 buffered. Because it shares the same sheets backend,
+    // flushStream's row map refresh sees the row dest1 already wrote.
+    const dest2 = createDestination(sheets)
+    await collect(
+      dest2.write(
+        { config: cfg({ spreadsheet_id: dest1.spreadsheetId! }), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice Updated' })])
+      )
+    )
+
+    const rows = getData(dest1.spreadsheetId!, 'customers')!
+    expect(rows).toEqual([
+      ['id', 'name'],
+      ['cus_1', 'Alice Updated'],
+    ])
+  })
+
   it('explicit _row_number takes priority over row map lookup', async () => {
     const { sheets, getData } = createMemorySheets()
     const dest = createDestination(sheets)

--- a/packages/destination-google-sheets/src/index.ts
+++ b/packages/destination-google-sheets/src/index.ts
@@ -206,6 +206,11 @@ export function createDestination(
       const rowAssignments: Record<string, Record<string, number>> = {}
       // Row maps for native upsert: rowKey → 1-based row number per stream
       const rowMaps = new Map<string, Map<string, number>>()
+      // Tracks whether we've refreshed the row map from the sheet for each stream
+      // (once per write() call, on first flush)
+      const rowMapRefreshed = new Set<string>()
+      // Pending append index: rowKey → index in appendBuffers for O(1) in-batch dedup
+      const appendKeyIndex = new Map<string, Map<string, number>>()
 
       const ensureHeadersForRecord = async (
         streamName: string,
@@ -236,6 +241,7 @@ export function createDestination(
 
           streamHeaders.set(streamName, headers)
           appendBuffers.set(streamName, [])
+          appendKeyIndex.set(streamName, new Map())
           updateBuffers.set(streamName, [])
         }
 
@@ -275,8 +281,52 @@ export function createDestination(
           updateBuffers.set(streamName, [])
         }
 
-        const appends = appendBuffers.get(streamName)
+        let appends = appendBuffers.get(streamName)
         if (!appends || appends.length === 0) return
+
+        // On the first flush per stream, refresh the row map from the sheet
+        // to catch rows written by concurrent write() calls (e.g. liveLoop +
+        // reconcileLoop) or Temporal activity retries. Only done once per
+        // write() to avoid excessive API calls.
+        const primaryKey = primaryKeys.get(streamName)
+        const headers = streamHeaders.get(streamName)
+        if (
+          !rowMapRefreshed.has(streamName) &&
+          primaryKey &&
+          primaryKey.length > 0 &&
+          headers &&
+          appends.some((e) => e.rowKey)
+        ) {
+          rowMapRefreshed.add(streamName)
+          try {
+            const freshMap = await buildRowMap(sheets, spreadsheetId!, streamName, headers, primaryKey)
+            rowMaps.set(streamName, freshMap)
+
+            const lateUpdates: Array<{ rowNumber: number; values: string[] }> = []
+            const remaining: typeof appends = []
+            for (const entry of appends) {
+              const existing = entry.rowKey ? freshMap.get(entry.rowKey) : undefined
+              if (existing !== undefined) {
+                lateUpdates.push({ rowNumber: existing, values: entry.row })
+              } else {
+                remaining.push(entry)
+              }
+            }
+
+            if (lateUpdates.length > 0) {
+              await updateRows(sheets, spreadsheetId!, streamName, lateUpdates)
+            }
+            appends = remaining
+          } catch {
+            // Sheet read failed — proceed with append (best effort)
+          }
+        }
+
+        if (appends.length === 0) {
+          appendBuffers.set(streamName, [])
+          appendKeyIndex.get(streamName)?.clear()
+          return
+        }
 
         const range = await appendRows(
           sheets,
@@ -292,10 +342,11 @@ export function createDestination(
             const rowNumber = range.startRow + index
             rowAssignments[streamName] ??= {}
             rowAssignments[streamName][rowKey] = rowNumber
-            map?.set(rowKey, rowNumber) // keep row map in sync for subsequent records
+            map?.set(rowKey, rowNumber)
           }
         }
         appendBuffers.set(streamName, [])
+        appendKeyIndex.get(streamName)?.clear()
       }
 
       const flushAll = async () => {
@@ -317,7 +368,7 @@ export function createDestination(
             const rowKey =
               typeof data[ROW_KEY_FIELD] === 'string'
                 ? data[ROW_KEY_FIELD]
-                : primaryKey
+                : primaryKey && primaryKey.length > 0
                   ? serializeRowKey(primaryKey, cleanData)
                   : undefined
 
@@ -331,7 +382,15 @@ export function createDestination(
               if (existingRow !== undefined) {
                 updateBuffers.get(stream)!.push({ rowNumber: existingRow, values: row })
               } else {
-                appendBuffers.get(stream)!.push({ row, rowKey })
+                const buffer = appendBuffers.get(stream)!
+                const keyIdx = appendKeyIndex.get(stream)!
+                const pendingIdx = keyIdx.get(rowKey)
+                if (pendingIdx !== undefined) {
+                  buffer[pendingIdx] = { row, rowKey }
+                } else {
+                  keyIdx.set(rowKey, buffer.length)
+                  buffer.push({ row, rowKey })
+                }
               }
             } else {
               // 3. No key at all — pure append

--- a/packages/destination-google-sheets/src/index.ts
+++ b/packages/destination-google-sheets/src/index.ts
@@ -263,6 +263,7 @@ export function createDestination(
           if (primaryKey && primaryKey.length > 0 && headers) {
             try {
               map = await buildRowMap(sheets, spreadsheetId!, streamName, headers, primaryKey)
+              rowMapRefreshed.add(streamName)
             } catch {
               map = new Map() // sheet doesn't exist yet or is empty
             }

--- a/packages/destination-google-sheets/src/writer.ts
+++ b/packages/destination-google-sheets/src/writer.ts
@@ -210,14 +210,19 @@ export async function createIntroSheet(
   }
 
   const now = new Date().toISOString()
-  const rows = [
+  const rows: string[][] = [
     ['Stripe Sync Engine'],
     [''],
     ['This spreadsheet is managed by Stripe Sync Engine.'],
     ['Data is synced automatically from your Stripe account.'],
     [''],
-    ['Synced streams:'],
-    ...streamNames.map((name) => [`  • ${name}`]),
+    ['Synced streams:', '', 'Unique rows', 'Duplicate rows'],
+    ...streamNames.map((name) => [
+      `  • ${name}`,
+      '',
+      `=COUNTUNIQUE('${name}'!A2:A)`,
+      `=COUNTA('${name}'!A2:A)-COUNTUNIQUE('${name}'!A2:A)`,
+    ]),
     [''],
     [`Last setup: ${now}`],
     [''],
@@ -228,7 +233,7 @@ export async function createIntroSheet(
     sheets.spreadsheets.values.update({
       spreadsheetId,
       range: `'${TITLE}'!A1`,
-      valueInputOption: 'RAW',
+      valueInputOption: 'USER_ENTERED',
       requestBody: { values: rows },
     })
   )


### PR DESCRIPTION
## Summary

- Fix duplicate rows caused by concurrent write() calls 
- Fix within-batch duplicates where two records with the same primary key in the same batch (before flush) both got appended. Pending appends are now tracked and deduplicated before flush.
- I've also added a synced counts on the first page

## New test: 

1) duplicate key within same batch
2) concurrent writes (two destination instances writing to the same spreadsheet)
