### PR TITLE
feat: add source vs postgres reconciliation counts script

### DIFF
--- a/scripts/compare-reconciliation-counts.js
+++ b/scripts/compare-reconciliation-counts.js
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
+const SQL_FILE = path.join(SCRIPT_DIR, 'reconciliation-counts-postgres.sql')
+
+function parseArgs(argv) {
+  const args = {}
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    const next = argv[i + 1]
+
+    if (arg === '--source-csv') {
+      args.sourceCsv = next
+      i += 1
+      continue
+    }
+
+    if (arg === '--db-url') {
+      args.dbUrl = next
+      i += 1
+      continue
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      args.help = true
+      continue
+    }
+
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+
+  return args
+}
+
+function usage() {
+  return [
+    'Usage:',
+    '  node scripts/compare-reconciliation-counts.js \\',
+    '    --source-csv path/to/source-counts.csv \\',
+    '    --db-url postgresql://user:pass@host:5432/db',
+    '',
+    'Options:',
+    '  --source-csv        Required. CSV exported from the source query.',
+    '  --db-url            Optional. Falls back to DATABASE_URL or POSTGRES_URL.',
+  ].join('\n')
+}
+
+function parseCsv(text) {
+  const rows = []
+  let row = []
+  let field = ''
+  let inQuotes = false
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i]
+
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"'
+          i += 1
+        } else {
+          inQuotes = false
+        }
+      } else {
+        field += ch
+      }
+      continue
+    }
+
+    if (ch === '"') {
+      inQuotes = true
+      continue
+    }
+
+    if (ch === ',') {
+      row.push(field)
+      field = ''
+      continue
+    }
+
+    if (ch === '\n') {
+      row.push(field)
+      if (row.some((value) => value.length > 0)) {
+        rows.push(row)
+      }
+      row = []
+      field = ''
+      continue
+    }
+
+    if (ch === '\r') {
+      continue
+    }
+
+    field += ch
+  }
+
+  row.push(field)
+  if (row.some((value) => value.length > 0)) {
+    rows.push(row)
+  }
+
+  return rows
+}
+
+function loadCountsFromCsvText(text, label) {
+  const rows = parseCsv(text)
+  if (rows.length === 0) {
+    throw new Error(`${label} CSV is empty`)
+  }
+
+  const header = rows[0]
+  const resourceIndex = header.indexOf('resource')
+  const countIndex = header.indexOf('n')
+
+  if (resourceIndex === -1 || countIndex === -1) {
+    throw new Error(`${label} CSV must contain "resource" and "n" columns`)
+  }
+
+  const counts = new Map()
+  for (const row of rows.slice(1)) {
+    const resource = row[resourceIndex]?.trim()
+    const rawCount = row[countIndex]?.trim()
+    if (!resource) continue
+    if (!rawCount) {
+      throw new Error(`${label} CSV has an empty count for resource "${resource}"`)
+    }
+    counts.set(resource, BigInt(rawCount))
+  }
+
+  return counts
+}
+
+function runPostgresQuery({ dbUrl }) {
+  const args = [dbUrl, '--no-psqlrc', '--csv', '-f', SQL_FILE]
+
+  const result = spawnSync('psql', args, {
+    encoding: 'utf8',
+    env: process.env,
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `psql exited with status ${result.status}`)
+  }
+
+  return result.stdout
+}
+
+function formatTable(rows) {
+  const headers = ['resource', 'source_n', 'postgres_n', 'delta', 'status']
+  const stringRows = rows.map((row) => [
+    row.resource,
+    row.sourceCount ?? '',
+    row.postgresCount ?? '',
+    row.delta ?? '',
+    row.status,
+  ])
+
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...stringRows.map((row) => row[index].length))
+  )
+
+  const separator = widths.map((width) => '-'.repeat(width)).join('-+-')
+  const formatRow = (cells) =>
+    cells
+      .map((cell, index) => {
+        const alignRight = index > 0 && index < 4
+        return alignRight ? cell.padStart(widths[index]) : cell.padEnd(widths[index])
+      })
+      .join(' | ')
+
+  return [formatRow(headers), separator, ...stringRows.map(formatRow)].join('\n')
+}
+
+function buildComparisonRows(sourceCounts, postgresCounts) {
+  const resources = new Set([...sourceCounts.keys(), ...postgresCounts.keys()])
+
+  return [...resources]
+    .sort((left, right) => left.localeCompare(right))
+    .map((resource) => {
+      const source = sourceCounts.get(resource)
+      const postgres = postgresCounts.get(resource)
+      const comparable = source !== undefined && postgres !== undefined
+      const delta = comparable ? postgres - source : null
+      const status =
+        source === undefined
+          ? 'missing_in_source'
+          : postgres === undefined
+            ? 'missing_in_postgres'
+            : delta === 0n
+              ? 'match'
+              : 'diff'
+
+      return {
+        resource,
+        sourceCount: source?.toString() ?? null,
+        postgresCount: postgres?.toString() ?? null,
+        delta: delta?.toString() ?? null,
+        status,
+      }
+    })
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+
+  if (args.help) {
+    console.log(usage())
+    return
+  }
+
+  if (!args.sourceCsv) {
+    throw new Error('Missing required argument: --source-csv')
+  }
+
+  const dbUrl = args.dbUrl ?? process.env.DATABASE_URL ?? process.env.POSTGRES_URL
+  if (!dbUrl) {
+    throw new Error('Provide --db-url or set DATABASE_URL / POSTGRES_URL')
+  }
+
+  const sourceCsvText = readFileSync(args.sourceCsv, 'utf8')
+  const sourceCounts = loadCountsFromCsvText(sourceCsvText, 'Source')
+
+  const postgresCsvText = runPostgresQuery({
+    dbUrl,
+  })
+
+  const postgresCounts = loadCountsFromCsvText(postgresCsvText, 'Postgres')
+  const rows = buildComparisonRows(sourceCounts, postgresCounts)
+  const mismatchCount = rows.filter((row) => row.status !== 'match').length
+  const matchCount = rows.length - mismatchCount
+
+  console.log(
+    [
+      `resources compared: ${rows.length}`,
+      `matches: ${matchCount}`,
+      `differences: ${mismatchCount}`,
+    ].join('\n')
+  )
+  console.log('')
+  console.log(formatTable(rows))
+
+  if (mismatchCount > 0) {
+    process.exitCode = 1
+  }
+}
+
+try {
+  main()
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  console.error(message)
+  console.error('')
+  console.error(usage())
+  process.exit(1)
+}

--- a/scripts/reconciliation-counts-postgres.sql
+++ b/scripts/reconciliation-counts-postgres.sql
@@ -1,0 +1,86 @@
+-- Reconciliation counts for sync-engine Postgres tables.
+--
+-- This destination database is assumed to already be scoped to the merchant
+-- and mode you want to reconcile, so this query counts all rows in each table.
+--
+-- Usage:
+--   psql "$DATABASE_URL" --csv -f scripts/reconciliation-counts-postgres.sql
+
+SELECT *
+FROM (
+  SELECT 'customers' AS resource, count(*) AS n
+  FROM public.customers
+
+  UNION ALL
+  SELECT 'payment_intents', count(*)
+  FROM public.payment_intents
+
+  UNION ALL
+  SELECT 'invoices', count(*)
+  FROM public.invoices
+
+  UNION ALL
+  SELECT 'invoiceitems', count(*)
+  FROM public.invoiceitems
+
+  UNION ALL
+  SELECT 'subscriptions', count(*)
+  FROM public.subscriptions
+
+  UNION ALL
+  SELECT 'plans', count(*)
+  FROM public.plans
+
+  UNION ALL
+  SELECT 'products', count(*)
+  FROM public.products
+
+  UNION ALL
+  SELECT 'payment_links', count(*)
+  FROM public.payment_links
+
+  UNION ALL
+  SELECT 'payment_method_domains', count(*)
+  FROM public.payment_method_domains
+
+  UNION ALL
+  SELECT 'tax_rates', count(*)
+  FROM public.tax_rates
+
+  UNION ALL
+  SELECT 'tax_ids', count(*)
+  FROM public.tax_ids
+
+  UNION ALL
+  SELECT 'file_links', count(*)
+  FROM public.file_links
+
+  UNION ALL
+  SELECT 'quotes', count(*)
+  FROM public.quotes
+
+  UNION ALL
+  SELECT 'promotion_codes', count(*)
+  FROM public.promotion_codes
+
+  UNION ALL
+  SELECT 'payment_methods', count(*)
+  FROM public.payment_methods
+
+  UNION ALL
+  SELECT 'climate_orders', count(*)
+  FROM public.climate_orders
+
+  UNION ALL
+  SELECT 'checkout_sessions', count(*)
+  FROM public.checkout_sessions
+
+  UNION ALL
+  SELECT 'prices', count(*)
+  FROM public.prices
+
+  UNION ALL
+  SELECT 'treasury_financial_accounts', count(*)
+  FROM public.treasury_financial_accounts
+) q
+ORDER BY resource;


### PR DESCRIPTION
## Summary
- add a reusable SQL query to count the relevant sync-engine Postgres tables in a scoped destination database
- add a small Node CLI that reads a source CSV, runs the Postgres counts query via psql, and prints a formatted comparison table
- return a non-zero exit code when counts differ so the script is automation-friendly

## Validation
- `node --check scripts/compare-reconciliation-counts.js`
- `pnpm exec eslint scripts/compare-reconciliation-counts.js`
- manual run of the comparison script against a scoped Postgres database and a local source CSV export