### PR TITLE
fix(ci): make merge-manifest Docker smoke test exit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,8 +446,12 @@ jobs:
             ghcr.io/${{ github.repository }}-service:${{ github.sha }}-amd64 \
             ghcr.io/${{ github.repository }}-service:${{ github.sha }}-arm64
 
+      # ENTRYPOINT is serve.js; bare `--version` is ignored and the API runs forever.
       - name: Docker smoke test
-        run: docker run --rm ghcr.io/${{ github.repository }}:${{ github.sha }} --version
+        run: >-
+          docker run --rm --entrypoint node
+          ghcr.io/${{ github.repository }}:${{ github.sha }}
+          --use-env-proxy dist/bin/sync-engine.js --version
 
   # ---------------------------------------------------------------------------
   # E2E Docker — Docker image smoke + engine tests (runs on every push/PR)


### PR DESCRIPTION
## Problem
The `Merge multi-arch manifest` job runs `docker run ... --version` on the engine image. The image ENTRYPOINT is `serve.js`, which ignores `--version` and starts the HTTP API, so the step never finishes until the run is canceled.

## Fix
Run the CLI with an explicit entrypoint: `node --use-env-proxy dist/bin/sync-engine.js --version`, which prints the version and exits.

Made with [Cursor](https://cursor.com)