### PR TITLE
feat(destination-google-sheets): date-aware upsert via newer_than_field

### DIFF
--- a/packages/destination-google-sheets/src/index.test.ts
+++ b/packages/destination-google-sheets/src/index.test.ts
@@ -670,6 +670,162 @@ describe('native upsert', () => {
   })
 })
 
+describe('newer_than_field stale write prevention', () => {
+  function catalogWithNewerThan(): ConfiguredCatalog {
+    return {
+      streams: [
+        {
+          stream: {
+            name: 'customers',
+            primary_key: [['id']],
+            newer_than_field: 'updated',
+            json_schema: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                name: { type: 'string' },
+                updated: { type: 'integer' },
+              },
+            },
+          },
+          sync_mode: 'full_refresh',
+          destination_sync_mode: 'append',
+        },
+      ],
+    }
+  }
+
+  it('rejects a stale update (incoming updated < existing)', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWithNewerThan()
+
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice v2', updated: 200 })])
+      )
+    )
+
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice v1 (stale)', updated: 100 })])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows[1]?.[1]).toBe('Alice v2') // name unchanged — stale write rejected
+    expect(rows[1]?.[2]).toBe('200') // updated unchanged
+  })
+
+  it('applies a newer update (incoming updated > existing)', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWithNewerThan()
+
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice v1', updated: 100 })])
+      )
+    )
+
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice v2', updated: 200 })])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows[1]?.[1]).toBe('Alice v2') // name updated
+    expect(rows[1]?.[2]).toBe('200') // updated updated
+  })
+
+  it('rejects equal timestamp — treated as stale for idempotency', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWithNewerThan()
+
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice', updated: 100 })])
+      )
+    )
+
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice again', updated: 100 })])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows[1]?.[1]).toBe('Alice') // name unchanged — equal timestamp not newer
+  })
+
+  it('without newer_than_field — stale-looking write still overwrites', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat: ConfiguredCatalog = {
+      streams: [
+        {
+          stream: { name: 'customers', primary_key: [['id']] },
+          sync_mode: 'full_refresh',
+          destination_sync_mode: 'append',
+        },
+      ],
+    }
+
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice v2', updated: 200 })])
+      )
+    )
+
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice v1', updated: 100 })])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows[1]?.[1]).toBe('Alice v1') // overwritten — no staleness guard
+  })
+
+  it('new key alongside stale — stale skipped, new row appended', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWithNewerThan()
+
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice', updated: 200 })])
+      )
+    )
+
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([
+          record('customers', { id: 'cus_1', name: 'Alice stale', updated: 100 }),
+          record('customers', { id: 'cus_2', name: 'Bob', updated: 300 }),
+        ])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows).toHaveLength(3) // header + cus_1 (unchanged) + cus_2 (new)
+    expect(rows[1]?.[1]).toBe('Alice') // cus_1 unchanged
+    expect(rows[2]?.[1]).toBe('Bob') // cus_2 appended
+  })
+})
+
 describe('envVars', () => {
   it('exports env var mapping', () => {
     expect(envVars.client_id).toBe('GOOGLE_CLIENT_ID')

--- a/packages/destination-google-sheets/src/index.ts
+++ b/packages/destination-google-sheets/src/index.ts
@@ -95,6 +95,18 @@ function stringify(value: unknown): string {
   return JSON.stringify(value)
 }
 
+/**
+ * Returns true if `incoming` is strictly newer than `existing`.
+ * Compares numerically when both parse as numbers (Unix timestamps),
+ * falls back to string comparison otherwise.
+ */
+function isNewerThan(incoming: unknown, existing: unknown): boolean {
+  const a = Number(incoming)
+  const b = Number(existing)
+  if (!isNaN(a) && !isNaN(b)) return a > b
+  return String(incoming) > String(existing)
+}
+
 /** Check if an error looks transient (rate limit or server error). */
 function isTransient(err: unknown): boolean {
   if (!(err instanceof Error) || !('code' in err)) return false
@@ -201,6 +213,11 @@ export function createDestination(sheetsClient?: sheets_v4.Sheets): Destination<
           configuredStream.stream.primary_key,
         ])
       )
+      const newerThanFields = new Map<string, string>(
+        catalog.streams
+          .filter((cs) => cs.stream.newer_than_field)
+          .map((cs) => [cs.stream.name, cs.stream.newer_than_field!])
+      )
 
       const spreadsheetId = config.spreadsheet_id
         ? config.spreadsheet_id
@@ -287,6 +304,7 @@ export function createDestination(sheetsClient?: sheets_v4.Sheets): Destination<
           sheetId: number
           headers: string[]
           primaryKey: string[][] | undefined
+          newerThanField: string | undefined
           appends: Array<{ row: string[]; rowKey?: string }>
           bufferedUpdates: Array<{ rowNumber: number; values: string[] }>
           needsRead: boolean
@@ -302,6 +320,7 @@ export function createDestination(sheetsClient?: sheets_v4.Sheets): Destination<
 
           const headers = streamHeaders.get(streamName) ?? []
           const primaryKey = primaryKeys.get(streamName)
+          const newerThanField = newerThanFields.get(streamName)
           const needsRead =
             !!primaryKey &&
             primaryKey.length > 0 &&
@@ -313,6 +332,7 @@ export function createDestination(sheetsClient?: sheets_v4.Sheets): Destination<
             sheetId,
             headers,
             primaryKey,
+            newerThanField,
             appends: bufferedAppends.slice(),
             bufferedUpdates,
             needsRead,
@@ -330,9 +350,19 @@ export function createDestination(sheetsClient?: sheets_v4.Sheets): Destination<
           const pkFields = prep.primaryKey.map((p) => p[0])
           const pkIsFirstN = pkFields.every((field, i) => prep.headers[i] === field)
           narrowByStream.set(prep.streamName, pkIsFirstN)
+          let columnCount: number | undefined
+          if (pkIsFirstN) {
+            const newerThanColIndex = prep.newerThanField
+              ? prep.headers.indexOf(prep.newerThanField)
+              : -1
+            columnCount =
+              newerThanColIndex >= 0
+                ? Math.max(pkFields.length, newerThanColIndex + 1)
+                : pkFields.length
+          }
           streamsToRead.push({
             name: prep.streamName,
-            ...(pkIsFirstN ? { columnCount: pkFields.length } : {}),
+            ...(pkIsFirstN ? { columnCount } : {}),
           })
         }
 
@@ -363,7 +393,7 @@ export function createDestination(sheetsClient?: sheets_v4.Sheets): Destination<
         // Per-stream prep from pre-fetched rows. Stream order is preserved
         // so row_assignments tracking matches the previous sequential impl.
         for (const prep of prepInputs) {
-          const { streamName, sheetId, headers, primaryKey, bufferedUpdates, needsRead } = prep
+          const { streamName, sheetId, headers, primaryKey, newerThanField, bufferedUpdates, needsRead } = prep
           let appends = prep.appends
           let existingRowCount = 0
 
@@ -373,28 +403,49 @@ export function createDestination(sheetsClient?: sheets_v4.Sheets): Destination<
               const isNarrow = narrowByStream.get(streamName) === true
               // Narrow reads skip the header row; add 1 so append startRow is correct.
               existingRowCount = isNarrow ? allRows.length + 1 : allRows.length
+              const newerThanColIndex =
+                isNarrow && newerThanField ? headers.indexOf(newerThanField) : -1
               const freshMap = isNarrow
-                ? buildRowMapFromPkColumns(allRows, primaryKey)
-                : buildRowMapFromRows(allRows, headers, primaryKey)
+                ? buildRowMapFromPkColumns(
+                    allRows,
+                    primaryKey,
+                    newerThanColIndex >= 0 ? newerThanColIndex : undefined
+                  )
+                : buildRowMapFromRows(allRows, headers, primaryKey, newerThanField)
+              const newerThanHeaderIndex =
+                newerThanField ? headers.indexOf(newerThanField) : -1
               const remaining: typeof appends = []
               let converted = 0
+              let staleSkipped = 0
               for (const entry of appends) {
                 const existing = entry.rowKey ? freshMap.get(entry.rowKey) : undefined
                 if (existing !== undefined) {
-                  bufferedUpdates.push({ rowNumber: existing, values: entry.row })
+                  if (
+                    newerThanField &&
+                    newerThanHeaderIndex >= 0 &&
+                    existing.newerThanValue !== undefined
+                  ) {
+                    const incomingValue = entry.row[newerThanHeaderIndex]
+                    if (!isNewerThan(incomingValue, existing.newerThanValue)) {
+                      staleSkipped++
+                      continue
+                    }
+                  }
+                  bufferedUpdates.push({ rowNumber: existing.rowNumber, values: entry.row })
                   converted++
                 } else {
                   remaining.push(entry)
                 }
               }
               appends = remaining
-              if (converted > 0) {
+              if (converted > 0 || staleSkipped > 0) {
                 log.debug(
                   {
                     streamName,
                     existingRows: existingRowCount,
                     keys: freshMap.size,
                     converted,
+                    staleSkipped,
                   },
                   'dedup: converted appends to updates'
                 )

--- a/packages/destination-google-sheets/src/writer.ts
+++ b/packages/destination-google-sheets/src/writer.ts
@@ -457,22 +457,30 @@ export async function deleteSpreadsheet(
   await withRetry(() => drive.files.delete({ fileId: spreadsheetId }))
 }
 
+export interface RowMapEntry {
+  rowNumber: number
+  /** Value of the newer_than_field column from the existing sheet row, if requested. */
+  newerThanValue: unknown
+}
+
 /**
- * Pure: serialized primary key → 1-based sheet row number, from rows you've
+ * Pure: serialized primary key → { rowNumber, newerThanValue }, from rows you've
  * already fetched. `headers` must be known. Prefer this over `buildRowMap`
  * when you also need the row data; avoids a second read.
  */
 export function buildRowMapFromRows(
   allRows: unknown[][],
   headers: string[],
-  primaryKey: string[][]
-): Map<string, number> {
+  primaryKey: string[][],
+  newerThanField?: string
+): Map<string, RowMapEntry> {
   const pkFields = primaryKey.map((path) => path[0])
   const pkIndices = pkFields.map((field) => headers.indexOf(field))
   if (pkIndices.some((i) => i === -1)) return new Map()
+  const newerThanIndex = newerThanField ? headers.indexOf(newerThanField) : -1
 
   // Skip header row (index 0), data starts at index 1
-  const map = new Map<string, number>()
+  const map = new Map<string, RowMapEntry>()
   for (let i = 1; i < allRows.length; i++) {
     const row = allRows[i] as string[]
     const data: Record<string, unknown> = {}
@@ -481,7 +489,8 @@ export function buildRowMapFromRows(
     }
     const rowKey = serializeRowKey(primaryKey, data)
     if (rowKey === '[""]' || rowKey === '[null]') continue
-    map.set(rowKey, i + 1) // 1-based: row 1 = headers, so data row at index i → row i+1
+    const newerThanValue = newerThanIndex >= 0 ? row[newerThanIndex] : undefined
+    map.set(rowKey, { rowNumber: i + 1, newerThanValue }) // 1-based: row 1 = headers, so data row at index i → row i+1
   }
   return map
 }
@@ -489,13 +498,17 @@ export function buildRowMapFromRows(
 /**
  * Like `buildRowMapFromRows` but for a header-less PK-only slice
  * (see `batchReadSheets` with `columnCount`). Row i → sheet row i + 2.
+ *
+ * `newerThanColIndex` is the 0-based absolute column index in the sheet
+ * (matches the index in the row array since reads always start from column A).
  */
 export function buildRowMapFromPkColumns(
   pkRows: unknown[][],
-  primaryKey: string[][]
-): Map<string, number> {
+  primaryKey: string[][],
+  newerThanColIndex?: number
+): Map<string, RowMapEntry> {
   const pkFields = primaryKey.map((path) => path[0])
-  const map = new Map<string, number>()
+  const map = new Map<string, RowMapEntry>()
   for (let i = 0; i < pkRows.length; i++) {
     const row = pkRows[i] as string[]
     const data: Record<string, unknown> = {}
@@ -504,7 +517,8 @@ export function buildRowMapFromPkColumns(
     }
     const rowKey = serializeRowKey(primaryKey, data)
     if (rowKey === '[""]' || rowKey === '[null]') continue
-    map.set(rowKey, i + 2)
+    const newerThanValue = newerThanColIndex !== undefined ? row[newerThanColIndex] : undefined
+    map.set(rowKey, { rowNumber: i + 2, newerThanValue })
   }
   return map
 }
@@ -523,7 +537,8 @@ export async function buildRowMap(
   primaryKey: string[][]
 ): Promise<Map<string, number>> {
   const allRows = await readSheet(sheets, spreadsheetId, sheetName)
-  return buildRowMapFromRows(allRows, headers, primaryKey)
+  const richMap = buildRowMapFromRows(allRows, headers, primaryKey)
+  return new Map([...richMap.entries()].map(([k, v]) => [k, v.rowNumber]))
 }
 
 /** Read all values from a sheet tab. Used for verification in tests. */


### PR DESCRIPTION
When a catalog stream declares `newer_than_field`, the write path now reads that column during the dedup flush and skips updates whose incoming value is not strictly newer than the existing sheet row. Equal timestamps are treated as stale for idempotency. The narrow batchRead range is extended to include the newer_than column, and both `buildRowMapFromRows` and `buildRowMapFromPkColumns` are updated to carry the comparison value alongside the row number.


Committed-By-Agent: claude

## Summary

<!-- What changed in plain language -->

-

## How to test (optional)

<!-- Add steps only if useful -->

-

## Related

<!-- Link issue(s) if any -->

- Closes #

> Thanks for contributing ❤️
