### PR TITLE
fix: raise sync-engine serve header limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -610,13 +610,14 @@ jobs:
             exit 0
           fi
           pnpm --filter @stripe/sync-e2e exec vitest run \
+            --exclude 'header-size-docker.test.ts' \
             --exclude 'service-docker.test.ts' \
             --exclude 'test-server-all-api.test.ts' \
             --exclude 'test-server-sync.test.ts' \
             --exclude 'test-sync-e2e.test.ts' \
             --exclude 'test-sync-engine.test.ts' \
             --exclude 'test-e2e-network.test.ts' \
-            --exclude 'test-disconnect.test.ts'  # ↑ run in main test job
+            --exclude 'test-disconnect.test.ts'  # ↑ run in dedicated Docker / main jobs
         env:
           STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
           POSTGRES_URL: 'postgres://postgres:postgres@localhost:55432/postgres'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,6 +518,12 @@ jobs:
           DISCONNECT_TEST_DOCKER_HOST_NETWORK: '1'
           ENGINE_IMAGE: 'ghcr.io/${{ github.repository }}:${{ github.sha }}-arm64'
 
+      - name: Header size serve test (Docker)
+        run: |
+          pnpm --filter @stripe/sync-e2e exec vitest run header-size-docker.test.ts
+        env:
+          ENGINE_IMAGE: 'ghcr.io/${{ github.repository }}:${{ github.sha }}-arm64'
+
       - name: Smokescreen proxy e2e
         run: |
           if [ -z "${STRIPE_API_KEY:-}" ]; then

--- a/apps/engine/src/api/index.ts
+++ b/apps/engine/src/api/index.ts
@@ -6,6 +6,7 @@ import sheetsDestination from '@stripe/sync-destination-google-sheets'
 import { createConnectorResolver } from '../lib/index.js'
 import { createApp } from './app.js'
 import { logger } from '../logger.js'
+import { ENGINE_SERVER_OPTIONS } from '../http-server-options.js'
 
 const port = Number(process.env.PORT || 3001)
 
@@ -39,11 +40,7 @@ async function main() {
       {
         fetch: app.fetch,
         port,
-        // Pipeline config and connector state are passed via the X-Pipeline header.
-        // Node.js defaults to 16 KB which caps state at ~250 entries — too small for
-        // connectors like google-sheets that carry row mappings. 50 MB is a conservative
-        // ceiling; typical headers remain small. See docs/engine/header-size-limits.md
-        serverOptions: { maxHeaderSize: 50 * 1024 * 1024 },
+        serverOptions: ENGINE_SERVER_OPTIONS,
       },
       (info) => {
         logger.info(

--- a/apps/engine/src/http-server-options.ts
+++ b/apps/engine/src/http-server-options.ts
@@ -1,7 +1,15 @@
+import type { ServerOptions as HttpServerOptions } from 'node:http'
+
+const KB = 1024
+const MB = 1024 * KB
+const ENGINE_MAX_HEADER_SIZE_MB = 50
+
+export const ENGINE_MAX_HEADER_SIZE_BYTES = ENGINE_MAX_HEADER_SIZE_MB * MB
+
 // Pipeline config and connector state are passed via HTTP headers.
 // Node.js defaults to 16 KB which is too small for resumed syncs that carry
 // both X-Pipeline and X-State. Keep the CLI serve path and API entrypoint on
 // the same ceiling so the deployed container and local API behave the same way.
 export const ENGINE_SERVER_OPTIONS = {
-  maxHeaderSize: 50 * 1024 * 1024,
-} as const
+  maxHeaderSize: ENGINE_MAX_HEADER_SIZE_BYTES,
+} satisfies Pick<HttpServerOptions, 'maxHeaderSize'>

--- a/apps/engine/src/http-server-options.ts
+++ b/apps/engine/src/http-server-options.ts
@@ -1,0 +1,7 @@
+// Pipeline config and connector state are passed via HTTP headers.
+// Node.js defaults to 16 KB which is too small for resumed syncs that carry
+// both X-Pipeline and X-State. Keep the CLI serve path and API entrypoint on
+// the same ceiling so the deployed container and local API behave the same way.
+export const ENGINE_SERVER_OPTIONS = {
+  maxHeaderSize: 50 * 1024 * 1024,
+} as const

--- a/apps/engine/src/serve-command.ts
+++ b/apps/engine/src/serve-command.ts
@@ -4,6 +4,7 @@ import { createApp } from './api/app.js'
 import { parseJsonOrFile } from '@stripe/sync-ts-cli'
 import { defaultConnectors } from './lib/default-connectors.js'
 import { logger } from './logger.js'
+import { ENGINE_SERVER_OPTIONS } from './http-server-options.js'
 
 export async function serveAction(opts: {
   port?: number
@@ -20,7 +21,14 @@ export async function serveAction(opts: {
     npm: opts.connectorsFromNpm ?? false,
   })
   const app = await createApp(resolver)
-  serve({ fetch: app.fetch, port }, (info) => {
-    logger.info({ port: info.port }, `Sync Engine listening on http://localhost:${info.port}`)
-  })
+  serve(
+    {
+      fetch: app.fetch,
+      port,
+      serverOptions: ENGINE_SERVER_OPTIONS,
+    },
+    (info) => {
+      logger.info({ port: info.port }, `Sync Engine listening on http://localhost:${info.port}`)
+    }
+  )
 }

--- a/e2e/header-size-docker.test.ts
+++ b/e2e/header-size-docker.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { execFileSync, spawnSync } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import { createServer, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import path from 'node:path'
@@ -16,13 +16,54 @@ interface MockStripeServer {
 
 interface EngineContainer {
   url: string
-  logs: () => string
-  kill: () => void
+  logs: () => Promise<string>
+  kill: () => Promise<void>
 }
 
-function hasDocker(): boolean {
+async function runCommand(
+  command: string,
+  args: string[],
+  options: {
+    cwd?: string
+    allowFailure?: boolean
+  } = {}
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+    child.on('error', reject)
+    child.on('close', (exitCode) => {
+      if (exitCode === 0 || options.allowFailure) {
+        resolve({ stdout, stderr, exitCode })
+        return
+      }
+
+      reject(
+        new Error(
+          [`Command failed: ${command} ${args.join(' ')}`, stdout.trim(), stderr.trim()]
+            .filter(Boolean)
+            .join('\n\n')
+        )
+      )
+    })
+  })
+}
+
+async function hasDocker(): Promise<boolean> {
   try {
-    execFileSync('docker', ['info'], { stdio: 'ignore' })
+    await runCommand('docker', ['info'])
     return true
   } catch {
     return false
@@ -33,9 +74,13 @@ function getPort(): number {
   return 10_000 + Math.floor(Math.random() * 50_000)
 }
 
-function getContainerLogs(containerName: string): string {
-  const result = spawnSync('docker', ['logs', containerName], { encoding: 'utf8' })
-  return `${result.stdout ?? ''}${result.stderr ?? ''}`.trim()
+async function getContainerLogs(containerName: string): Promise<string> {
+  const result = await runCommand('docker', ['logs', containerName], { allowFailure: true })
+  return `${result.stdout}${result.stderr}`.trim()
+}
+
+async function removeContainer(containerName: string): Promise<void> {
+  await runCommand('docker', ['rm', '-f', containerName], { allowFailure: true })
 }
 
 async function startMockStripeApi(): Promise<MockStripeServer> {
@@ -131,14 +176,13 @@ async function startEngineDocker(port: number): Promise<EngineContainer> {
   const containerName = `header-size-test-${port}`
 
   if (!process.env.ENGINE_IMAGE) {
-    execFileSync('docker', ['build', '--target', 'engine', '-t', image, '.'], {
+    await runCommand('docker', ['build', '--target', 'engine', '-t', image, '.'], {
       cwd: REPO_ROOT,
-      stdio: 'inherit',
     })
   }
 
   try {
-    execFileSync(
+    await runCommand(
       'docker',
       [
         'run',
@@ -159,30 +203,19 @@ async function startEngineDocker(port: number): Promise<EngineContainer> {
       ],
       {
         cwd: REPO_ROOT,
-        stdio: 'ignore',
       }
     )
     await waitForServer(`http://localhost:${port}`)
   } catch (error) {
-    const logs = getContainerLogs(containerName)
-    try {
-      execFileSync('docker', ['rm', '-f', containerName], { stdio: 'ignore' })
-    } catch {
-      // ignore cleanup failures
-    }
+    const logs = await getContainerLogs(containerName)
+    await removeContainer(containerName)
     throw new Error(`Failed to start engine container.\n\n${logs || String(error)}`)
   }
 
   return {
     url: `http://localhost:${port}`,
     logs: () => getContainerLogs(containerName),
-    kill: () => {
-      try {
-        execFileSync('docker', ['rm', '-f', containerName], { stdio: 'ignore' })
-      } catch {
-        // ignore cleanup failures
-      }
-    },
+    kill: () => removeContainer(containerName),
   }
 }
 
@@ -191,7 +224,7 @@ describe('docker serve header size', () => {
   let engine: EngineContainer
 
   beforeAll(async () => {
-    if (!hasDocker()) {
+    if (!(await hasDocker())) {
       throw new Error('Docker is required for header-size docker e2e tests')
     }
 
@@ -200,7 +233,7 @@ describe('docker serve header size', () => {
   }, 180_000)
 
   afterAll(async () => {
-    engine?.kill()
+    await engine?.kill()
     await mockStripe?.close()
   })
 
@@ -213,8 +246,9 @@ describe('docker serve header size', () => {
       headers: { 'X-Pipeline': pipelineHeader },
     })
     const body = await res.text()
+    const logs = res.status === 200 ? '' : await engine.logs()
 
-    expect(res.status, engine.logs()).toBe(200)
+    expect(res.status, logs).toBe(200)
     expect(res.headers.get('content-type')).toContain('application/x-ndjson')
     expect(body).toContain('"type":"connection_status"')
   }, 30_000)

--- a/e2e/header-size-docker.test.ts
+++ b/e2e/header-size-docker.test.ts
@@ -1,0 +1,221 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import path from 'node:path'
+import { BUNDLED_API_VERSION } from '@stripe/sync-openapi'
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..')
+const DEFAULT_NODE_MAX_HEADER_SIZE = 16 * 1024
+const TEST_HEADER_SIZE = 20 * 1024
+
+interface MockStripeServer {
+  url: string
+  close: () => Promise<void>
+}
+
+interface EngineContainer {
+  url: string
+  logs: () => string
+  kill: () => void
+}
+
+function hasDocker(): boolean {
+  try {
+    execFileSync('docker', ['info'], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function getPort(): number {
+  return 10_000 + Math.floor(Math.random() * 50_000)
+}
+
+function getContainerLogs(containerName: string): string {
+  const result = spawnSync('docker', ['logs', containerName], { encoding: 'utf8' })
+  return `${result.stdout ?? ''}${result.stderr ?? ''}`.trim()
+}
+
+async function startMockStripeApi(): Promise<MockStripeServer> {
+  let serverRef: Server | null = null
+
+  const url = await new Promise<string>((resolve) => {
+    serverRef = createServer((req, res) => {
+      const requestUrl = new URL(req.url ?? '/', 'http://localhost')
+
+      if (requestUrl.pathname === '/v1/account') {
+        const body = JSON.stringify({
+          id: 'acct_test_mock',
+          object: 'account',
+          charges_enabled: true,
+          payouts_enabled: true,
+          details_submitted: true,
+        })
+        res.statusCode = 200
+        res.setHeader('Content-Type', 'application/json')
+        res.setHeader('Content-Length', Buffer.byteLength(body))
+        res.end(body)
+        return
+      }
+
+      res.statusCode = 404
+      res.end('not_found')
+    })
+
+    serverRef.listen(0, '0.0.0.0', () => {
+      resolve(`http://localhost:${(serverRef!.address() as AddressInfo).port}`)
+    })
+  })
+
+  return {
+    url,
+    close: () =>
+      new Promise((resolve, reject) => {
+        serverRef?.close((err) => (err ? reject(err) : resolve()))
+      }),
+  }
+}
+
+function dockerVisibleUrl(url: string): string {
+  const normalized = new URL(url)
+  if (normalized.hostname === 'localhost' || normalized.hostname === '127.0.0.1') {
+    normalized.hostname = 'host.docker.internal'
+  }
+  return normalized.toString()
+}
+
+function makePipelineHeader(targetBytes: number, mockStripeUrl: string): string {
+  const base = {
+    source: {
+      type: 'stripe',
+      stripe: {
+        api_key: 'sk_test_fake',
+        api_version: BUNDLED_API_VERSION,
+        base_url: mockStripeUrl,
+      },
+    },
+    destination: {
+      type: 'postgres',
+      postgres: {
+        connection_string: 'postgres://user:pass@127.0.0.1:1/testdb',
+        schema: 'header_size_test',
+      },
+    },
+    streams: [{ name: 'customers' }],
+    _padding: '',
+  }
+
+  const shellSize = Buffer.byteLength(JSON.stringify(base))
+  base._padding = 'x'.repeat(Math.max(0, targetBytes - shellSize))
+  return JSON.stringify(base)
+}
+
+async function waitForServer(url: string, timeout = 60_000): Promise<void> {
+  const deadline = Date.now() + timeout
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${url}/health`)
+      if (res.ok) return
+    } catch {
+      // keep polling until timeout
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500))
+  }
+  throw new Error(`Server at ${url} did not become healthy in ${timeout}ms`)
+}
+
+async function startEngineDocker(port: number): Promise<EngineContainer> {
+  const image = process.env.ENGINE_IMAGE ?? 'sync-engine:header-size-test'
+  const containerName = `header-size-test-${port}`
+
+  if (!process.env.ENGINE_IMAGE) {
+    execFileSync('docker', ['build', '--target', 'engine', '-t', image, '.'], {
+      cwd: REPO_ROOT,
+      stdio: 'inherit',
+    })
+  }
+
+  try {
+    execFileSync(
+      'docker',
+      [
+        'run',
+        '-d',
+        '--name',
+        containerName,
+        '--entrypoint',
+        'node',
+        '-e',
+        'PORT=3000',
+        '-p',
+        `${port}:3000`,
+        '--add-host',
+        'host.docker.internal:host-gateway',
+        image,
+        '/app/dist/cli/index.js',
+        'serve',
+      ],
+      {
+        cwd: REPO_ROOT,
+        stdio: 'ignore',
+      }
+    )
+    await waitForServer(`http://localhost:${port}`)
+  } catch (error) {
+    const logs = getContainerLogs(containerName)
+    try {
+      execFileSync('docker', ['rm', '-f', containerName], { stdio: 'ignore' })
+    } catch {
+      // ignore cleanup failures
+    }
+    throw new Error(`Failed to start engine container.\n\n${logs || String(error)}`)
+  }
+
+  return {
+    url: `http://localhost:${port}`,
+    logs: () => getContainerLogs(containerName),
+    kill: () => {
+      try {
+        execFileSync('docker', ['rm', '-f', containerName], { stdio: 'ignore' })
+      } catch {
+        // ignore cleanup failures
+      }
+    },
+  }
+}
+
+describe('docker serve header size', () => {
+  let mockStripe: MockStripeServer
+  let engine: EngineContainer
+
+  beforeAll(async () => {
+    if (!hasDocker()) {
+      throw new Error('Docker is required for header-size docker e2e tests')
+    }
+
+    mockStripe = await startMockStripeApi()
+    engine = await startEngineDocker(getPort())
+  }, 180_000)
+
+  afterAll(async () => {
+    engine?.kill()
+    await mockStripe?.close()
+  })
+
+  it('accepts a pipeline header larger than Node default when run via the CLI serve command', async () => {
+    const pipelineHeader = makePipelineHeader(TEST_HEADER_SIZE, dockerVisibleUrl(mockStripe.url))
+    expect(Buffer.byteLength(pipelineHeader)).toBeGreaterThan(DEFAULT_NODE_MAX_HEADER_SIZE)
+
+    const res = await fetch(`${engine.url}/pipeline_check`, {
+      method: 'POST',
+      headers: { 'X-Pipeline': pipelineHeader },
+    })
+    const body = await res.text()
+
+    expect(res.status, engine.logs()).toBe(200)
+    expect(res.headers.get('content-type')).toContain('application/x-ndjson')
+    expect(body).toContain('"type":"connection_status"')
+  }, 30_000)
+})


### PR DESCRIPTION
## Summary
- apply the 50 MB Node header limit to the CLI `serve` path used by the deployed engine container
- centralize the server option so the API entrypoint and CLI serve path stay in sync
- add a dockerized black-box e2e that builds the `engine` image and runs `node /app/dist/cli/index.js serve` before asserting a >16 KB header is accepted

## Testing
- `pnpm build`
- `pnpm --filter @stripe/sync-engine exec vitest run src/api/header-size.test.ts`
- `pnpm --filter @stripe/sync-e2e exec vitest run header-size-docker.test.ts`

## Context
Production was hitting HTTP 431 on resumed `/pipeline_sync` requests because the deployed CLI `serve` entrypoint still used Node's default 16 KB max header size while the non-prod API entrypoint had already been raised.