### PR TITLE
fix(destination-google-sheets): re-fetch metadata after ensureSheets to prevent overview clobbering first stream tab

### DIFF
--- a/packages/destination-google-sheets/src/index.test.ts
+++ b/packages/destination-google-sheets/src/index.test.ts
@@ -188,6 +188,48 @@ describe('destination-google-sheets', () => {
     expect(getData(id, 'my_stream')).toBeDefined()
   })
 
+  it('setup — all stream tabs created with correct headers, Overview does not clobber first stream', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+
+    const streamNames = ['stream_a', 'stream_b', 'stream_c', 'stream_d', 'stream_e']
+    const multiCatalog: ConfiguredCatalog = {
+      streams: streamNames.map((name) => ({
+        stream: {
+          name,
+          primary_key: [['id']],
+          json_schema: {
+            type: 'object',
+            properties: { id: { type: 'string' }, value: { type: 'string' } },
+          },
+        },
+        sync_mode: 'full_refresh',
+        destination_sync_mode: 'append',
+      })),
+    }
+
+    for await (const _ of dest.setup({ config: cfg(), catalog: multiCatalog })) {
+      // drain
+    }
+
+    const id = getSpreadsheetIds()[0]
+
+    // All 5 stream tabs must exist with correct headers
+    for (const name of streamNames) {
+      const rows = getData(id, name)
+      expect(rows, `tab "${name}" should exist`).toBeDefined()
+      expect(rows![0], `tab "${name}" should have correct headers`).toEqual(['id', 'value'])
+    }
+
+    // Overview tab must exist and start with the spreadsheet title, not stream headers
+    const overviewRows = getData(id, 'Overview')
+    expect(overviewRows, 'Overview tab should exist').toBeDefined()
+    expect(overviewRows![0][0]).toBe('Stripe Sync Engine')
+
+    // Sheet1 should be gone (renamed to a stream tab or Overview)
+    expect(getData(id, 'Sheet1')).toBeUndefined()
+  })
+
   it('end-of-stream flush — remaining buffered rows written when input ends', async () => {
     const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
     const dest = createDestination(sheets)

--- a/packages/destination-google-sheets/src/index.ts
+++ b/packages/destination-google-sheets/src/index.ts
@@ -153,10 +153,16 @@ export function createDestination(sheetsClient?: sheets_v4.Sheets): Destination<
       const sheetIdMap = await ensureSheets(sheets, spreadsheetId, meta, streamHeaders)
       const sheetIds = catalog.streams.map((s) => sheetIdMap.get(s.stream.name)!)
 
-      const streamNames = catalog.streams.map((s) => s.stream.name)
-      await ensureIntroSheet(sheets, spreadsheetId, meta, streamNames)
+      // Re-fetch metadata after ensureSheets: it may have renamed Sheet1 to the first
+      // stream tab, making the original `meta` stale. ensureIntroSheet uses meta to
+      // check whether Sheet1 exists (to rename vs. insert) — if it sees the stale
+      // Sheet1 entry it will rename the first stream's tab to "Overview".
+      const freshMeta = await getSpreadsheetMeta(sheets, spreadsheetId)
 
-      await protectSheets(sheets, spreadsheetId, meta, sheetIds)
+      const streamNames = catalog.streams.map((s) => s.stream.name)
+      await ensureIntroSheet(sheets, spreadsheetId, freshMeta, streamNames)
+
+      await protectSheets(sheets, spreadsheetId, freshMeta, sheetIds)
 
       if (isNew) {
         yield msg.control({


### PR DESCRIPTION
## Summary                                                                                        
                                                                                                              
  - On a new spreadsheet, \`ensureSheets\` renames \`Sheet1\` to the first stream tab, making the pre-fetched 
  \`meta\` stale
  - \`ensureIntroSheet\` then uses that stale \`meta\`, sees \`Sheet1\` still exists (as the only sheet), and 
  renames it to \`Overview\` — silently clobbering the first stream's tab and leaking its headers into the    
  Overview tab
  - Fix: re-fetch metadata between \`ensureSheets\` and \`ensureIntroSheet\`/\`protectSheets\` so both        
  functions see the actual spreadsheet state                                                                  
   
  ## Test plan                                                                                                
                                                            
  - [ ] Added regression test in \`src/index.test.ts\`: creates a spreadsheet with 5 streams via \`setup()\`, 
  asserts all 5 stream tabs exist with correct headers and that \`Overview\` contains \`Stripe Sync Engine\` 
  not stream headers                                                                                          
  - [ ] All 30 tests pass                                   