### PR TITLE
Soft limit timing should be independent of messages

### DIFF
--- a/apps/engine/src/lib/pipeline.ts
+++ b/apps/engine/src/lib/pipeline.ts
@@ -111,10 +111,13 @@ export interface TakeLimitsOptions {
 /**
  * Applies stream limits and emits an `eof` terminal message as the final item.
  *
- * - `soft_time_limit`: between-message cooperative deadline. Closes the
- *   iterator via `return()`, letting upstream `finally` blocks run.
- * - `time_limit`: hard deadline enforced via `Promise.race`. Forces eof even
- *   if upstream is blocked.
+ * - `soft_time_limit`: wall-clock deadline raced against `iterator.next()`.
+ *   Fires even if the source is idle (no messages in flight). Closes the
+ *   iterator via `return()`, letting upstream `finally` blocks run so the
+ *   destination can flush its buffer.
+ * - `time_limit`: hard deadline also raced via `Promise.race`. Forces eof
+ *   even if upstream is blocked; downstream generators get a cold
+ *   `.return()` rather than a graceful drain.
  * - `signal`: external `AbortSignal` (e.g. client disconnect). Terminates
  *   immediately.
  *
@@ -136,10 +139,10 @@ export function takeLimits<T extends { type: string }>(
         ? startedAt + opts.time_limit * 1000
         : undefined
 
-    const needsRace = hardDeadline != null || opts.signal != null
-    const needsSlowPath = needsRace || softDeadline != null
+    const needsSlowPath = softDeadline != null || hardDeadline != null || opts.signal != null
 
     let iterator: AsyncIterator<T> | undefined
+    let softTimer: ReturnType<typeof setTimeout> | undefined
     let hardTimer: ReturnType<typeof setTimeout> | undefined
     let iteratorClosed = false
 
@@ -175,11 +178,18 @@ export function takeLimits<T extends { type: string }>(
       return
     }
 
-    // Slow path: manual iterator + Promise.race for hard deadline / signal
+    // Slow path: manual iterator + Promise.race for soft/hard deadlines / signal
     iterator = messages[Symbol.asyncIterator]()
 
     function cleanup() {
-      if (hardTimer != null) clearTimeout(hardTimer)
+      if (softTimer != null) {
+        clearTimeout(softTimer)
+        softTimer = undefined
+      }
+      if (hardTimer != null) {
+        clearTimeout(hardTimer)
+        hardTimer = undefined
+      }
     }
 
     async function closeIterator() {
@@ -215,9 +225,19 @@ export function takeLimits<T extends { type: string }>(
         const nextP = iterator.next()
         const racers: Promise<
           | { kind: 'next'; result: IteratorResult<T> }
+          | { kind: 'soft_deadline' }
           | { kind: 'hard_deadline' }
           | { kind: 'aborted' }
         >[] = [nextP.then((result) => ({ kind: 'next' as const, result }))]
+
+        if (softDeadline != null) {
+          const remainingMs = Math.max(0, softDeadline - Date.now())
+          racers.push(
+            new Promise((resolve) => {
+              softTimer = setTimeout(() => resolve({ kind: 'soft_deadline' as const }), remainingMs)
+            })
+          )
+        }
 
         if (hardDeadline != null) {
           const remainingMs = Math.max(0, hardDeadline - Date.now())
@@ -232,6 +252,19 @@ export function takeLimits<T extends { type: string }>(
 
         const winner = await Promise.race(racers)
         cleanup()
+
+        if (winner.kind === 'soft_deadline') {
+          log.warn(
+            {
+              elapsed_ms: Date.now() - startedAt,
+              soft_time_limit: opts.soft_time_limit,
+              event: 'SYNC_TIME_LIMIT_SOFT',
+            },
+            'SYNC_TIME_LIMIT_SOFT'
+          )
+          yield closeIteratorAndMakeEof({ has_more: true })
+          return
+        }
 
         if (winner.kind === 'hard_deadline') {
           log.warn(
@@ -259,21 +292,7 @@ export function takeLimits<T extends { type: string }>(
           return
         }
 
-        const msg = result.value
-        yield msg
-
-        if (softDeadline != null && Date.now() >= softDeadline) {
-          log.warn(
-            {
-              elapsed_ms: Date.now() - startedAt,
-              soft_time_limit: opts.soft_time_limit,
-              event: 'SYNC_TIME_LIMIT_SOFT',
-            },
-            'SYNC_TIME_LIMIT_SOFT'
-          )
-          yield closeIteratorAndMakeEof({ has_more: true })
-          return
-        }
+        yield result.value
       }
     } finally {
       cleanup()

--- a/e2e/test-disconnect.test.ts
+++ b/e2e/test-disconnect.test.ts
@@ -471,8 +471,22 @@ for (const runtime of runtimes) {
       await waitForLog(engine, 'SYNC_TIME_LIMIT_SOFT')
     }, 30_000)
 
-    it('hard time limit forces return when source blocks', async () => {
-      // Use a mock with very long delay (5s per page) so the source blocks past the hard deadline
+    it('soft time limit forces return when source blocks', async () => {
+      // Regression test for the soft-limit wall-clock racer: before the fix,
+      // soft_time_limit was only evaluated *after* a yielded message, so a
+      // source blocked on a slow upstream call never triggered it — the hard
+      // deadline had to step in. Now soft fires on wall-clock regardless of
+      // source activity, which is what lets the pipeline stop the source
+      // cooperatively and give the destination a drain window (rather than
+      // being force-terminated by hard).
+      //
+      // This test only has a source (pipeline_read), so the drain itself is
+      // covered by the pipeline.test.ts unit tests. Here we just prove soft
+      // actually fires when the source is blocked end-to-end through the
+      // HTTP boundary.
+      //
+      // time_limit=2 → defaultSoftTimeLimit=0.8*2=1.6s → soft wins against the
+      // 2s hard deadline and against the 5s-per-page blocked source.
       const slowMock = await startMockStripeApi({
         delayMs: 5000,
         port: runtime.name === 'docker' ? 18889 : 0,
@@ -489,7 +503,7 @@ for (const runtime of runtimes) {
         })
         if (!res.ok) {
           const body = await res.text().catch(() => '')
-          console.error(`hard time limit test: pipeline_read returned ${res.status}: ${body}`)
+          console.error(`soft time limit test: pipeline_read returned ${res.status}: ${body}`)
         }
         expect(res.status).toBe(200)
 
@@ -503,11 +517,11 @@ for (const runtime of runtimes) {
 
         expect(eof).toBeDefined()
         expect(eof.eof.has_more).toBe(true)
-        // Hard deadline = 2s + 1s = 3s. Allow generous CI slack.
-        expect(elapsed).toBeGreaterThan(2000)
+        // Soft deadline = 1.6s. Allow generous CI slack on both sides.
+        expect(elapsed).toBeGreaterThan(1600)
         expect(elapsed).toBeLessThan(15000)
 
-        // The key assertion: the response completed in ~3s, NOT in 5s+ (a full page delay).
+        // The key assertion: the response completed in ~1.6s, NOT in 5s+ (a full page delay).
         // The connector may have launched concurrent requests before the hard deadline,
         // so we don't assert request count — we assert elapsed time above.
         const countAtEof = slowMock.requestCount()
@@ -517,7 +531,7 @@ for (const runtime of runtimes) {
         const countAfterWait = slowMock.requestCount()
         expect(countAfterWait - countAtEof).toBeLessThanOrEqual(1)
 
-        await waitForLog(engine, 'SYNC_TIME_LIMIT_HARD')
+        await waitForLog(engine, 'SYNC_TIME_LIMIT_SOFT')
       } finally {
         await slowMock.close()
       }


### PR DESCRIPTION
## Summary

Live-mode sources (src-webhook, src-websocket, src-events-api) park on await waiting for Stripe events. The old soft_time_limit check only ran after each yield, so an idle live source never hit the soft limit — the hard time_limit won instead, which cold-cancels via Promise.race and skips destination flushes / state checkpoints.

## FIX
Make soft_deadline a first-class racer alongside iterator.next(), hardDeadline, and signal in takeLimits(). When it wins, close the iterator via .return() (so finally blocks run) and emit eof { has_more: true } — same semantics as before, just triggered on wall-clock.

Also track softTimer in cleanup() and drop the now-redundant post-yield check.

## Test
New regression in pipeline.test.ts: source yields one record then sleeps 10s; with soft_time_limit: 0.3, time_limit: 5, expects EOF in ~300ms with has_more: true.

## Compatibility
No API changes. Fast path unchanged. Batch sources trip the soft limit fractionally earlier (wall-clock vs. next message) — EOF shape identical.
