### PR TITLE
optimize boundry

### DIFF
--- a/packages/protocol/src/utils/binary-subdivision.test.ts
+++ b/packages/protocol/src/utils/binary-subdivision.test.ts
@@ -28,19 +28,19 @@ describe('subdivideRanges', () => {
 
   it('splits older remainder into N equal segments', () => {
     const remaining: Range[] = [{ gte: iso(0), lt: iso(1000), cursor: 'cur_1' }]
-    const out = subdivideRanges(remaining, new Map([[remaining[0], 900]]), N)
-    // boundary + N segments of [0, 900)
-    expect(out[0]).toEqual({ gte: iso(900), lt: iso(901), cursor: 'cur_1' })
-    const segments = out.slice(1)
+    const segments = subdivideRanges(remaining, new Map([[remaining[0], 900]]), N)
+    // N segments of [0, 900)
+    expect(segments[segments.length - 1]).toEqual({ gte: iso(450), lt: iso(901), cursor: 'cur_1' })
     expect(segments).toHaveLength(DEFAULT_SUBDIVISION_FACTOR)
     // All segments are contiguous and cover [0, 900)
     expect(toUnixSeconds(segments[0].gte)).toBe(0)
-    expect(toUnixSeconds(segments[segments.length - 1].lt)).toBe(900)
+    expect(toUnixSeconds(segments[segments.length - 1].lt)).toBe(901)
     for (let i = 1; i < segments.length; i++) {
       expect(segments[i].gte).toBe(segments[i - 1].lt)
     }
-    // All cursors are null
-    for (const s of segments) expect(s.cursor).toBeNull()
+    for (let i = 0; i < segments.length - 1; i++) {
+      expect(segments[i].cursor).toBeNull()
+    }
   })
 
   it('does not subdivide when the observed point is at or below the range start', () => {
@@ -52,17 +52,13 @@ describe('subdivideRanges', () => {
   it('handles multiple ranges: only cursor + lastObserved entries subdivide', () => {
     const a: Range = { gte: iso(0), lt: iso(30), cursor: null }
     const b: Range = { gte: iso(30), lt: iso(60), cursor: 'cur_b' }
-    const c: Range = { gte: iso(60), lt: iso(120), cursor: 'cur_c' }
-    const out = subdivideRanges([a, b, c], new Map([[c, 90]]), N)
+    const c: Range = { gte: iso(60), lt: iso(160), cursor: 'cur_c' }
+    const out = subdivideRanges([a, b, c], new Map([[c, 120]]), N)
     // a passes through, b passes through (no lastObserved), c subdivides
     expect(out[0]).toEqual(a)
     expect(out[1]).toEqual(b)
-    expect(out[2]).toEqual({ gte: iso(90), lt: iso(91), cursor: 'cur_c' })
-    // Remaining segments cover [60, 90) with N segments (capped to span)
-    const segments = out.slice(3)
-    expect(segments.length).toBeGreaterThanOrEqual(1)
-    expect(toUnixSeconds(segments[0].gte)).toBe(60)
-    expect(toUnixSeconds(segments[segments.length - 1].lt)).toBe(90)
+    expect(out[2]).toEqual({ gte: iso(60), lt: iso(90), cursor: null })
+    expect(out[3]).toEqual({ gte: iso(90), lt: iso(121), cursor: 'cur_c' })
   })
 
   it('passes through a range with cursor but no lastObserved entry', () => {
@@ -70,20 +66,21 @@ describe('subdivideRanges', () => {
     expect(subdivideRanges([range], new Map(), N)).toEqual([range])
   })
 
-  it('emits single segment when older remainder is 1 second', () => {
+  it('emits single segment when older remainder is 30 second', () => {
     const remaining: Range[] = [{ gte: iso(1000), lt: iso(1002), cursor: 'cur_tail' }]
     const out = subdivideRanges(remaining, new Map([[remaining[0], 1001]]), N)
     expect(out).toEqual([
-      { gte: iso(1001), lt: iso(1002), cursor: 'cur_tail' },
-      { gte: iso(1000), lt: iso(1001), cursor: null },
+      { gte: iso(1000), lt: iso(1002), cursor: 'cur_tail' }
     ])
   })
 
-  it('produces boundary + N segments for a splittable range', () => {
+  it('N segments for a splittable range', () => {
     const remaining: Range[] = [{ gte: iso(0), lt: iso(1000), cursor: 'cur_dense' }]
     const out = subdivideRanges(remaining, new Map([[remaining[0], 900]]), N)
-    expect(out).toHaveLength(1 + DEFAULT_SUBDIVISION_FACTOR) // boundary + N segments
-    expect(out[0]).toEqual({ gte: iso(900), lt: iso(901), cursor: 'cur_dense' })
+    expect(out).toHaveLength(DEFAULT_SUBDIVISION_FACTOR) // boundary + N segments
+    expect(out[0]).toEqual({ gte: iso(0), lt: iso(450), cursor: null })
+    expect(out[1]).toEqual({ gte: iso(450), lt: iso(901), cursor: 'cur_dense' })
+
     // Segments cover [0, 900) contiguously
     for (let i = 2; i < out.length; i++) {
       expect(out[i].gte).toBe(out[i - 1].lt)
@@ -91,14 +88,10 @@ describe('subdivideRanges', () => {
   })
 
   it('keeps the entire last observed second in the cursor-backed boundary range', () => {
-    const remaining: Range[] = [{ gte: iso(1000), lt: iso(1010), cursor: 'cur_same_second' }]
-    const out = subdivideRanges(remaining, new Map([[remaining[0], 1008]]), N)
-    expect(out[0]).toEqual({ gte: iso(1008), lt: iso(1009), cursor: 'cur_same_second' })
-    // Remaining segments cover [1000, 1008) — 8 seconds, capped at min(N, 8)
-    const segments = out.slice(1)
-    expect(segments.length).toBe(Math.min(DEFAULT_SUBDIVISION_FACTOR, 8))
-    expect(toUnixSeconds(segments[0].gte)).toBe(1000)
-    expect(toUnixSeconds(segments[segments.length - 1].lt)).toBe(1008)
+    const remaining: Range[] = [{ gte: iso(1000), lt: iso(2000), cursor: 'cur_same_second' }]
+    const out = subdivideRanges(remaining, new Map([[remaining[0], 1900]]), N)
+    expect(out[0]).toEqual({ gte: iso(1000), lt: iso(1450), cursor: null })
+    expect(out[1]).toEqual({ gte: iso(1450), lt: iso(1901), cursor: 'cur_same_second' })
   })
 })
 
@@ -130,12 +123,12 @@ function simulateRound(ranges: Range[], density: (ts: number) => number, pageSiz
 
 describe('binary subdivision: data distribution scenarios', () => {
   it('uniform density: splits into boundary + N segments', () => {
-    const ranges: Range[] = [{ gte: iso(0), lt: iso(1000), cursor: null }]
+    const ranges: Range[] = [{ gte: iso(0), lt: iso(61000), cursor: null }]
     const round1 = simulateRound(ranges, () => 1)
-    expect(round1.length).toBe(1 + DEFAULT_SUBDIVISION_FACTOR) // boundary + N segments
-    expect(round1[0].cursor).not.toBeNull() // boundary keeps cursor
-    for (let i = 1; i < round1.length; i++) {
-      expect(round1[i].cursor).toBeNull() // segments start fresh
+    expect(round1.length).toBe(DEFAULT_SUBDIVISION_FACTOR) // segments
+    expect(round1[round1.length - 1].cursor).not.toBeNull() // boundary is part of the last segment
+    for (let i = 0; i < round1.length - 1; i++) {
+      expect(round1[i].cursor).toBeNull() // all except last segment start fresh
     }
   })
 

--- a/packages/protocol/src/utils/binary-subdivision.ts
+++ b/packages/protocol/src/utils/binary-subdivision.ts
@@ -49,16 +49,17 @@ export function toIso(unixSeconds: number): string {
 export const DEFAULT_SUBDIVISION_FACTOR = 2
 
 /**
- * Subdivide ranges that have a cursor (were in progress but didn't complete).
+ * Subdivide an in-progress range (cursor set, one page fetched) into `n`
+ * parallel children covering the unfetched older remainder.
  *
- * Stripe list APIs return newest records first. After one page, the newer side
- * of the range is already fetched; the unfetched remainder is the older side,
- * plus the boundary second that may still have more rows after the current
- * cursor.
+ * Stripe returns records newest-first; the page covered `[splitPoint, range.lt)`.
+ * Split `[rangeStart, splitPoint)` into `n` equal segments; the top segment
+ * widens its `lt` to `splitPoint + 1` and inherits the cursor so one request
+ * drains the boundary second AND its older window via `starting_after` + a
+ * widened `created` filter.
  *
- * N-ary subdivision: split the older remainder into `n` equal segments.
- * Reaches full parallelism in O(log_n M) rounds. Wastes at most n-1 empty
- * probes per split on skewed data.
+ * Ranges with segment duration below 30s pass through unchanged so the cursor
+ * paginates them sequentially instead of fanning out empty probes.
  */
 export function subdivideRanges(
   remaining: Range[],
@@ -72,36 +73,32 @@ export function subdivideRanges(
       result.push(range)
       continue
     }
+    const newEnd = lastObserved.get(range)!
+    const start = toUnixSeconds(range.gte)
 
-    const splitPoint = lastObserved.get(range)!
-    const rangeStartUnix = toUnixSeconds(range.gte)
-    const rangeEndUnix = toUnixSeconds(range.lt)
-    const olderEndUnix = splitPoint
-
-    // Nothing older to split — keep paginating sequentially.
-    if (olderEndUnix <= rangeStartUnix) {
+    if (newEnd <= start) {
       result.push(range)
       continue
     }
 
-    // Boundary range: keeps the cursor to drain remaining records at this second.
-    const boundaryGteUnix = Math.max(rangeStartUnix, splitPoint)
-    const boundaryLtUnix = Math.min(rangeEndUnix, splitPoint + 1)
-    result.push({ gte: toIso(boundaryGteUnix), lt: toIso(boundaryLtUnix), cursor: range.cursor })
+    const secondsLeft = newEnd - start
+    const segments = Math.min(n, secondsLeft)
+    const segmentDuration = Math.floor(secondsLeft / segments)
+    if (segmentDuration < 30) {
+      result.push(range)
+      continue
+    }
 
-    // Split the older remainder [rangeStart, splitPoint) into n equal segments.
-    const span = olderEndUnix - rangeStartUnix
-    if (span <= 1) {
-      // Can't split a 1-second range further.
-      result.push({ gte: toIso(rangeStartUnix), lt: toIso(olderEndUnix), cursor: null })
-    } else {
-      const segments = Math.min(n, span) // don't create more segments than seconds
-      for (let i = 0; i < segments; i++) {
-        const segGte = rangeStartUnix + Math.floor((span * i) / segments)
-        const segLt = rangeStartUnix + Math.floor((span * (i + 1)) / segments)
-        if (segLt > segGte) {
-          result.push({ gte: toIso(segGte), lt: toIso(segLt), cursor: null })
-        }
+    for (let i = 0; i < segments; i++) {
+      const segGte = start + segmentDuration * i
+      const segLt = Math.min(newEnd, segGte + segmentDuration) // set a ceiling to newEnd
+      const lastSegment = i === segments - 1
+      if (lastSegment) {
+        // handle the edge case where there are multiple objects created in a same second
+        //  but our fetch didn't return all of them because of the limit of 100.
+        result.push({ gte: toIso(segGte), lt: toIso(newEnd + 1), cursor: range.cursor })
+      } else {
+        result.push({ gte: toIso(segGte), lt: toIso(segLt), cursor: null })
       }
     }
   }

--- a/packages/source-stripe/src/index.test.ts
+++ b/packages/source-stripe/src/index.test.ts
@@ -2399,7 +2399,7 @@ describe('StripeSource', () => {
   })
 
   describe('read() — streams without supportsCreatedFilter sync sequentially', () => {
-    it('subdivides after first page and fetches boundary + halves in parallel', async () => {
+    it('subdivides after first page and fetches two older halves in parallel', async () => {
       const listFn = vi
         .fn()
         .mockResolvedValueOnce({
@@ -2440,9 +2440,11 @@ describe('StripeSource', () => {
       )
 
       // First call: full range → has_more + created=1_500_000_000.
-      // streamingSubdivide splits into: boundary [1_500_000_000, 1_500_000_001) + 2 older halves.
-      // All 3 child ranges return empty → exhausted → range_complete for each.
-      expect(listFn).toHaveBeenCalledTimes(4)
+      // streamingSubdivide splits into 2 older halves; the newest half widens
+      // its lt to splitPoint+1 and inherits the cursor, so the boundary second
+      // is drained inline instead of via a separate request.
+      // Both child ranges return has_more=false → exhausted → range_complete for each.
+      expect(listFn).toHaveBeenCalledTimes(3)
       expect(listFn).toHaveBeenNthCalledWith(1, {
         limit: 100,
         created: {
@@ -2467,20 +2469,20 @@ describe('StripeSource', () => {
           }),
         })
       )
-      // Boundary range around the split point should complete
+      // The newest older half absorbs the boundary: its lt extends to
+      // splitPoint+1 so the cursor paginates any shared-second records inline.
       expect(rangeCompletes).toContainEqual(
         expect.objectContaining({
           stream_status: expect.objectContaining({
             stream: 'customers',
-            range_complete: {
-              gte: new Date(1_500_000_000 * 1000).toISOString(),
+            range_complete: expect.objectContaining({
               lt: new Date(1_500_000_001 * 1000).toISOString(),
-            },
+            }),
           }),
         })
       )
-      // Head + boundary + 2 older halves = 4 range_complete events
-      expect(rangeCompletes).toHaveLength(4)
+      // Head + 2 older halves = 3 range_complete events
+      expect(rangeCompletes).toHaveLength(3)
     })
 
     it('uses sequential pagination (no created filter) for non-parallel streams', async () => {


### PR DESCRIPTION
## Summary
- Fold the boundary-second drain into the newest older-segment of each subdivision, saving one API call per subdivision cycle.
- Add a 30s minimum-segment-duration threshold so thin older remainders paginate sequentially via the cursor instead of fanning out empty probes.

## Why
The prior implementation emitted 1 + min(N, span) ranges per subdivision: a tiny cursor-bearing [splitPoint, splitPoint+1) range plus N equal segments of [rangeStart, splitPoint). The boundary range exists to drain records that share the splitPoint second and sit behind the cursor
That tiny extra request is almost always empty, but critical for correctness and it costs one slot against the rate limiter on every subdivision.

## Change
Removed the separate boundary emit.
The newest segment now uses lt = newEnd + 1 and inherits range.cursor; the other segments are unchanged (cursor = null, fresh windows).
Added a 30s minimum segment-duration threshold — ranges whose segments would be shorter than 30s pass through unchanged and paginate sequentially via the cursor, avoiding wasteful empty probes as a subdivision tails off.


