### PR TITLE
fix: extract only debug headers and sanitize non-JSON previews

### DIFF
--- a/packages/openapi/index.ts
+++ b/packages/openapi/index.ts
@@ -15,6 +15,7 @@ export {
   buildRetrieveFn,
   resolveTableName,
   StripeApiRequestError,
+  pickDebugHeaders,
 } from './listFnResolver.js'
 export type {
   ListEndpoint,

--- a/packages/openapi/listFnResolver.ts
+++ b/packages/openapi/listFnResolver.ts
@@ -242,6 +242,20 @@ const DEBUG_HEADERS = [
   'stripe-server-environment',
 ]
 
+/**
+ * Extract only the debug-relevant headers from a Response, avoiding
+ * `Object.fromEntries(headers.entries())` which materializes every header
+ * and can silently drop duplicate keys like `set-cookie`.
+ */
+export function pickDebugHeaders(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const key of DEBUG_HEADERS) {
+    const v = headers.get(key)
+    if (v) out[key] = v
+  }
+  return out
+}
+
 function extractErrorMessage(
   body: unknown,
   status: number,
@@ -288,8 +302,7 @@ async function readJson(response: Response): Promise<unknown> {
 
 function assertOk(response: Response, body: unknown, method: string, path: string): void {
   if (!response.ok) {
-    const responseHeaders = Object.fromEntries(response.headers.entries())
-    throw new StripeApiRequestError(response.status, body, method, path, responseHeaders)
+    throw new StripeApiRequestError(response.status, body, method, path, pickDebugHeaders(response.headers))
   }
 }
 

--- a/packages/source-stripe/src/client.test.ts
+++ b/packages/source-stripe/src/client.test.ts
@@ -51,7 +51,8 @@ describe('makeClient', () => {
       '/v1/account'
     )
     expect(err.status).toBe(401)
-    expect(err.message).toBe('Invalid API Key')
+    expect(err.message).toContain('Invalid API Key')
+    expect(err.message).toContain('GET /v1/account (401)')
   })
 
   it('retries transient GET failures and eventually succeeds', async () => {

--- a/packages/source-stripe/src/client.ts
+++ b/packages/source-stripe/src/client.ts
@@ -3,6 +3,7 @@ import {
   StripeWebhookEndpointSchema,
   StripeApiListSchema,
   StripeApiRequestError,
+  pickDebugHeaders,
   type StripeAccount,
   type StripeApiList,
   type StripeWebhookEndpoint,
@@ -71,24 +72,25 @@ export function makeClient(
       env
     )
 
-    const responseHeaders = Object.fromEntries(response.headers.entries())
+    const debugHeaders = pickDebugHeaders(response.headers)
 
     const text = await response.text()
     let json: unknown
     try {
       json = JSON.parse(text)
     } catch {
+      const preview = text.slice(0, 200).replace(/[\r\n]+/g, '\\n')
       throw new StripeApiRequestError(
         response.status,
-        { error: { message: `Non-JSON response: ${text.slice(0, 200)}` } },
+        { error: { message: `Non-JSON response: ${preview}` } },
         method,
         path,
-        responseHeaders
+        debugHeaders
       )
     }
 
     if (!response.ok) {
-      throw new StripeApiRequestError(response.status, json, method, path, responseHeaders)
+      throw new StripeApiRequestError(response.status, json, method, path, debugHeaders)
     }
 
     return json


### PR DESCRIPTION
## Summary

Fixup for #289 — addresses review feedback:

- **pickDebugHeaders helper**: Replaces `Object.fromEntries(response.headers.entries())` with a targeted extraction of only the debug-relevant headers (`request-id`, `stripe-should-retry`, `stripe-action-id`, `stripe-server-environment`) using `response.headers.get()`. This avoids materializing all response headers and sidesteps the case-sensitivity / duplicate-key pitfalls of `Object.fromEntries`.
- **Non-JSON body sanitization**: Escapes `\r\n` sequences in the truncated non-JSON response preview so HTML error pages (502s, proxy errors) don't blow up structured log lines.
- **Test fix**: Updates the `client.test.ts` assertion to match the new enriched error message format (`toContain` instead of `toBe`), and also asserts the context suffix is present.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm --filter @stripe/sync-openapi test` — 40/40 pass
- [x] `pnpm --filter @stripe/sync-source-stripe test` — 100/100 pass


Made with [Cursor](https://cursor.com)