### PR TITLE
Add soft-delete explanation to Google Sheets Overview tab

### DIFF
--- a/packages/destination-google-sheets/src/writer.ts
+++ b/packages/destination-google-sheets/src/writer.ts
@@ -351,6 +351,10 @@ export async function ensureIntroSheet(
     [''],
     [`Last setup: ${now}`],
     [''],
+    ['ℹ️  Deleted records: Stripe objects are never removed from this spreadsheet. When a record is'],
+    ['   deleted in Stripe, its row remains and the "deleted" column is set to TRUE. You can filter'],
+    ['   these out in formulas, e.g. =FILTER(A2:Z, D2:D<>TRUE) where D is the "deleted" column.'],
+    [''],
     ['⚠️  Do not edit data in the synced tabs. Changes will be overwritten on the next sync.'],
   ]
 


### PR DESCRIPTION
## Summary
                                                                                                              
   - Adds a note to the Overview tab explaining that Stripe objects are never hard-deleted from the
   spreadsheet
   - Clarifies that when a record is deleted in Stripe, its row stays and the `deleted` column is set to
   `TRUE`
   - Includes a `FILTER` formula example so users know how to exclude deleted records from their own
   formulas

   ## Motivation

   Previously the Overview tab had no mention of how deletes work, which could confuse users who noticed
   stale records persisting in their sheets. This surfaces the behavior upfront so users can account for it
    in their formulas.

   ## Test plan

   - [ ] Run setup against a real spreadsheet and verify the new lines appear in the Overview tab
   - [ ] Delete a Stripe object, re-sync, and confirm the row remains with `deleted = TRUE`

   🤖 Generated with [Claude Code](https://claude.com/claude-code)