### PR TITLE
fix(source-stripe): skip v2 accounts and Sigma list errors in test mode

### DIFF
--- a/packages/source-stripe/src/index.test.ts
+++ b/packages/source-stripe/src/index.test.ts
@@ -789,40 +789,51 @@ describe('StripeSource', () => {
       })
     })
 
-    it('marks known skippable Stripe list errors as complete without emitting error traces', async () => {
-      const listFn = vi
-        .fn()
-        .mockRejectedValueOnce(new Error('This object is only available in testmode'))
+    it.each([
+      ['testmode-only resource', 'This object is only available in testmode'],
+      [
+        'v2 core accounts in test mode',
+        "Accounts v2 isn't available in test mode. Switch to a sandbox to test. [GET /v2/core/accounts (400)] {request-id=req_x, stripe-should-retry=false}",
+      ],
+      [
+        'sigma scheduled_query_runs testmode',
+        'This API surface is not enabled for testmode usage. [GET /v1/sigma/scheduled_query_runs (400)] {request-id=req_y}',
+      ],
+    ])(
+      'marks known skippable Stripe list errors as complete without emitting error traces (%s)',
+      async (_label, errorMessage) => {
+        const listFn = vi.fn().mockRejectedValueOnce(new Error(errorMessage))
 
-      const registry: Record<string, ResourceConfig> = {
-        invoices: makeConfig({
-          order: 1,
-          tableName: 'invoices',
-          listFn: listFn as ResourceConfig['listFn'],
-        }),
+        const registry: Record<string, ResourceConfig> = {
+          invoices: makeConfig({
+            order: 1,
+            tableName: 'invoices',
+            listFn: listFn as ResourceConfig['listFn'],
+          }),
+        }
+
+        vi.mocked(buildResourceRegistry).mockReturnValue(registry as any)
+        const messages = await collect(
+          source.read({ config, catalog: catalog({ name: 'invoices', primary_key: [['id']] }) })
+        )
+
+        expect(messages).toHaveLength(2)
+        expect(messages[0]).toMatchObject({
+          type: 'trace',
+          trace: {
+            trace_type: 'stream_status',
+            stream_status: { stream: 'invoices', status: 'started' },
+          },
+        })
+        expect(messages[1]).toMatchObject({
+          type: 'trace',
+          trace: {
+            trace_type: 'stream_status',
+            stream_status: { stream: 'invoices', status: 'complete' },
+          },
+        })
       }
-
-      vi.mocked(buildResourceRegistry).mockReturnValue(registry as any)
-      const messages = await collect(
-        source.read({ config, catalog: catalog({ name: 'invoices', primary_key: [['id']] }) })
-      )
-
-      expect(messages).toHaveLength(2)
-      expect(messages[0]).toMatchObject({
-        type: 'trace',
-        trace: {
-          trace_type: 'stream_status',
-          stream_status: { stream: 'invoices', status: 'started' },
-        },
-      })
-      expect(messages[1]).toMatchObject({
-        type: 'trace',
-        trace: {
-          trace_type: 'stream_status',
-          stream_status: { stream: 'invoices', status: 'complete' },
-        },
-      })
-    })
+    )
 
     it('continues to next stream after error on previous stream', async () => {
       const failingListFn = vi.fn().mockRejectedValueOnce(new Error('Connection refused'))

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -73,13 +73,16 @@ export function errorToTrace(err: unknown, stream: string): TraceMessage {
 //   400 "This endpoint is not in live mode"                     → not in live mode
 //   400 "Must provide customer"                                 → Must provide customer
 //   400 "Must provide source or customer"                       → Must provide
-//   400 "This API surface is not enabled for testmode usage."   → not enabled for
+//   400 "This API surface is not enabled for testmode usage."   → not enabled for / API surface is not enabled
 //   400 "Accounts v2 is not enabled for your platform."         → not enabled for
+//   400 "Accounts v2 isn't available in test mode. …"           → isn't available in test mode
 //   400 "Your account is not set up to use Issuing."            → not set up to use
 const SKIPPABLE_ERROR_PATTERNS = [
   'only available in testmode',
   'not in live mode',
   'not enabled for',
+  'API surface is not enabled',
+  "isn't available in test mode",
   'Must provide customer',
   'Must provide ',
   'not set up to use',


### PR DESCRIPTION
## Summary
Extends `SKIPPABLE_ERROR_PATTERNS` in `src-list-api.ts` so list backfill treats these Stripe 400s as skippable (stream completes without error traces):

- **v2 core accounts** in API test mode: `Accounts v2 isn't available in test mode. Switch to a sandbox to test.` — new pattern: `isn't available in test mode`.
- **Sigma `scheduled_query_runs`**: `This API surface is not enabled for testmode usage.` — already matched `not enabled for`; added `API surface is not enabled` for clearer/extra coverage.

## Tests
- Parametrized existing skippable list-error test with realistic `StripeApiRequestError`-style messages.

## Notes
- Per-stream names (`v2_core_accounts`, `scheduled_query_runs`) are not used; matching is message-based on the thrown error string.