### PR TITLE
Handle deletes in sheets destination

### DIFF
--- a/packages/destination-google-sheets/src/index.test.ts
+++ b/packages/destination-google-sheets/src/index.test.ts
@@ -788,6 +788,564 @@ describe('native upsert', () => {
   })
 })
 
+describe('delete handling', () => {
+  const catalogWith = (primaryKey: string[][] = [['id']]): ConfiguredCatalog => ({
+    streams: [
+      {
+        stream: {
+          name: 'customers',
+          primary_key: primaryKey,
+          json_schema: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              name: { type: 'string' },
+              deleted: { type: 'boolean' },
+              _account_id: { type: 'string' },
+            },
+          },
+        },
+        sync_mode: 'full_refresh',
+        destination_sync_mode: 'append',
+      },
+    ],
+  })
+
+  /**
+   * Seed the sheet with N customers `cus_1..cus_N`. Records only carry `id`
+   * and `name`, mirroring what the Stripe source actually emits for
+   * non-delete events. Headers start as `['id', 'name']`; the second write's
+   * `deleted: true` record extends them to `['id', 'name', 'deleted']` on the
+   * fly, which leaves seeded data rows 2-wide and newly-written rows 3-wide.
+   */
+  async function seedCustomers(
+    dest: ReturnType<typeof createDestination>,
+    cat: ConfiguredCatalog,
+    names: Array<[string, string]>
+  ): Promise<void> {
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: cat },
+        toAsyncIter(names.map(([id, name]) => record('customers', { id, name })))
+      )
+    )
+  }
+
+  /** Extract the row_assignments meta message from a write() output stream. */
+  function extractRowAssignments(
+    output: DestinationOutput[]
+  ): Record<string, Record<string, number>> {
+    const metaLog = output.find(
+      (m) =>
+        m.type === 'log' &&
+        m.log.level === 'debug' &&
+        typeof m.log.message === 'string' &&
+        m.log.message.startsWith('__sync_engine_google_sheets__:')
+    )
+    if (!metaLog) return {}
+    const parsed = parseGoogleSheetsMetaLog((metaLog as { log: { message: string } }).log.message)
+    return parsed?.assignments ?? {}
+  }
+
+  // MARK: - routing
+
+  it('record with deleted:true is routed to the delete path (no row appended)', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWith()
+
+    // Against an empty sheet, the delete target can't resolve, so the delete
+    // is a silent no-op and the record must not leak into the append path.
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice', deleted: true })])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows).toEqual([['id', 'name', 'deleted']])
+  })
+
+  it('deleted:false is treated as a normal append (strict === true check)', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWith()
+
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice', deleted: false })])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows).toEqual([
+      ['id', 'name', 'deleted'],
+      ['cus_1', 'Alice', 'false'],
+    ])
+  })
+
+  // MARK: - Phase 2 (tail swap)
+
+  it('body delete, no appends → tail donor swapped into the hole', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWith()
+
+    await seedCustomers(dest, cat, [
+      ['cus_1', 'Alice'],
+      ['cus_2', 'Bob'],
+      ['cus_3', 'Charlie'],
+    ])
+
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_2', name: 'Bob', deleted: true })])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    // Seeded rows are 2-wide; blank rows written by delete compaction are
+    // 3-wide because the header was extended on the delete record's arrival.
+    expect(rows).toEqual([
+      ['id', 'name', 'deleted'],
+      ['cus_1', 'Alice'],
+      ['cus_3', 'Charlie'], // was cus_2; donor (row 4) swapped in
+      ['', '', ''], // donor row blanked
+    ])
+  })
+
+  it('tail delete, no appends → blanked in place, no swap needed', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWith()
+
+    await seedCustomers(dest, cat, [
+      ['cus_1', 'Alice'],
+      ['cus_2', 'Bob'],
+      ['cus_3', 'Charlie'],
+    ])
+
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_3', name: 'Charlie', deleted: true })])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows).toEqual([
+      ['id', 'name', 'deleted'],
+      ['cus_1', 'Alice'],
+      ['cus_2', 'Bob'],
+      ['', '', ''],
+    ])
+  })
+
+  it('multiple body deletes → multiple tail-swaps with paired survivors', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWith()
+
+    await seedCustomers(dest, cat, [
+      ['cus_a', 'Alice'],
+      ['cus_b', 'Bob'],
+      ['cus_c', 'Charlie'],
+      ['cus_d', 'Dave'],
+      ['cus_e', 'Eve'],
+    ])
+
+    // Deleting the first two body rows pairs delete-row-2 ↔ donor-row-5 and
+    // delete-row-3 ↔ donor-row-6 (bodyDeletes asc × survivorDonors asc).
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([
+          record('customers', { id: 'cus_a', name: 'Alice', deleted: true }),
+          record('customers', { id: 'cus_b', name: 'Bob', deleted: true }),
+        ])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows).toEqual([
+      ['id', 'name', 'deleted'],
+      ['cus_d', 'Dave'], // was cus_a; donor (row 5)
+      ['cus_e', 'Eve'], // was cus_b; donor (row 6)
+      ['cus_c', 'Charlie'], // unchanged
+      ['', '', ''],
+      ['', '', ''],
+    ])
+  })
+
+  it('mix of body and tail deletes → body swapped, tail blanked', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWith()
+
+    await seedCustomers(dest, cat, [
+      ['cus_a', 'Alice'],
+      ['cus_b', 'Bob'],
+      ['cus_c', 'Charlie'],
+      ['cus_d', 'Dave'],
+    ])
+
+    // Delete middle (body) + last (tail). Tail survivor row 4 (c) fills row 3;
+    // both donor row 4 and delete-tail row 5 end up blank.
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([
+          record('customers', { id: 'cus_b', name: 'Bob', deleted: true }),
+          record('customers', { id: 'cus_d', name: 'Dave', deleted: true }),
+        ])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows).toEqual([
+      ['id', 'name', 'deleted'],
+      ['cus_a', 'Alice'],
+      ['cus_c', 'Charlie'], // was cus_b; donor (row 4)
+      ['', '', ''], // donor row 4 blanked
+      ['', '', ''], // tail delete row 5
+    ])
+  })
+
+  it('deleting every data row → all data rows blanked (edge: no survivors)', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWith()
+
+    await seedCustomers(dest, cat, [
+      ['cus_1', 'Alice'],
+      ['cus_2', 'Bob'],
+      ['cus_3', 'Charlie'],
+    ])
+
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([
+          record('customers', { id: 'cus_1', name: 'Alice', deleted: true }),
+          record('customers', { id: 'cus_2', name: 'Bob', deleted: true }),
+          record('customers', { id: 'cus_3', name: 'Charlie', deleted: true }),
+        ])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows).toEqual([
+      ['id', 'name', 'deleted'],
+      ['', '', ''],
+      ['', '', ''],
+      ['', '', ''],
+    ])
+  })
+
+  // MARK: - Phase 1 (donation)
+
+  it('single delete + single append → append donates into the hole', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWith()
+
+    await seedCustomers(dest, cat, [
+      ['cus_1', 'Alice'],
+      ['cus_2', 'Bob'],
+      ['cus_3', 'Charlie'],
+    ])
+
+    const out = await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([
+          record('customers', { id: 'cus_2', name: 'Bob', deleted: true }),
+          record('customers', { id: 'cus_4', name: 'Dave', deleted: false }),
+        ])
+      )
+    )
+
+    // No tail swap — the pending append fills the deleted slot directly.
+    // Nothing gets blanked, row count is unchanged. The donated append
+    // includes `deleted: false` so its row is 3-wide; the untouched seeded
+    // rows stay 2-wide.
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows).toEqual([
+      ['id', 'name', 'deleted'],
+      ['cus_1', 'Alice'],
+      ['cus_4', 'Dave', 'false'], // donated into cus_2's slot
+      ['cus_3', 'Charlie'],
+    ])
+
+    // Donated append's new home is recorded in row_assignments so the
+    // service layer knows where to find it on the next sync.
+    expect(extractRowAssignments(out)).toEqual({ customers: { '["cus_4"]': 3 } })
+  })
+
+  it('1 delete + 2 appends → one donated, one appended to bottom; both in row_assignments', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWith()
+
+    await seedCustomers(dest, cat, [
+      ['cus_1', 'Alice'],
+      ['cus_2', 'Bob'],
+      ['cus_3', 'Charlie'],
+    ])
+
+    const out = await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([
+          record('customers', { id: 'cus_2', name: 'Bob', deleted: true }),
+          record('customers', { id: 'cus_4', name: 'Dave', deleted: false }),
+          record('customers', { id: 'cus_5', name: 'Eve', deleted: false }),
+        ])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows).toEqual([
+      ['id', 'name', 'deleted'],
+      ['cus_1', 'Alice'],
+      ['cus_4', 'Dave', 'false'], // donated into cus_2's slot (row 3)
+      ['cus_3', 'Charlie'],
+      ['cus_5', 'Eve', 'false'], // appended at bottom (row 5)
+    ])
+
+    expect(extractRowAssignments(out)).toEqual({
+      customers: { '["cus_4"]': 3, '["cus_5"]': 5 },
+    })
+  })
+
+  // MARK: - in-batch reconciliation
+
+  it('append and delete of the same rowKey in one batch cancel each other out', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWith()
+
+    // Empty sheet — the row was never in the sheet. Append would be wasted,
+    // the subsequent delete would immediately overwrite it: drop both.
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: cat },
+        toAsyncIter([
+          record('customers', { id: 'cus_1', name: 'Alice', deleted: false }),
+          record('customers', { id: 'cus_1', name: 'Alice', deleted: true }),
+        ])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows).toEqual([['id', 'name', 'deleted']])
+  })
+
+  // MARK: - no-ops and edges
+
+  it('delete of a rowKey that is not in the sheet is a silent no-op', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWith()
+
+    await seedCustomers(dest, cat, [
+      ['cus_1', 'Alice'],
+      ['cus_2', 'Bob'],
+    ])
+
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_missing', name: '', deleted: true })])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    // The delete record's `deleted: true` extends the header to 3 cols, but
+    // the untouched seeded data rows stay 2-wide.
+    expect(rows).toEqual([
+      ['id', 'name', 'deleted'],
+      ['cus_1', 'Alice'],
+      ['cus_2', 'Bob'],
+    ])
+  })
+
+  it('delete-only batch (no appends, no updates) still processes the delete', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWith()
+
+    await seedCustomers(dest, cat, [
+      ['cus_1', 'Alice'],
+      ['cus_2', 'Bob'],
+    ])
+
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice', deleted: true })])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows).toEqual([
+      ['id', 'name', 'deleted'],
+      ['cus_2', 'Bob'], // donor (row 3, seeded 2-wide) swapped into row 2
+      ['', '', ''], // row 3 blanked
+    ])
+  })
+
+  // MARK: - cross-cutting
+
+  it('deletes on one stream do not affect rows on a sibling stream', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const multiCat: ConfiguredCatalog = {
+      streams: [
+        catalogWith().streams[0],
+        {
+          stream: {
+            name: 'invoices',
+            primary_key: [['id']],
+            json_schema: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                amount: { type: 'number' },
+                deleted: { type: 'boolean' },
+              },
+            },
+          },
+          sync_mode: 'full_refresh',
+          destination_sync_mode: 'append',
+        },
+      ],
+    }
+
+    // Seed both streams
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: multiCat },
+        toAsyncIter([
+          record('customers', { id: 'cus_1', name: 'Alice', deleted: false }),
+          record('customers', { id: 'cus_2', name: 'Bob', deleted: false }),
+          record('invoices', { id: 'inv_1', amount: 100, deleted: false }),
+        ])
+      )
+    )
+
+    // Second write: delete on customers, append on invoices
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: multiCat },
+        toAsyncIter([
+          record('customers', { id: 'cus_1', name: 'Alice', deleted: true }),
+          record('invoices', { id: 'inv_2', amount: 200, deleted: false }),
+        ])
+      )
+    )
+
+    const customers = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(customers).toEqual([
+      ['id', 'name', 'deleted'],
+      ['cus_2', 'Bob', 'false'], // donor swapped in
+      ['', '', ''],
+    ])
+
+    const invoices = getData(getSpreadsheetIds()[0], 'invoices')!
+    expect(invoices).toEqual([
+      ['id', 'amount', 'deleted'],
+      ['inv_1', '100', 'false'], // unaffected by the customers delete
+      ['inv_2', '200', 'false'],
+    ])
+  })
+
+  it('composite primary key — delete resolves on the full key', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWith([['id'], ['_account_id']])
+
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: cat },
+        toAsyncIter([
+          record('customers', {
+            id: 'cus_1',
+            _account_id: 'acct_A',
+            name: 'Alice',
+            deleted: false,
+          }),
+        ])
+      )
+    )
+
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([
+          record('customers', {
+            id: 'cus_1',
+            _account_id: 'acct_A',
+            name: 'Alice',
+            deleted: true,
+          }),
+        ])
+      )
+    )
+
+    // Composite rowKey = '["cus_1","acct_A"]' matches the seeded row → tail blanked.
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    expect(rows).toEqual([
+      ['id', '_account_id', 'name', 'deleted'],
+      ['', '', '', ''],
+    ])
+  })
+
+  // MARK: - invariants
+
+  it('scattered deletes still produce a gap-free block of survivors at the top', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat = catalogWith()
+
+    await seedCustomers(dest, cat, [
+      ['cus_1', 'Alice'],
+      ['cus_2', 'Bob'],
+      ['cus_3', 'Charlie'],
+      ['cus_4', 'Dave'],
+      ['cus_5', 'Eve'],
+    ])
+
+    // Delete 3 rows scattered through body and tail: rows 2, 4, 5.
+    // Only row 6 (cus_5) is a tail survivor; it fills body delete at row 2.
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([
+          record('customers', { id: 'cus_1', name: 'Alice', deleted: true }),
+          record('customers', { id: 'cus_3', name: 'Charlie', deleted: true }),
+          record('customers', { id: 'cus_4', name: 'Dave', deleted: true }),
+        ])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const dataRows = rows.slice(1) // skip header
+    const nonBlankRows = dataRows.filter((r) => r.some((cell) => cell !== ''))
+    const firstBlankIdx = dataRows.findIndex((r) => r.every((cell) => cell === ''))
+
+    // Invariant: all non-blank rows precede all blank rows — no gaps.
+    expect(firstBlankIdx).toBe(nonBlankRows.length)
+
+    // Spot-check: surviving data is {cus_2, cus_5}; originally 5 rows, 3 deletes → 2 remain.
+    const survivingIds = nonBlankRows.map((r) => r[0]).sort()
+    expect(survivingIds).toEqual(['cus_2', 'cus_5'])
+  })
+})
+
 describe('envVars', () => {
   it('exports env var mapping', () => {
     expect(envVars.client_id).toBe('GOOGLE_CLIENT_ID')

--- a/packages/destination-google-sheets/src/index.ts
+++ b/packages/destination-google-sheets/src/index.ts
@@ -243,11 +243,12 @@ export function createDestination(
         ? config.spreadsheet_id
         : await createSpreadsheet(sheets, config.spreadsheet_title)
 
-      // Per-stream state: column headers plus buffered appends/updates.
+      // Per-stream state: column headers plus buffered appends/updates/deletes.
       const streamHeaders = new Map<string, string[]>()
       const sheetIds = new Map<string, number>()
       const appendBuffers = new Map<string, Array<{ row: string[]; rowKey?: string }>>()
       const updateBuffers = new Map<string, Array<{ rowNumber: number; values: string[] }>>()
+      const deleteBuffers = new Map<string, Array<{ rowKey?: string; rowNumber?: number }>>()
       const rowAssignments: Record<string, Record<string, number>> = {}
       // Pending append index: rowKey → index in appendBuffers for O(1) in-batch dedup
       const appendKeyIndex = new Map<string, Map<string, number>>()
@@ -287,6 +288,7 @@ export function createDestination(
           appendBuffers.set(streamName, [])
           appendKeyIndex.set(streamName, new Map())
           updateBuffers.set(streamName, [])
+          deleteBuffers.set(streamName, [])
         }
 
         const next = extendHeaders(headers, cleanData)
@@ -304,21 +306,28 @@ export function createDestination(
         const flushStart = Date.now()
         let totalBufferedAppends = 0
         let totalBufferedUpdates = 0
+        let totalBufferedDeletes = 0
         for (const [, arr] of appendBuffers) totalBufferedAppends += arr.length
         for (const [, arr] of updateBuffers) totalBufferedUpdates += arr.length
+        for (const [, arr] of deleteBuffers) totalBufferedDeletes += arr.length
         log.debug(
           {
             appends: totalBufferedAppends,
             updates: totalBufferedUpdates,
+            deletes: totalBufferedDeletes,
             streams: appendBuffers.size,
           },
           'flushAll start'
         )
 
         const opsByStream = new Map<string, StreamBatchOps>()
-        const streamNames = [...new Set([...appendBuffers.keys(), ...updateBuffers.keys()])]
+        const streamNames = [
+          ...new Set([...appendBuffers.keys(), ...updateBuffers.keys(), ...deleteBuffers.keys()]),
+        ]
 
-        // Only streams with keyed appends need a read-before-flush pass for dedup.
+        // Streams with keyed appends or any deletes need a read-before-flush
+        // pass: appends for dedupe, deletes for rowKey → rowNumber resolution
+        // and last-row-swap donor values.
         type StreamPrep = {
           streamName: string
           sheetId: number
@@ -326,13 +335,22 @@ export function createDestination(
           primaryKey: string[][] | undefined
           appends: Array<{ row: string[]; rowKey?: string }>
           bufferedUpdates: Array<{ rowNumber: number; values: string[] }>
+          bufferedDeletes: Array<{ rowNumber?: number; rowKey?: string }>
           needsRead: boolean
         }
         const prepInputs: StreamPrep[] = []
         for (const streamName of streamNames) {
-          const bufferedAppends = appendBuffers.get(streamName) ?? []
+          const bufferedAppends = (appendBuffers.get(streamName) ?? []).slice()
           const bufferedUpdates = (updateBuffers.get(streamName) ?? []).slice()
-          if (bufferedAppends.length === 0 && bufferedUpdates.length === 0) continue
+          const bufferedDeletes = (deleteBuffers.get(streamName) ?? []).slice()
+
+          if (
+            bufferedAppends.length === 0 &&
+            bufferedUpdates.length === 0 &&
+            bufferedDeletes.length === 0
+          ) {
+            continue
+          }
 
           const sheetId = sheetIds.get(streamName)
           if (sheetId === undefined) continue
@@ -343,15 +361,16 @@ export function createDestination(
             !!primaryKey &&
             primaryKey.length > 0 &&
             headers.length > 0 &&
-            bufferedAppends.some((e) => e.rowKey)
+            (bufferedAppends.some((e) => e.rowKey) || bufferedDeletes.length > 0)
 
           prepInputs.push({
             streamName,
             sheetId,
             headers,
             primaryKey,
-            appends: bufferedAppends.slice(),
+            appends: bufferedAppends,
             bufferedUpdates,
+            bufferedDeletes,
             needsRead,
           })
         }
@@ -365,7 +384,11 @@ export function createDestination(
         for (const prep of prepInputs) {
           if (!prep.needsRead || !prep.primaryKey) continue
           const pkFields = prep.primaryKey.map((p) => p[0])
-          const pkIsFirstN = pkFields.every((field, i) => prep.headers[i] === field)
+          // Tail-swap donor rows need full row values, not just the PK slice;
+          // suppress narrow reads whenever a stream has deletes.
+          const pkIsFirstN =
+            prep.bufferedDeletes.length === 0 &&
+            pkFields.every((field, i) => prep.headers[i] === field)
           narrowByStream.set(prep.streamName, pkIsFirstN)
           streamsToRead.push({
             name: prep.streamName,
@@ -400,7 +423,15 @@ export function createDestination(
         // Per-stream prep from pre-fetched rows. Stream order is preserved
         // so row_assignments tracking matches the previous sequential impl.
         for (const prep of prepInputs) {
-          const { streamName, sheetId, headers, primaryKey, bufferedUpdates, needsRead } = prep
+          const {
+            streamName,
+            sheetId,
+            headers,
+            primaryKey,
+            bufferedUpdates,
+            bufferedDeletes,
+            needsRead,
+          } = prep
           let appends = prep.appends
           let existingRowCount = 0
 
@@ -435,6 +466,118 @@ export function createDestination(
                   },
                   'dedup: converted appends to updates'
                 )
+              }
+
+              // Delete handling. Each delete resolves to a sheet rowNumber;
+              // we then fill those rows in two phases:
+              //   Phase 1 — donate pending appends: overwrite a deleted row
+              //             with an append's values instead of adding that
+              //             append at the bottom.
+              //   Phase 2 — tail-row swap: for surplus deletes, copy the
+              //             sheet's bottom-most surviving rows into the
+              //             deleted slots and blank the donor rows.
+              if (bufferedDeletes.length > 0) {
+                // In-batch reconcile by rowKey: a delete and a pending
+                // append for the same key cancel out — the row isn't in
+                // the sheet yet (we'd be about to append it) and the delete
+                // would immediately overwrite it. Drop both sides.
+                for (let i = bufferedDeletes.length - 1; i >= 0; i--) {
+                  const key = bufferedDeletes[i].rowKey
+                  if (key === undefined) continue
+                  const appendIdx = appends.findIndex((a) => a.rowKey === key)
+                  if (appendIdx >= 0) {
+                    appends.splice(appendIdx, 1)
+                    bufferedDeletes.splice(i, 1)
+                  }
+                }
+
+                const deleteRowNumbers = new Set<number>()
+                for (const entry of bufferedDeletes) {
+                  let rowNumber: number | undefined
+                  if (typeof entry.rowNumber === 'number') rowNumber = entry.rowNumber
+                  else if (entry.rowKey) rowNumber = freshMap.get(entry.rowKey)
+                  // Row 1 is the header row; data rows are [2, existingRowCount].
+                  if (rowNumber !== undefined && rowNumber >= 2 && rowNumber <= existingRowCount) {
+                    deleteRowNumbers.add(rowNumber)
+                  }
+                }
+
+                if (deleteRowNumbers.size > 0) {
+                  const blankRow = new Array<string>(headers.length).fill('')
+                  const deleteList = [...deleteRowNumbers].sort((a, b) => a - b)
+
+                  // Phase 1 — donate pending appends into deleted slots. If
+                  // the donor had a rowKey, record its new home in
+                  // rowAssignments (it no longer lands at the bottom).
+                  let donated = 0
+                  while (donated < deleteList.length && appends.length > 0) {
+                    const targetRow = deleteList[donated]
+                    const donor = appends.shift()!
+                    bufferedUpdates.push({ rowNumber: targetRow, values: donor.row })
+                    if (donor.rowKey) {
+                      rowAssignments[streamName] ??= {}
+                      rowAssignments[streamName][donor.rowKey] = targetRow
+                    }
+                    donated++
+                  }
+
+                  // Phase 2 — surplus deletes pull from the sheet tail.
+                  const remainingDeletes = deleteList.slice(donated)
+                  const K = remainingDeletes.length
+                  let swapped = 0
+                  let blanked = 0
+                  if (K > 0 && !isNarrow) {
+                    const tailStart = existingRowCount - K + 1
+                    const survivorDonors: number[] = []
+                    for (let r = tailStart; r <= existingRowCount; r++) {
+                      if (!deleteRowNumbers.has(r)) survivorDonors.push(r)
+                    }
+                    // Body deletes get a tail survivor's values; |survivors|
+                    // == |body deletes| by construction (both equal K − k
+                    // where k is the count of deletes already in the tail).
+                    const bodyDeletes = remainingDeletes.filter((r) => r < tailStart)
+                    const tailDeletes = remainingDeletes.filter((r) => r >= tailStart)
+                    for (let i = 0; i < bodyDeletes.length; i++) {
+                      const deletedRow = bodyDeletes[i]
+                      const donorRow = survivorDonors[i]
+                      // Full read: row 1 is headers, sheet row R ↔ allRows[R-1].
+                      const donorValues = (allRows[donorRow - 1] ?? []).map((v) =>
+                        v == null ? '' : String(v)
+                      )
+                      bufferedUpdates.push({ rowNumber: deletedRow, values: donorValues })
+                      bufferedUpdates.push({ rowNumber: donorRow, values: blankRow })
+                      swapped++
+                    }
+                    // Deletes already in the trailing range just get cleared.
+                    for (const deletedRow of tailDeletes) {
+                      bufferedUpdates.push({ rowNumber: deletedRow, values: blankRow })
+                      blanked++
+                    }
+                  } else if (K > 0 && isNarrow) {
+                    // Defensive: narrow reads are suppressed for streams
+                    // with deletes, so we shouldn't hit this. Fall back to
+                    // blanking without a tail swap so behavior stays sane.
+                    log.warn(
+                      { streamName, count: K },
+                      'deletes present on narrow-read stream; blanking without swap'
+                    )
+                    for (const rowNumber of remainingDeletes) {
+                      bufferedUpdates.push({ rowNumber, values: blankRow })
+                      blanked++
+                    }
+                  }
+
+                  log.debug(
+                    {
+                      streamName,
+                      deletes: deleteRowNumbers.size,
+                      donatedFromAppends: donated,
+                      swapped,
+                      blanked,
+                    },
+                    'delete handling'
+                  )
+                }
               }
             }
           }
@@ -484,6 +627,7 @@ export function createDestination(
           appendBuffers.set(streamName, [])
           appendKeyIndex.get(streamName)?.clear()
           updateBuffers.set(streamName, [])
+          deleteBuffers.set(streamName, [])
         }
 
         log.info({ durationMs: Date.now() - flushStart }, 'flushAll done')
@@ -517,7 +661,9 @@ export function createDestination(
                   ? serializeRowKey(primaryKey, cleanData)
                   : undefined
 
-            if (rowNumber !== undefined) {
+            if (cleanData['deleted'] === true) {
+              deleteBuffers.get(stream)!.push({ rowKey, rowNumber })
+            } else if (rowNumber !== undefined) {
               // 1. Explicit _row_number (backwards compat with service layer)
               updateBuffers.get(stream)!.push({ rowNumber, values: row })
             } else if (rowKey) {


### PR DESCRIPTION
## Summary

Before this PR, the Google Sheets destination would update the row with a field 'deleted=true', this is changed now to actually remove the row from the table.

Two things were broken end-to-end before I could test the destination with live deletes so this PR depends on.
#331 #332

## How delete handling works

Records with cleanData['deleted'] === true go into a new per-stream deleteBuffers map, alongside the existing appendBuffers and updateBuffers.

Phase 1, donate appends. For each deleted row, pop a pending append and write it as an update at the deleted slot. No new row at the bottom.
Phase 2, tail swap. When deletes outnumber appends, take the bottom-most surviving rows and pair each body-delete with one of them: write the donor's values into the deleted row, blank the donor's original row. Deletes that already fall inside the trailing range are blanked in place. Result: Data stay contiguous at the top, blanks only appear at the bottom.

Also added an in-batch reconciliation step: if a pending append and a delete share a rowKey (typical when customer.created and customer.deleted arrive in the same poll cycle), drop both. The row was never in the sheet, the delete has nothing to target, and appending just to compact would be wasted work.

## Tests
Added a describe('delete handling') block with 15 cases covering routing, both compaction phases, in-batch reconciliation, multi-stream isolation, composite primary keys, and a no-gap invariant. A
`pnpm --filter @stripe/sync-destination-google-sheets exec vitest run src/index.test.ts -t 'delete handling'`