### PR TITLE
fix(source-stripe): swallow prefetch rejection on abort

### DIFF
--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -362,6 +362,9 @@ async function* paginateSequential(opts: {
       if (supportsForwardPagination && supportsLimit) nextParams.limit = 100
       if (supportsForwardPagination) nextParams.starting_after = nextCursor
       prefetchedResponse = listFn(nextParams as Parameters<typeof listFn>[0])
+      // Attach a no-op catch to prevent unhandled rejection when the generator
+      // returns early (e.g. pipeline shutdown via abort signal). The actual error
+      // is still available via the original promise stored in the map.
       prefetchedResponse.catch(() => {})
     }
 

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -362,6 +362,7 @@ async function* paginateSequential(opts: {
       if (supportsForwardPagination && supportsLimit) nextParams.limit = 100
       if (supportsForwardPagination) nextParams.starting_after = nextCursor
       prefetchedResponse = listFn(nextParams as Parameters<typeof listFn>[0])
+      prefetchedResponse.catch(() => {})
     }
 
     log.trace({


### PR DESCRIPTION
## Summary

`paginateSequential` kicks off the next page, but if a soft/hard time limit fires before we `await` it, nothing handles the rejection and the engine crashes with an unhandled `AbortError`.

Attach a no-op `.catch()` to `prefetchedResponse` — mirrors what `streamingSubdivide` already does on its in-flight promises. The rejection still propagates if we do eventually `await` it, so the existing `AbortError` handling in `listApiBackfill` still works..
