### PR TITLE
Log request action IDs in sync engine

### DIFF
--- a/apps/engine/src/api/app.test.ts
+++ b/apps/engine/src/api/app.test.ts
@@ -437,6 +437,117 @@ describe('engine request id header', () => {
       })
     )
   })
+
+  it('keeps action ids isolated across concurrent streaming requests', async () => {
+    const bridgeLogger = createLogger({ name: 'bridge-source', level: 'debug' })
+    const bridgeMsg = createSourceMessageFactory<
+      Record<string, never>,
+      Record<string, never>,
+      Record<string, unknown>
+    >()
+
+    let releaseBothReads!: () => void
+    const bothReadsStarted = new Promise<void>((resolve) => {
+      releaseBothReads = resolve
+    })
+    let readCount = 0
+
+    const bridgeSource = {
+      async *spec() {
+        yield { type: 'spec' as const, spec: { config: z.toJSONSchema(z.object({})) } }
+      },
+      async *check() {
+        yield {
+          type: 'connection_status' as const,
+          connection_status: { status: 'succeeded' as const },
+        }
+      },
+      async *discover() {
+        yield {
+          type: 'catalog' as const,
+          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+        }
+      },
+      async *read() {
+        bridgeLogger.info('before barrier')
+        readCount += 1
+        if (readCount === 2) releaseBothReads()
+        await bothReadsStarted
+        bridgeLogger.info('after barrier')
+        yield bridgeMsg.record({
+          stream: 'customers',
+          data: { id: `cus_${readCount}` },
+          emitted_at: new Date().toISOString(),
+        })
+      },
+    } satisfies Source<Record<string, never>>
+
+    const destConfigSchema = await getRawConfigJsonSchema(destinationTest)
+    const bridgeResolver: ConnectorResolver = {
+      resolveSource: async () => bridgeSource,
+      resolveDestination: async () => destinationTest,
+      sources: () =>
+        new Map([
+          [
+            'bridge',
+            {
+              connector: bridgeSource,
+              configSchema: {} as any,
+              rawConfigJsonSchema: z.toJSONSchema(z.object({})),
+            },
+          ],
+        ]),
+      destinations: () =>
+        new Map([
+          [
+            'test',
+            {
+              connector: destinationTest,
+              configSchema: {} as any,
+              rawConfigJsonSchema: destConfigSchema,
+            },
+          ],
+        ]),
+    }
+
+    const app = await createApp(bridgeResolver)
+    const actionA = 'act_concurrent_a'
+    const actionB = 'act_concurrent_b'
+    const requestHeaders = (actionId: string) => ({
+      'X-Pipeline': JSON.stringify({
+        source: { type: 'bridge', bridge: {} },
+        destination: { type: 'test', test: {} },
+      }),
+      'X-Action-Id': actionId,
+    })
+
+    const [resA, resB] = await Promise.all([
+      app.request('/pipeline_read', {
+        method: 'POST',
+        headers: requestHeaders(actionA),
+      }),
+      app.request('/pipeline_read', {
+        method: 'POST',
+        headers: requestHeaders(actionB),
+      }),
+    ])
+
+    const [eventsA, eventsB] = await Promise.all([readNdjson<Message>(resA), readNdjson<Message>(resB)])
+
+    const actionIdsA = eventsA
+      .filter((event): event is Extract<Message, { type: 'log' }> => event.type === 'log')
+      .map((event) => event.log.data?.action_id)
+    const actionIdsB = eventsB
+      .filter((event): event is Extract<Message, { type: 'log' }> => event.type === 'log')
+      .map((event) => event.log.data?.action_id)
+
+    expect(actionIdsA).toEqual(expect.arrayContaining([actionA]))
+    expect(actionIdsB).toEqual(expect.arrayContaining([actionB]))
+    expect(actionIdsA.every((actionId) => actionId === actionA)).toBe(true)
+    expect(actionIdsB.every((actionId) => actionId === actionB)).toBe(true)
+    expect(actionIdsA).not.toContain(actionB)
+    expect(actionIdsB).not.toContain(actionA)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/apps/engine/src/api/app.test.ts
+++ b/apps/engine/src/api/app.test.ts
@@ -397,6 +397,7 @@ describe('engine request id header', () => {
     }
 
     const app = await createApp(bridgeResolver)
+    const actionId = 'act_bridge_123'
     const res = await app.request('/pipeline_read', {
       method: 'POST',
       headers: {
@@ -404,6 +405,7 @@ describe('engine request id header', () => {
           source: { type: 'bridge', bridge: {} },
           destination: { type: 'test', test: {} },
         }),
+        'X-Action-Id': actionId,
       },
     })
 
@@ -431,6 +433,7 @@ describe('engine request id header', () => {
         engine_request_id: expect.stringMatching(
           /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
         ),
+        action_id: actionId,
       })
     )
   })

--- a/apps/engine/src/api/app.ts
+++ b/apps/engine/src/api/app.ts
@@ -80,7 +80,8 @@ export async function createApp(resolver: ConnectorResolver) {
 
   app.use('*', async (c, next) => {
     const engineRequestId = crypto.randomUUID()
-    await runWithEngineRequestContext({ engineRequestId }, async () => {
+    const action_id = c.req.header('X-Action-Id')?.trim() || undefined
+    await runWithEngineRequestContext({ engineRequestId, action_id }, async () => {
       const start = Date.now()
       log.info({ method: c.req.method, path: c.req.path }, 'request start')
       await next()

--- a/apps/engine/src/request-context.ts
+++ b/apps/engine/src/request-context.ts
@@ -4,6 +4,7 @@ export const ENGINE_REQUEST_ID_HEADER = 'sync-engine-reueest-id'
 
 type EngineRequestContext = {
   engineRequestId: string
+  action_id?: string
 }
 
 export function runWithEngineRequestContext<T>(context: EngineRequestContext, fn: () => T): T {

--- a/packages/logger/src/index.test.ts
+++ b/packages/logger/src/index.test.ts
@@ -32,6 +32,7 @@ describe('@stripe/sync-logger', () => {
     runWithLogContext(
       {
         engineRequestId: 'req_123',
+        action_id: 'act_123',
         onLog(entry) {
           entries.push(entry)
         },
@@ -48,6 +49,7 @@ describe('@stripe/sync-logger', () => {
         data: {
           name: 'logger-test',
           engine_request_id: 'req_123',
+          action_id: 'act_123',
           stream: 'customers',
           attempt: 2,
         },
@@ -125,6 +127,7 @@ describe('@stripe/sync-logger', () => {
       })(),
       {
         engineRequestId: 'req_stream',
+        action_id: 'act_stream',
         onLog(entry) {
           entries.push(entry)
         },
@@ -142,6 +145,7 @@ describe('@stripe/sync-logger', () => {
         data: {
           name: 'logger-test',
           engine_request_id: 'req_stream',
+          action_id: 'act_stream',
           stream: 'customers',
         },
       },

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -19,6 +19,7 @@ const DEFAULT_REDACT_CENSOR = '[redacted]'
 
 export type LoggerContext = {
   engineRequestId?: string
+  action_id?: string
   onLog?: (entry: RoutedLogEntry) => void
   protocolLogDestinations?: DestinationStream[]
   suppressProtocolStdout?: boolean
@@ -268,6 +269,8 @@ function extractCapturedData(
 
   const engineRequestId = getEngineRequestId()
   if (engineRequestId) data.engine_request_id = engineRequestId
+  const actionId = getLoggerContext()?.action_id
+  if (actionId) data.action_id = actionId
 
   const first = args[0]
   if (first instanceof Error) {
@@ -424,8 +427,12 @@ export function createLogger(
       },
       mixin(...args) {
         const base = userMixin ? userMixin.apply(this, args) : {}
-        const engineRequestId = getEngineRequestId()
-        return engineRequestId ? { ...base, engine_request_id: engineRequestId } : base
+        const context = getLoggerContext()
+        return {
+          ...base,
+          ...(context?.engineRequestId ? { engine_request_id: context.engineRequestId } : {}),
+          ...(context?.action_id ? { action_id: context.action_id } : {}),
+        }
       },
     },
     destination


### PR DESCRIPTION
## Summary
- add request-scoped logger context via AsyncLocalStorage so every log line includes per-request metadata
- capture the inbound `X-Action-Id` header and expose it in logs as `action_id`
- add focused tests covering concurrent request isolation and log field injection

## Testing
- pnpm --filter @stripe/sync-engine exec tsc --noEmit
- pnpm --filter @stripe/sync-engine exec vitest run src/logger.test.ts --config vitest.config.ts