### PR TITLE
Fix Postgres upsert & add Google sheet upsert support

### DIFF
--- a/apps/engine/src/__generated__/openapi.d.ts
+++ b/apps/engine/src/__generated__/openapi.d.ts
@@ -337,8 +337,11 @@ export interface components {
                     metadata?: {
                         [key: string]: unknown;
                     };
-                    /** @description Field whose value increases monotonically. Destination uses it to skip stale writes (e.g. "updated"). */
-                    newer_than_field?: string;
+                    /**
+                     * @description Field whose value increases monotonically. Destination uses it to skip stale writes (e.g. "updated").
+                     * @default _updated_at
+                     */
+                    newer_than_field: string;
                     /** @description Field in record data that signals a soft delete (e.g. "deleted"). Destination uses this to classify upserts as deletes when the field is truthy. */
                     soft_delete_field?: string;
                 }[];

--- a/apps/engine/src/__generated__/openapi.d.ts
+++ b/apps/engine/src/__generated__/openapi.d.ts
@@ -337,10 +337,7 @@ export interface components {
                     metadata?: {
                         [key: string]: unknown;
                     };
-                    /**
-                     * @description Field whose value increases monotonically. Destination uses it to skip stale writes (e.g. "updated").
-                     * @default _updated_at
-                     */
+                    /** @description Field whose value increases monotonically. Destination uses it to skip stale writes (e.g. "updated"). */
                     newer_than_field: string;
                     /** @description Field in record data that signals a soft delete (e.g. "deleted"). Destination uses this to classify upserts as deletes when the field is truthy. */
                     soft_delete_field?: string;

--- a/apps/engine/src/__generated__/openapi.json
+++ b/apps/engine/src/__generated__/openapi.json
@@ -1094,6 +1094,7 @@
                       "additionalProperties": {}
                     },
                     "newer_than_field": {
+                      "default": "_updated_at",
                       "description": "Field whose value increases monotonically. Destination uses it to skip stale writes (e.g. \"updated\").",
                       "type": "string"
                     },

--- a/apps/engine/src/__generated__/openapi.json
+++ b/apps/engine/src/__generated__/openapi.json
@@ -1094,9 +1094,8 @@
                       "additionalProperties": {}
                     },
                     "newer_than_field": {
-                      "default": "_updated_at",
-                      "description": "Field whose value increases monotonically. Destination uses it to skip stale writes (e.g. \"updated\").",
-                      "type": "string"
+                      "type": "string",
+                      "description": "Field whose value increases monotonically. Destination uses it to skip stale writes (e.g. \"updated\")."
                     },
                     "soft_delete_field": {
                       "description": "Field in record data that signals a soft delete (e.g. \"deleted\"). Destination uses this to classify upserts as deletes when the field is truthy.",
@@ -1105,7 +1104,8 @@
                   },
                   "required": [
                     "name",
-                    "primary_key"
+                    "primary_key",
+                    "newer_than_field"
                   ],
                   "description": "A named collection of records — analogous to a table or API resource."
                 },

--- a/apps/engine/src/__tests__/stripe-to-postgres.test.ts
+++ b/apps/engine/src/__tests__/stripe-to-postgres.test.ts
@@ -49,16 +49,6 @@ beforeAll(async () => {
     if (i === 29) throw new Error('Postgres did not become ready in time')
   }
 
-  // Create the trigger function that destination-postgres expects
-  await pool.query(`
-    CREATE OR REPLACE FUNCTION set_updated_at() RETURNS trigger LANGUAGE plpgsql AS $$
-    BEGIN
-      NEW := jsonb_populate_record(NEW, jsonb_build_object('updated_at', now(), '_updated_at', now()));
-      RETURN NEW;
-    END;
-    $$;
-  `)
-
   console.log(`\n  Postgres: ${connectionString}`)
 }, 60_000)
 

--- a/apps/engine/src/__tests__/sync.test.ts
+++ b/apps/engine/src/__tests__/sync.test.ts
@@ -77,12 +77,14 @@ async function* toAsync<T>(items: T[]): AsyncIterable<T> {
   }
 }
 
+// Monotonic seconds so consecutive records are strictly newer (staleness gate rejects equal stamps).
+let nextRecordTs = Math.floor(Date.now() / 1000)
 function record(stream: string, id: string, data?: Record<string, unknown>): RecordMessage {
   return {
     type: 'record',
     record: {
       stream,
-      data: { id, ...data },
+      data: { id, _updated_at: nextRecordTs++, ...data },
       emitted_at: new Date().toISOString(),
     },
   }

--- a/apps/engine/src/api/app.test.ts
+++ b/apps/engine/src/api/app.test.ts
@@ -355,7 +355,11 @@ describe('engine request id header', () => {
       async *discover() {
         yield {
           type: 'catalog' as const,
-          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+          catalog: {
+            streams: [
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+            ],
+          },
         }
       },
       async *read() {
@@ -465,7 +469,11 @@ describe('engine request id header', () => {
       async *discover() {
         yield {
           type: 'catalog' as const,
-          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+          catalog: {
+            streams: [
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+            ],
+          },
         }
       },
       async *read() {

--- a/apps/engine/src/lib/destination-filter.test.ts
+++ b/apps/engine/src/lib/destination-filter.test.ts
@@ -11,7 +11,12 @@ function makeCatalog(
 ): ConfiguredCatalog {
   return {
     streams: streams.map((s) => ({
-      stream: { name: s.name, primary_key: [['id']], json_schema: s.json_schema },
+      stream: {
+        name: s.name,
+        primary_key: [['id']],
+        newer_than_field: '_updated_at',
+        json_schema: s.json_schema,
+      },
       sync_mode: 'full_refresh' as const,
       destination_sync_mode: 'append' as const,
       fields: s.fields,

--- a/apps/engine/src/lib/engine.test.ts
+++ b/apps/engine/src/lib/engine.test.ts
@@ -86,7 +86,11 @@ describe('protocol schemas', () => {
   describe('Stream', () => {
     it('parses a valid stream', () => {
       const result = Stream.parse({ name: 'customers', primary_key: [['id']] })
-      expect(result).toEqual({ name: 'customers', primary_key: [['id']] })
+      expect(result).toEqual({
+        name: 'customers',
+        primary_key: [['id']],
+        newer_than_field: '_updated_at',
+      })
     })
 
     it('parses with optional fields', () => {

--- a/apps/engine/src/lib/engine.test.ts
+++ b/apps/engine/src/lib/engine.test.ts
@@ -85,7 +85,11 @@ beforeEach(() => {
 describe('protocol schemas', () => {
   describe('Stream', () => {
     it('parses a valid stream', () => {
-      const result = Stream.parse({ name: 'customers', primary_key: [['id']] })
+      const result = Stream.parse({
+        name: 'customers',
+        primary_key: [['id']],
+        newer_than_field: '_updated_at',
+      })
       expect(result).toEqual({
         name: 'customers',
         primary_key: [['id']],
@@ -97,6 +101,7 @@ describe('protocol schemas', () => {
       const result = Stream.parse({
         name: 'users',
         primary_key: [['id']],
+        newer_than_field: '_updated_at',
         json_schema: { type: 'object' },
         metadata: { account_id: 'acct_123' },
       })
@@ -105,18 +110,20 @@ describe('protocol schemas', () => {
     })
 
     it('rejects missing name', () => {
-      expect(() => Stream.parse({ primary_key: [['id']] })).toThrow()
+      expect(() =>
+        Stream.parse({ primary_key: [['id']], newer_than_field: '_updated_at' })
+      ).toThrow()
     })
 
     it('rejects missing primary_key', () => {
-      expect(() => Stream.parse({ name: 'test' })).toThrow()
+      expect(() => Stream.parse({ name: 'test', newer_than_field: '_updated_at' })).toThrow()
     })
   })
 
   describe('ConfiguredStream', () => {
     it('parses a valid configured stream', () => {
       const result = ConfiguredStream.parse({
-        stream: { name: 'customers', primary_key: [['id']] },
+        stream: { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
         sync_mode: 'incremental',
         destination_sync_mode: 'append_dedup',
         cursor_field: ['updated_at'],
@@ -128,7 +135,7 @@ describe('protocol schemas', () => {
     it('rejects invalid sync_mode', () => {
       expect(() =>
         ConfiguredStream.parse({
-          stream: { name: 'test', primary_key: [['id']] },
+          stream: { name: 'test', primary_key: [['id']], newer_than_field: '_updated_at' },
           sync_mode: 'invalid',
           destination_sync_mode: 'append',
         })
@@ -141,7 +148,7 @@ describe('protocol schemas', () => {
       const result = ConfiguredCatalog.parse({
         streams: [
           {
-            stream: { name: 'customers', primary_key: [['id']] },
+            stream: { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
             sync_mode: 'full_refresh',
             destination_sync_mode: 'overwrite',
           },
@@ -216,7 +223,7 @@ describe('protocol schemas', () => {
       const msg = CatalogMessage.parse({
         type: 'catalog',
         catalog: {
-          streams: [{ name: 'users', primary_key: [['id']] }],
+          streams: [{ name: 'users', primary_key: [['id']], newer_than_field: '_updated_at' }],
         },
       })
       expect(msg.catalog.streams).toHaveLength(1)
@@ -261,7 +268,12 @@ describe('protocol schemas', () => {
           record: { stream: 's', data: {}, emitted_at: '2024-01-01T00:00:00.000Z' },
         },
         { type: 'source_state', source_state: { stream: 's', data: null } },
-        { type: 'catalog', catalog: { streams: [{ name: 's', primary_key: [['id']] }] } },
+        {
+          type: 'catalog',
+          catalog: {
+            streams: [{ name: 's', primary_key: [['id']], newer_than_field: '_updated_at' }],
+          },
+        },
         { type: 'log', log: { level: 'info', message: 'hi' } },
         {
           type: 'connection_status',
@@ -514,7 +526,9 @@ describe('engine message validation', () => {
         yield {
           type: 'catalog',
           catalog: {
-            streams: [{ name: 'customers', primary_key: [['id']] }],
+            streams: [
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+            ],
           },
         }
       },
@@ -624,7 +638,9 @@ describe('engine stream membership validation', () => {
         yield {
           type: 'catalog',
           catalog: {
-            streams: [{ name: 'customers', primary_key: [['id']] }],
+            streams: [
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+            ],
           },
         }
       },
@@ -687,7 +703,11 @@ describe('engine.pipeline_sync() pipeline', () => {
       async *discover() {
         yield {
           type: 'catalog',
-          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+          catalog: {
+            streams: [
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+            ],
+          },
         }
       },
       async *read(params) {
@@ -737,7 +757,11 @@ describe('engine.pipeline_sync() pipeline', () => {
       async *discover() {
         yield {
           type: 'catalog',
-          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+          catalog: {
+            streams: [
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+            ],
+          },
         }
       },
       async *read(params) {
@@ -787,7 +811,11 @@ describe('engine.pipeline_sync() pipeline', () => {
       async *discover() {
         yield {
           type: 'catalog',
-          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+          catalog: {
+            streams: [
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+            ],
+          },
         }
       },
       async *read(params) {
@@ -834,7 +862,11 @@ describe('engine.pipeline_sync() pipeline', () => {
       async *discover() {
         yield {
           type: 'catalog',
-          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+          catalog: {
+            streams: [
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+            ],
+          },
         }
       },
       async *read() {
@@ -888,7 +920,11 @@ describe('engine.pipeline_sync() pipeline', () => {
       async *discover() {
         yield {
           type: 'catalog',
-          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+          catalog: {
+            streams: [
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+            ],
+          },
         }
       },
       async *read() {
@@ -940,9 +976,9 @@ describe('engine.pipeline_sync() pipeline', () => {
           type: 'catalog',
           catalog: {
             streams: [
-              { name: 'customers', primary_key: [['id']] },
-              { name: 'charges', primary_key: [['id']] },
-              { name: 'invoices', primary_key: [['id']] },
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+              { name: 'charges', primary_key: [['id']], newer_than_field: '_updated_at' },
+              { name: 'invoices', primary_key: [['id']], newer_than_field: '_updated_at' },
             ],
           },
         }
@@ -1032,8 +1068,8 @@ describe('engine.pipeline_sync() pipeline', () => {
           type: 'catalog',
           catalog: {
             streams: [
-              { name: 'customers', primary_key: [['id']] },
-              { name: 'charges', primary_key: [['id']] },
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+              { name: 'charges', primary_key: [['id']], newer_than_field: '_updated_at' },
             ],
           },
         }
@@ -1114,8 +1150,8 @@ describe('engine.pipeline_sync() pipeline', () => {
           type: 'catalog',
           catalog: {
             streams: [
-              { name: 'customers', primary_key: [['id']] },
-              { name: 'charges', primary_key: [['id']] },
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+              { name: 'charges', primary_key: [['id']], newer_than_field: '_updated_at' },
             ],
           },
         }
@@ -1209,8 +1245,8 @@ describe('engine.pipeline_sync() pipeline', () => {
           type: 'catalog',
           catalog: {
             streams: [
-              { name: 'customers', primary_key: [['id']] },
-              { name: 'invoices', primary_key: [['id']] },
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+              { name: 'invoices', primary_key: [['id']], newer_than_field: '_updated_at' },
             ],
           },
         }
@@ -1295,7 +1331,11 @@ describe('engine.pipeline_sync() pipeline', () => {
       async *discover() {
         yield {
           type: 'catalog',
-          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+          catalog: {
+            streams: [
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+            ],
+          },
         }
       },
       async *read() {},
@@ -1341,7 +1381,11 @@ describe('engine.pipeline_sync() pipeline', () => {
       async *discover() {
         yield {
           type: 'catalog',
-          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+          catalog: {
+            streams: [
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+            ],
+          },
         }
       },
       async *read() {
@@ -1413,8 +1457,8 @@ describe('engine.pipeline_sync() pipeline', () => {
           type: 'catalog',
           catalog: {
             streams: [
-              { name: 'customers', primary_key: [['id']] },
-              { name: 'products', primary_key: [['id']] },
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+              { name: 'products', primary_key: [['id']], newer_than_field: '_updated_at' },
             ],
           },
         }
@@ -1473,8 +1517,8 @@ describe('engine.pipeline_sync() pipeline', () => {
           type: 'catalog',
           catalog: {
             streams: [
-              { name: 'customers', primary_key: [['id']] },
-              { name: 'products', primary_key: [['id']] },
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+              { name: 'products', primary_key: [['id']], newer_than_field: '_updated_at' },
             ],
           },
         }
@@ -1643,7 +1687,9 @@ describe('engine.pipeline_sync() pipeline', () => {
         yield {
           type: 'catalog',
           catalog: {
-            streams: [{ name: 'customers', primary_key: [['id']] }],
+            streams: [
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+            ],
           },
         }
       },
@@ -1738,7 +1784,11 @@ describe('engine.pipeline_sync() graceful close', () => {
       async *discover() {
         yield {
           type: 'catalog',
-          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+          catalog: {
+            streams: [
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+            ],
+          },
         } as CatalogMessage
       },
       async *read() {
@@ -1888,7 +1938,11 @@ describe('engine cancellation integration', () => {
       async *discover() {
         yield {
           type: 'catalog',
-          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+          catalog: {
+            streams: [
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+            ],
+          },
         } as CatalogMessage
       },
       read() {
@@ -1968,7 +2022,11 @@ describe('engine cancellation integration', () => {
       async *discover() {
         yield {
           type: 'catalog',
-          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+          catalog: {
+            streams: [
+              { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
+            ],
+          },
         } as CatalogMessage
       },
       read() {
@@ -2091,7 +2149,9 @@ describe('engine cancellation integration', () => {
 
 describe('withTimeRanges', () => {
   function mkCatalog(streamNames: string[]) {
-    return buildCatalog(streamNames.map((name) => ({ name, primary_key: [['id']] })))
+    return buildCatalog(
+      streamNames.map((name) => ({ name, primary_key: [['id']], newer_than_field: '_updated_at' }))
+    )
   }
 
   it('returns same catalog when timeCeiling is undefined', () => {
@@ -2191,7 +2251,7 @@ describe('engine.pipeline_setup() timeout', () => {
         yield {
           type: 'catalog',
           catalog: {
-            streams: [{ name: 'items', primary_key: [['id']] }],
+            streams: [{ name: 'items', primary_key: [['id']], newer_than_field: '_updated_at' }],
           },
         }
       },

--- a/apps/engine/src/lib/pipeline.test.ts
+++ b/apps/engine/src/lib/pipeline.test.ts
@@ -33,7 +33,12 @@ function catalog(
 ): ConfiguredCatalog {
   return {
     streams: streams.map((s) => ({
-      stream: { name: s.name, primary_key: [['id']], json_schema: s.json_schema },
+      stream: {
+        name: s.name,
+        primary_key: [['id']],
+        newer_than_field: '_updated_at',
+        json_schema: s.json_schema,
+      },
       sync_mode: 'full_refresh',
       destination_sync_mode: 'append',
       fields: s.fields,

--- a/apps/engine/src/lib/source-test.ts
+++ b/apps/engine/src/lib/source-test.ts
@@ -42,6 +42,7 @@ export const sourceTest = {
       ? Object.entries(config.streams).map(([name, def]) => ({
           name,
           primary_key: def.primary_key ?? [['id']],
+          newer_than_field: '_updated_at',
         }))
       : []
     yield { type: 'catalog', catalog: { streams } }

--- a/apps/supabase/src/edge-functions/stripe-webhook.ts
+++ b/apps/supabase/src/edge-functions/stripe-webhook.ts
@@ -56,7 +56,7 @@ Deno.serve(async (req) => {
 
   const catalog = {
     streams: DEFAULT_SYNC_OBJECTS.map((name) => ({
-      stream: { name, primary_key: [['id']] },
+      stream: { name, primary_key: [['id']], newer_than_field: '_updated_at' },
       sync_mode: 'full_refresh' as const,
       destination_sync_mode: 'append_dedup' as const,
     })),

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -71,3 +71,102 @@ Short records of key architectural choices and why they were made.
 - _Generic metadata bag_ (`metadata: Record<string, unknown>` on `ConnectorSpecification`): Untyped, hard for clients to discover without documentation.
 
 **Consequence:** The version list is static — updated when the connector package is released. The `SUPPORTED_API_VERSIONS` constant in `@stripe/sync-openapi` is the source of truth. Versions not in the enum are rejected at config validation time.
+
+## DDR-009: Source-synthesised `_updated_at` for staleness gating
+
+**Decision:** Every stream in the Stripe source catalog declares
+`newer_than_field = '_updated_at'` and includes
+`_updated_at: { type: 'integer' }` in `json_schema.properties`. The
+source stamps every record with a unix-seconds value on that field.
+Destinations project `_updated_at` from `_raw_data` as a queryable
+column (e.g. Postgres timestamptz via `to_timestamp(...)`); they never
+compute or rewrite the value.
+
+The source's stamping ladder, by code path:
+
+- **Webhook / events API / WebSocket** (`process-event.ts`):
+  `dataObject.updated` if Stripe provides one, else `event.created`.
+- **List-API backfill** (`src-list-api.ts`):
+  `record.updated` if present, else `response.responseAt` — the HTTP `Date`
+  header on the page response, which falls back to local `now()` inside
+  `@stripe/sync-openapi/listFnResolver.ts` so it is never undefined.
+
+**Rationale:** Stripe declares a native `updated` field on roughly 8 of
+~100 resources. The remaining ~95% (customer, charge, invoice,
+subscription, …) have no source-side staleness signal at all, so
+out-of-order webhook deliveries — or a backfill page racing a live
+webhook — silently overwrote newer rows with older. Synthesising one
+canonical column in the source gives the whole catalog one uniform gate
+that destinations can rely on without per-resource branching.
+
+**Alternatives considered:**
+
+- _Destination-side wall clock_ (previous behaviour): each destination
+  stamped its own `_updated_at = now()`. Two destinations writing the
+  same record produced different timestamps, and a re-delivered event
+  always looked "newer" than the original — defeating the gate.
+- _Per-stream catalog overrides_: declare `newer_than_field = 'updated'`
+  on the resources that have it, leave it unset elsewhere. Loses
+  protection on the long tail and forces destinations into a "no gate"
+  fallback.
+- _`event.created` only_: simpler, but discards the more accurate
+  `record.updated` value where Stripe provides it, and offers nothing
+  for backfill rows.
+- _Destination-owned column not in `json_schema.properties`_: required
+  the engine's `enforceCatalog` to learn an exemption for
+  `newer_than_field`. Declaring `_updated_at` in the catalog as
+  `{type: 'integer'}` keeps the wire contract honest and the engine's
+  field filter generic.
+- _`_updated_at` as a `GENERATED ALWAYS` column_: cleaner per-table model
+  but breaks existing deployments — the legacy column was a non-generated
+  `timestamptz NOT NULL DEFAULT now()` and Postgres requires a column
+  drop+recreate to switch a non-generated column to generated. Kept the
+  legacy shape and explicit write in `upsertMany` to avoid a forced
+  schema migration.
+
+**Cross-layer plumbing this requires:**
+
+1. **Catalog declaration** (`source-stripe/src/catalog.ts`): every
+   stream sets `newer_than_field = '_updated_at'` and adds
+   `_updated_at: { type: 'integer' }` to `json_schema.properties` plus
+   `json_schema.required`. The field is part of the wire schema, so the
+   engine's `enforceCatalog` lets it through naturally without a per-field
+   exemption.
+2. **Postgres column shape** (`destination-postgres/src/schemaProjection.ts`):
+   `_updated_at` is a hardcoded non-generated `timestamptz NOT NULL
+   DEFAULT now()` column at the top of every table. This shape is kept
+   for backward compat: existing deployments need no column migration.
+   `jsonSchemaToColumns` skips `_updated_at` so it's never also emitted
+   as a generated column on top of the hardcoded one. The
+   `handle_updated_at` trigger is dropped at setup; the column is now
+   maintained by `upsertMany`, not by a row trigger.
+3. **Postgres write**
+   (`destination-postgres/src/index.ts`, `upsertMany`): the only writer of
+   the column. It reads the source-stamped unix seconds at
+   `record.data[newer_than_field]`, converts to ISO per row, and INSERTs
+   into the `_updated_at` column. The staleness gate is hardcoded as
+   `newerThanColumn: '_updated_at'` regardless of what the catalog calls
+   `newer_than_field` — the source field name maps to a fixed destination
+   column. Records arriving without a numeric `newer_than_field` value
+   throw a loud error with a DDR-009 reference (principle #5).
+4. **Sheets explicit write**
+   (`destination-google-sheets/src/index.ts`): the source value is
+   written into the `_updated_at` cell verbatim, and in-batch dedup
+   compares it. Missing values throw with a DDR-009 reference; stale
+   in-batch dupes are dropped with a debug log.
+
+**Consequence:**
+
+- Destinations never compute or refresh `_updated_at`; the source is the
+  single writer. See principle #12.
+- The legacy auto-update mechanism is removed in two places:
+  `DROP TRIGGER IF EXISTS handle_updated_at` per table inside
+  `buildCreateTableWithSchema`, and
+  `DROP FUNCTION IF EXISTS set_updated_at() CASCADE` once at setup; the
+  `CASCADE` cleans up orphan triggers from older deployments.
+- The same Stripe object stamps to the same value regardless of delivery
+  path (webhook re-delivery, backfill, WebSocket), so duplicates collapse
+  cleanly through the gate.
+- `_updated_at` is part of the published wire schema. Tools that
+  consume the catalog (introspection, OpenAPI generation, custom
+  destinations) see the field and can decide their own projection.

--- a/docs/architecture/principles.md
+++ b/docs/architecture/principles.md
@@ -45,3 +45,7 @@ Connectors must emit `LogMessage` or `TraceMessage` during long-running operatio
 ## 11. Stripe polymorphism pattern
 
 Polymorphic objects use `{type, [type]: payload}` where the `type` value names the sub-hash key. This is Stripe's standard API polymorphism pattern (see Trailhead: `api-design/polymorphism-in-the-stripe-api`). Examples: `PipelineConfig.source` uses `{type: 'stripe', stripe: {...}}`, `ControlPayload` uses `{control_type: 'source_config', source_config: {...}}`, `TracePayload` uses `{trace_type: 'error', error: {...}}`.
+
+## 12. Destinations never own `_updated_at`
+
+Source is the single writer; destinations only store and gate. See [DDR-009](./decisions.md#ddr-009-source-synthesised-_updated_at-for-staleness-gating).

--- a/packages/destination-google-sheets/__tests__/integration.test.ts
+++ b/packages/destination-google-sheets/__tests__/integration.test.ts
@@ -24,6 +24,11 @@ describeWithEnv(
       return google.sheets({ version: 'v4', auth })
     }
 
+    function stripUpdatedAt(rows: unknown[][]): unknown[][] {
+      const idx = rows[0]?.indexOf('_updated_at') ?? -1
+      return idx < 0 ? rows : rows.map((row) => row.filter((_, i) => i !== idx))
+    }
+
     it.skip('writes records to an existing spreadsheet and reads them back', async () => {
       const sheets = makeSheetsClient()
       const dest = createDestination(sheets)
@@ -151,6 +156,7 @@ describeWithEnv(
         iso.slice(20, 23)
       const streamName = `upsert_${ts}`
       const emittedAt = new Date().toISOString()
+      let nextUpdatedAt = Math.floor(Date.now() / 1000)
 
       const config: Config = {
         client_id: GOOGLE_CLIENT_ID,
@@ -190,7 +196,7 @@ describeWithEnv(
           type: 'record',
           record: {
             stream: streamName,
-            data: { id: 'cus_1', name: 'Alice', balance: 100 },
+            data: { id: 'cus_1', name: 'Alice', balance: 100, _updated_at: nextUpdatedAt++ },
             emitted_at: emittedAt,
           },
         },
@@ -198,7 +204,7 @@ describeWithEnv(
           type: 'record',
           record: {
             stream: streamName,
-            data: { id: 'cus_2', name: 'Bob', balance: 250 },
+            data: { id: 'cus_2', name: 'Bob', balance: 250, _updated_at: nextUpdatedAt++ },
             emitted_at: emittedAt,
           },
         },
@@ -206,7 +212,7 @@ describeWithEnv(
           type: 'record',
           record: {
             stream: streamName,
-            data: { id: 'cus_3', name: 'Charlie', balance: 0 },
+            data: { id: 'cus_3', name: 'Charlie', balance: 0, _updated_at: nextUpdatedAt++ },
             emitted_at: emittedAt,
           },
         },
@@ -219,7 +225,7 @@ describeWithEnv(
       expect(output1.filter((m) => m.type === 'trace')).toHaveLength(0)
 
       // Verify initial state
-      let rows = await readSheet(sheets, GOOGLE_SPREADSHEET_ID, streamName)
+      let rows = stripUpdatedAt(await readSheet(sheets, GOOGLE_SPREADSHEET_ID, streamName))
       expect(rows).toHaveLength(4) // header + 3 rows
       expect(rows[0]).toEqual(['id', 'name', 'balance']) // PK-first ordering
 
@@ -229,7 +235,7 @@ describeWithEnv(
           type: 'record',
           record: {
             stream: streamName,
-            data: { id: 'cus_1', name: 'Alice Updated', balance: 150 },
+            data: { id: 'cus_1', name: 'Alice Updated', balance: 150, _updated_at: nextUpdatedAt++ },
             emitted_at: emittedAt,
           },
         },
@@ -237,7 +243,7 @@ describeWithEnv(
           type: 'record',
           record: {
             stream: streamName,
-            data: { id: 'cus_3', name: 'Charlie Updated', balance: 50 },
+            data: { id: 'cus_3', name: 'Charlie Updated', balance: 50, _updated_at: nextUpdatedAt++ },
             emitted_at: emittedAt,
           },
         },
@@ -245,7 +251,7 @@ describeWithEnv(
           type: 'record',
           record: {
             stream: streamName,
-            data: { id: 'cus_4', name: 'Diana', balance: 300 },
+            data: { id: 'cus_4', name: 'Diana', balance: 300, _updated_at: nextUpdatedAt++ },
             emitted_at: emittedAt,
           },
         },
@@ -259,7 +265,7 @@ describeWithEnv(
       expect(output2.filter((m) => m.type === 'trace')).toHaveLength(0)
 
       // Verify upsert results
-      rows = await readSheet(sheets, GOOGLE_SPREADSHEET_ID, streamName)
+      rows = stripUpdatedAt(await readSheet(sheets, GOOGLE_SPREADSHEET_ID, streamName))
       expect(rows).toHaveLength(5) // header + 3 original + 1 new
       expect(rows[0]).toEqual(['id', 'name', 'balance'])
       expect(rows[1]).toEqual(['cus_1', 'Alice Updated', '150']) // updated in place

--- a/packages/destination-google-sheets/__tests__/integration.test.ts
+++ b/packages/destination-google-sheets/__tests__/integration.test.ts
@@ -168,6 +168,7 @@ describeWithEnv(
             stream: {
               name: streamName,
               primary_key: [['id']],
+              newer_than_field: '_updated_at',
               json_schema: {
                 type: 'object',
                 properties: {

--- a/packages/destination-google-sheets/src/index.test.ts
+++ b/packages/destination-google-sheets/src/index.test.ts
@@ -43,9 +43,13 @@ async function* toAsyncIter<T>(items: T[]): AsyncIterableIterator<T> {
 }
 
 const now = new Date().toISOString()
+let nextRecordTs = Math.floor(Date.now() / 1000)
 
 function record(stream: string, data: Record<string, unknown>): DestinationInput {
-  return { type: 'record', record: { stream, data, emitted_at: now } }
+  return {
+    type: 'record',
+    record: { stream, data: { _updated_at: nextRecordTs++, ...data }, emitted_at: now },
+  }
 }
 
 function state(stream: string, data: unknown): DestinationInput {
@@ -1606,6 +1610,27 @@ describe('newer_than_field stale write prevention', () => {
     ],
   }
 
+  it('fails loud when an incoming record is missing newer_than_field', async () => {
+    const { sheets } = createMemorySheets()
+    const dest = createDestination(sheets)
+
+    const output = await collect(
+      dest.write(
+        { config: cfg(), catalog: newerThanCatalog },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice' })])
+      )
+    )
+
+    expect(output).toContainEqual({
+      type: 'connection_status',
+      connection_status: {
+        status: 'failed',
+        message:
+          'stream "customers" record missing newer_than_field "updated"; source must stamp this field on every record per DDR-009',
+      },
+    })
+  })
+
   it('skips upsert when incoming record is older than existing (across batches)', async () => {
     const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
     const dest = createDestination(sheets)
@@ -1728,13 +1753,8 @@ describe('newer_than_field stale write prevention', () => {
 })
 
 describe('_updated_at column (source-owned, passthrough)', () => {
-  // The Stripe source stamps every record with `_updated_at` (unix
-  // seconds, from `event.created` for webhooks or the HTTP `Date`
-  // header for backfill, falling back to local now()). The destination
-  // is intentionally passive — it does not generate, refresh, or
-  // override the value. PG mirrors this with a generated column over
-  // `_raw_data->>'_updated_at'`; Sheets just passes the raw value
-  // through, no stamping logic of its own.
+  // The Stripe source stamps `_updated_at`; Sheets passes it through and
+  // uses it for stale-write gating, but never invents its own timestamp.
   it('only writes a _updated_at column when the source provides the value', async () => {
     const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
     const dest = createDestination(sheets)
@@ -1742,7 +1762,16 @@ describe('_updated_at column (source-owned, passthrough)', () => {
     await collect(
       dest.write(
         { config: cfg(), catalog },
-        toAsyncIter([record('users', { id: 'u1', name: 'Alice' })])
+        toAsyncIter([
+          {
+            type: 'record',
+            record: {
+              stream: 'users',
+              data: { id: 'u1', name: 'Alice' },
+              emitted_at: now,
+            },
+          },
+        ])
       )
     )
 

--- a/packages/destination-google-sheets/src/index.test.ts
+++ b/packages/destination-google-sheets/src/index.test.ts
@@ -11,6 +11,25 @@ import {
 import { applyBatch, MAX_CELLS_PER_SPREADSHEET, readSheet, type StreamBatchOps } from './writer.js'
 import { createMemorySheets } from '../__tests__/memory-sheets.js'
 
+/**
+ * Strip the source-provided `_updated_at` column from a 2D rows array.
+ *
+ * The source stamps every record with `_updated_at` (unix seconds, from
+ * `event.created` for webhooks or the HTTP `Date` header for backfill);
+ * the destination passes the value through verbatim. Most tests don't
+ * care about its exact value and just want to assert on source data;
+ * use this helper at the assertion site to drop the column before
+ * comparing. Tests that exercise the column itself stay in the
+ * `_updated_at column` describe block at the bottom of this file.
+ */
+function stripUpdatedAt(rows: unknown[][] | undefined): unknown[][] {
+  if (!rows || rows.length === 0) return rows ?? []
+  const header = rows[0] as unknown[]
+  const idx = header.indexOf('_updated_at')
+  if (idx < 0) return rows
+  return rows.map((row) => row.filter((_, i) => i !== idx))
+}
+
 /** Collect all output from the destination's write() generator. */
 async function collect(iter: AsyncIterable<DestinationOutput>): Promise<DestinationOutput[]> {
   const out: DestinationOutput[] = []
@@ -61,7 +80,7 @@ describe('destination-google-sheets', () => {
     await collect(dest.write({ config: cfg(), catalog }, toAsyncIter(messages)))
 
     const id = getSpreadsheetIds()[0]
-    const rows = getData(id, 'users')!
+    const rows = stripUpdatedAt(getData(id, 'users')!)
     expect(rows[0]).toEqual(['id', 'name', 'email'])
     expect(rows[1]).toEqual(['u1', 'Alice', 'alice@test.invalid'])
   })
@@ -81,7 +100,7 @@ describe('destination-google-sheets', () => {
     await collect(dest.write({ config: cfg({ batch_size: 3 }), catalog }, toAsyncIter(messages)))
 
     const id = getSpreadsheetIds()[0]
-    const rows = getData(id, 'items')!
+    const rows = stripUpdatedAt(getData(id, 'items')!)
     // header + 5 data rows (batch at 3, then remaining 2 flushed at end)
     expect(rows).toHaveLength(6)
     expect(rows[0]).toEqual(['id'])
@@ -120,7 +139,7 @@ describe('destination-google-sheets', () => {
 
     // All 3 records should be written (flushed at end before state was yielded)
     const id = getSpreadsheetIds()[0]
-    const rows = getData(id, 'orders')!
+    const rows = stripUpdatedAt(getData(id, 'orders')!)
     expect(rows).toHaveLength(4) // header + 3 rows
   })
 
@@ -208,11 +227,11 @@ describe('destination-google-sheets', () => {
 
     const id = getSpreadsheetIds()[0]
 
-    const customerRows = getData(id, 'customers')!
+    const customerRows = stripUpdatedAt(getData(id, 'customers')!)
     expect(customerRows[0]).toEqual(['id', 'name'])
     expect(customerRows).toHaveLength(3) // header + 2
 
-    const invoiceRows = getData(id, 'invoices')!
+    const invoiceRows = stripUpdatedAt(getData(id, 'invoices')!)
     expect(invoiceRows[0]).toEqual(['id', 'amount', 'customer'])
     expect(invoiceRows).toHaveLength(3) // header + 2
   })
@@ -274,6 +293,7 @@ describe('destination-google-sheets', () => {
         stream: {
           name,
           primary_key: [['id']],
+          newer_than_field: '_updated_at',
           json_schema: {
             type: 'object',
             properties: { id: { type: 'string' }, value: { type: 'string' } },
@@ -319,7 +339,7 @@ describe('destination-google-sheets', () => {
     await collect(dest.write({ config: cfg({ batch_size: 100 }), catalog }, toAsyncIter(messages)))
 
     const id = getSpreadsheetIds()[0]
-    const rows = getData(id, 'events')!
+    const rows = stripUpdatedAt(getData(id, 'events')!)
     expect(rows).toHaveLength(3) // header + 2 rows
   })
 
@@ -340,7 +360,7 @@ describe('destination-google-sheets', () => {
     await collect(dest.write({ config: cfg(), catalog }, toAsyncIter(messages)))
 
     const id = getSpreadsheetIds()[0]
-    const rows = getData(id, 'types')!
+    const rows = stripUpdatedAt(getData(id, 'types')!)
     expect(rows[1]).toEqual(['hello', '42', 'true', '', '{"nested":true}'])
   })
 
@@ -355,7 +375,9 @@ describe('destination-google-sheets', () => {
 
     await collect(dest.write({ config: cfg(), catalog }, toAsyncIter(messages)))
 
-    const rows = await readSheet(sheets, getSpreadsheetIds()[0], 'test')
+    const rows = stripUpdatedAt(
+      (await readSheet(sheets, getSpreadsheetIds()[0], 'test')) as unknown[][]
+    )
     expect(rows).toEqual([
       ['a', 'b'],
       ['1', '2'],
@@ -419,6 +441,7 @@ describe('check', () => {
           stream: {
             name: 'customers',
             primary_key: [['id']],
+            newer_than_field: '_updated_at',
             json_schema: {
               type: 'object',
               properties: {
@@ -468,7 +491,7 @@ describe('check', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name'],
       ['cus_1', 'Alice Updated'],
@@ -510,7 +533,7 @@ describe('check', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows[0]).toEqual(['id', 'name', 'email'])
     expect(rows[1]).toEqual(['cus_1', 'Alice'])
     expect(rows[2]).toEqual(['cus_2', 'Bob', 'bob@test.invalid'])
@@ -524,6 +547,7 @@ describe('native upsert', () => {
         stream: {
           name: 'customers',
           primary_key: primaryKey,
+          newer_than_field: '_updated_at',
           json_schema: {
             type: 'object',
             properties: { id: { type: 'string' }, name: { type: 'string' } },
@@ -556,7 +580,7 @@ describe('native upsert', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name'],
       ['cus_1', 'Alice Updated'],
@@ -582,7 +606,7 @@ describe('native upsert', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name'],
       ['cus_1', 'Alice'],
@@ -600,13 +624,13 @@ describe('native upsert', () => {
       dest.write(
         { config: cfg({ batch_size: 1 }), catalog: cat },
         toAsyncIter([
-          record('customers', { id: 'cus_1', name: 'Alice' }),
-          record('customers', { id: 'cus_1', name: 'Alice Updated' }),
+          record('customers', { id: 'cus_1', name: 'Alice', _updated_at: 1 }),
+          record('customers', { id: 'cus_1', name: 'Alice Updated', _updated_at: 2 }),
         ])
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name'],
       ['cus_1', 'Alice Updated'],
@@ -623,13 +647,13 @@ describe('native upsert', () => {
       dest.write(
         { config: cfg(), catalog: cat },
         toAsyncIter([
-          record('customers', { id: 'cus_1', name: 'Alice' }),
-          record('customers', { id: 'cus_1', name: 'Alice Updated' }),
+          record('customers', { id: 'cus_1', name: 'Alice', _updated_at: 1 }),
+          record('customers', { id: 'cus_1', name: 'Alice Updated', _updated_at: 2 }),
         ])
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name'],
       ['cus_1', 'Alice Updated'],
@@ -660,7 +684,7 @@ describe('native upsert', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name'],
       ['cus_1', 'Alice Updated'],
@@ -691,8 +715,8 @@ describe('native upsert', () => {
     expect(ids).toHaveLength(2)
     expect(ids[0]).not.toBe(ids[1])
 
-    const rowsA = getData(ids[0], 'customers')!
-    const rowsB = getData(ids[1], 'customers')!
+    const rowsA = stripUpdatedAt(getData(ids[0], 'customers')!)
+    const rowsB = stripUpdatedAt(getData(ids[1], 'customers')!)
     expect(rowsA).toHaveLength(2)
     expect(rowsB).toHaveLength(2)
 
@@ -736,7 +760,7 @@ describe('native upsert', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name'],
       ['cus_1', 'Alice'],
@@ -759,7 +783,7 @@ describe('native upsert', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name'],
       ['cus_1', 'Alice'],
@@ -782,7 +806,7 @@ describe('native upsert', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     // id should be first column despite being last in the record
     expect(rows[0]).toEqual(['id', 'name', 'email'])
   })
@@ -795,6 +819,7 @@ describe('delete handling', () => {
         stream: {
           name: 'customers',
           primary_key: primaryKey,
+          newer_than_field: '_updated_at',
           json_schema: {
             type: 'object',
             properties: {
@@ -863,7 +888,7 @@ describe('delete handling', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([['id', 'name', 'deleted']])
   })
 
@@ -879,7 +904,7 @@ describe('delete handling', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name', 'deleted'],
       ['cus_1', 'Alice', 'false'],
@@ -906,7 +931,7 @@ describe('delete handling', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     // Seeded rows are 2-wide; blank rows written by delete compaction are
     // 3-wide because the header was extended on the delete record's arrival.
     expect(rows).toEqual([
@@ -935,7 +960,7 @@ describe('delete handling', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name', 'deleted'],
       ['cus_1', 'Alice'],
@@ -969,7 +994,7 @@ describe('delete handling', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name', 'deleted'],
       ['cus_d', 'Dave'], // was cus_a; donor (row 5)
@@ -1004,7 +1029,7 @@ describe('delete handling', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name', 'deleted'],
       ['cus_a', 'Alice'],
@@ -1036,7 +1061,7 @@ describe('delete handling', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name', 'deleted'],
       ['', '', ''],
@@ -1072,7 +1097,7 @@ describe('delete handling', () => {
     // Nothing gets blanked, row count is unchanged. The donated append
     // includes `deleted: false` so its row is 3-wide; the untouched seeded
     // rows stay 2-wide.
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name', 'deleted'],
       ['cus_1', 'Alice'],
@@ -1107,7 +1132,7 @@ describe('delete handling', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name', 'deleted'],
       ['cus_1', 'Alice'],
@@ -1140,7 +1165,7 @@ describe('delete handling', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([['id', 'name', 'deleted']])
   })
 
@@ -1163,7 +1188,7 @@ describe('delete handling', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     // The delete record's `deleted: true` extends the header to 3 cols, but
     // the untouched seeded data rows stay 2-wide.
     expect(rows).toEqual([
@@ -1190,7 +1215,7 @@ describe('delete handling', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', 'name', 'deleted'],
       ['cus_2', 'Bob'], // donor (row 3, seeded 2-wide) swapped into row 2
@@ -1210,6 +1235,7 @@ describe('delete handling', () => {
           stream: {
             name: 'invoices',
             primary_key: [['id']],
+            newer_than_field: '_updated_at',
             json_schema: {
               type: 'object',
               properties: {
@@ -1248,14 +1274,14 @@ describe('delete handling', () => {
       )
     )
 
-    const customers = getData(getSpreadsheetIds()[0], 'customers')!
+    const customers = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(customers).toEqual([
       ['id', 'name', 'deleted'],
       ['cus_2', 'Bob', 'false'], // donor swapped in
       ['', '', ''],
     ])
 
-    const invoices = getData(getSpreadsheetIds()[0], 'invoices')!
+    const invoices = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'invoices')!)
     expect(invoices).toEqual([
       ['id', 'amount', 'deleted'],
       ['inv_1', '100', 'false'], // unaffected by the customers delete
@@ -1297,7 +1323,7 @@ describe('delete handling', () => {
     )
 
     // Composite rowKey = '["cus_1","acct_A"]' matches the seeded row → tail blanked.
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
       ['id', '_account_id', 'name', 'deleted'],
       ['', '', '', ''],
@@ -1332,7 +1358,7 @@ describe('delete handling', () => {
       )
     )
 
-    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     const dataRows = rows.slice(1) // skip header
     const nonBlankRows = dataRows.filter((r) => r.some((cell) => cell !== ''))
     const firstBlankIdx = dataRows.findIndex((r) => r.every((cell) => cell === ''))
@@ -1544,12 +1570,249 @@ describe('applyBatch cell-count limit', () => {
       (m) => m.type === 'connection_status' && m.connection_status.status === 'failed'
     )
     expect(failure).toBeDefined()
-    expect((failure as { connection_status: { message: string } }).connection_status.message).toMatch(
-      /cell-per-spreadsheet limit/
-    )
+    expect(
+      (failure as { connection_status: { message: string } }).connection_status.message
+    ).toMatch(/cell-per-spreadsheet limit/)
   })
 
   it('exports MAX_CELLS_PER_SPREADSHEET as 10 million', () => {
     expect(MAX_CELLS_PER_SPREADSHEET).toBe(10_000_000)
+  })
+})
+
+describe('newer_than_field stale write prevention', () => {
+  // Mirrors destination-postgres' newer_than_field suite. The Sheets path
+  // gates conversions from append → update by comparing the incoming
+  // record's timestamp against the existing sheet row's value.
+  const newerThanCatalog: ConfiguredCatalog = {
+    streams: [
+      {
+        stream: {
+          name: 'customers',
+          primary_key: [['id']],
+          json_schema: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              name: { type: 'string' },
+              updated: { type: 'integer' },
+            },
+          },
+          newer_than_field: 'updated',
+        },
+        sync_mode: 'full_refresh',
+        destination_sync_mode: 'append',
+      },
+    ],
+  }
+
+  it('skips upsert when incoming record is older than existing (across batches)', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: newerThanCatalog },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice v2', updated: 200 })])
+      )
+    )
+
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: newerThanCatalog },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice v1 (stale)', updated: 100 })])
+      )
+    )
+
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
+    expect(rows).toEqual([
+      ['id', 'name', 'updated'],
+      ['cus_1', 'Alice v2', '200'],
+    ])
+  })
+
+  it('applies upsert when incoming record is newer than existing (across batches)', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: newerThanCatalog },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice v1', updated: 100 })])
+      )
+    )
+
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: newerThanCatalog },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice v2', updated: 200 })])
+      )
+    )
+
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
+    expect(rows).toEqual([
+      ['id', 'name', 'updated'],
+      ['cus_1', 'Alice v2', '200'],
+    ])
+  })
+
+  it('in-batch newer-then-older — older record is dropped', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: newerThanCatalog },
+        toAsyncIter([
+          record('customers', { id: 'cus_1', name: 'Alice v2', updated: 200 }),
+          record('customers', { id: 'cus_1', name: 'Alice v1 (stale)', updated: 100 }),
+        ])
+      )
+    )
+
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
+    expect(rows).toEqual([
+      ['id', 'name', 'updated'],
+      ['cus_1', 'Alice v2', '200'],
+    ])
+  })
+
+  it('in-batch older-then-newer — newer record replaces pending entry', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: newerThanCatalog },
+        toAsyncIter([
+          record('customers', { id: 'cus_1', name: 'Alice v1', updated: 100 }),
+          record('customers', { id: 'cus_1', name: 'Alice v2', updated: 200 }),
+        ])
+      )
+    )
+
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
+    expect(rows).toEqual([
+      ['id', 'name', 'updated'],
+      ['cus_1', 'Alice v2', '200'],
+    ])
+  })
+
+  it('legacy row with empty updated cell — incoming update applies (missing-as-oldest)', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+
+    // Seed a "legacy" row that predates newer_than_field — its `updated`
+    // cell is an empty string. The incoming record (any timestamp) should
+    // still be applied because the existing value can't gate against it.
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: newerThanCatalog },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice legacy', updated: '' })])
+      )
+    )
+
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: newerThanCatalog },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice v1', updated: 100 })])
+      )
+    )
+
+    const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
+    expect(rows).toEqual([
+      ['id', 'name', 'updated'],
+      ['cus_1', 'Alice v1', '100'],
+    ])
+  })
+})
+
+describe('_updated_at column (source-owned, passthrough)', () => {
+  // The Stripe source stamps every record with `_updated_at` (unix
+  // seconds, from `event.created` for webhooks or the HTTP `Date`
+  // header for backfill, falling back to local now()). The destination
+  // is intentionally passive — it does not generate, refresh, or
+  // override the value. PG mirrors this with a generated column over
+  // `_raw_data->>'_updated_at'`; Sheets just passes the raw value
+  // through, no stamping logic of its own.
+  it('only writes a _updated_at column when the source provides the value', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+
+    await collect(
+      dest.write(
+        { config: cfg(), catalog },
+        toAsyncIter([record('users', { id: 'u1', name: 'Alice' })])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'users')!
+    expect(rows[0]).toEqual(['id', 'name'])
+    expect(rows[0]).not.toContain('_updated_at')
+  })
+
+  it('passes the source-provided _updated_at through verbatim', async () => {
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+
+    await collect(
+      dest.write(
+        { config: cfg(), catalog },
+        toAsyncIter([
+          record('users', { id: 'u1', name: 'Alice', _updated_at: 1700000000 }),
+          record('users', { id: 'u2', name: 'Bob', _updated_at: 1700000005 }),
+        ])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'users')!
+    const updatedAtIdx = (rows[0] as string[]).indexOf('_updated_at')
+    expect(updatedAtIdx).toBeGreaterThanOrEqual(0)
+    expect(rows.slice(1).map((r) => String(r[updatedAtIdx]))).toEqual(['1700000000', '1700000005'])
+  })
+
+  it('does not refresh _updated_at on its own when the row is updated', async () => {
+    // Without a source-provided value on the second write, the cell
+    // stays as whatever was originally written. The destination must
+    // not invent a new timestamp.
+    const { sheets, getData, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const cat: ConfiguredCatalog = {
+      streams: [
+        {
+          stream: {
+            name: 'customers',
+            primary_key: [['id']],
+            newer_than_field: '_updated_at',
+            json_schema: {
+              type: 'object',
+              properties: { id: { type: 'string' }, name: { type: 'string' } },
+            },
+          },
+          sync_mode: 'full_refresh',
+          destination_sync_mode: 'append',
+        },
+      ],
+    }
+
+    await collect(
+      dest.write(
+        { config: cfg(), catalog: cat },
+        toAsyncIter([record('customers', { id: 'cus_1', name: 'Alice', _updated_at: 1700000000 })])
+      )
+    )
+
+    await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: getSpreadsheetIds()[0] }), catalog: cat },
+        toAsyncIter([
+          record('customers', { id: 'cus_1', name: 'Alice v2', _updated_at: 1700000010 }),
+        ])
+      )
+    )
+
+    const rows = getData(getSpreadsheetIds()[0], 'customers')!
+    const updatedAtIdx = (rows[0] as string[]).indexOf('_updated_at')
+    expect(String(rows[1][updatedAtIdx])).toBe('1700000010')
   })
 })

--- a/packages/destination-google-sheets/src/index.ts
+++ b/packages/destination-google-sheets/src/index.ts
@@ -390,15 +390,20 @@ export function createDestination(
         for (const prep of prepInputs) {
           if (!prep.needsRead || !prep.primaryKey) continue
           const pkFields = prep.primaryKey.map((p) => p[0])
-          // Suppress narrow reads when deletes (need donor rows) or newer_than_field (need ts column) is in play.
-          const pkIsFirstN =
-            prep.bufferedDeletes.length === 0 &&
-            !streamNewerThanField.has(prep.streamName) &&
-            pkFields.every((field, i) => prep.headers[i] === field)
-          narrowByStream.set(prep.streamName, pkIsFirstN)
+          const newerThanField = streamNewerThanField.get(prep.streamName)
+          const newerThanIdx = newerThanField ? prep.headers.indexOf(newerThanField) : -1
+          const pkIsFirstN = pkFields.every((field, i) => prep.headers[i] === field)
+          const canReadPrefix = prep.bufferedDeletes.length === 0 && pkIsFirstN
+          const columnCount =
+            canReadPrefix && newerThanIdx >= 0
+              ? Math.max(pkFields.length, newerThanIdx + 1)
+              : canReadPrefix
+                ? pkFields.length
+                : undefined
+          narrowByStream.set(prep.streamName, columnCount !== undefined)
           streamsToRead.push({
             name: prep.streamName,
-            ...(pkIsFirstN ? { columnCount: pkFields.length } : {}),
+            ...(columnCount ? { columnCount } : {}),
           })
         }
 
@@ -460,7 +465,7 @@ export function createDestination(
                 const existing = entry.rowKey ? freshMap.get(entry.rowKey) : undefined
                 if (existing !== undefined) {
                   if (newerThanIdx >= 0) {
-                    const existingRow = allRows[existing - 1] ?? []
+                    const existingRow = allRows[isNarrow ? existing - 2 : existing - 1] ?? []
                     const existingCell = existingRow[newerThanIdx]
                     const existingValue = existingCell == null ? '' : String(existingCell)
                     const incomingValue = entry.row[newerThanIdx] ?? ''
@@ -670,6 +675,15 @@ export function createDestination(
             recordCount++
             const { stream, data } = msg.record
             const cleanData: Record<string, unknown> = stripSystemFields(data)
+            const newerThanField = streamNewerThanField.get(stream)
+            if (
+              newerThanField !== undefined &&
+              (!(newerThanField in cleanData) || cleanData[newerThanField] === undefined)
+            ) {
+              throw new Error(
+                `stream "${stream}" record missing newer_than_field "${newerThanField}"; source must stamp this field on every record per DDR-009`
+              )
+            }
             const headers = await ensureHeadersForRecord(stream, cleanData)
             const row = headers.map((header) => stringify(cleanData[header]))
             const rowNumber =
@@ -694,30 +708,29 @@ export function createDestination(
               const keyIdx = appendKeyIndex.get(stream)!
               const pendingIdx = keyIdx.get(rowKey)
               if (pendingIdx !== undefined) {
-                // Keep whichever same-batch dupe is newer — matches PG's
-                // EXCLUDED.col > tbl.col staleness gate.
-                const newerThanField = streamNewerThanField.get(stream)!
-                const newerThanIdx = headers.indexOf(newerThanField)
-                const incomingValue = row[newerThanIdx]
-                const pendingValue = buffer[pendingIdx].row[newerThanIdx]
-                if (incomingValue === undefined || pendingValue === undefined) {
-                  throw new Error(
-                    `stream "${stream}" record missing newer_than_field "${newerThanField}" (header index ${newerThanIdx}); source must stamp this field on every record per DDR-009`
-                  )
-                }
-                if (!isStrictlyNewer(incomingValue, pendingValue)) {
-                  log.debug(
-                    {
-                      stream,
-                      rowKey,
-                      newerThanField,
-                      incomingValue,
-                      pendingValue,
-                    },
-                    'in-batch dedup: ignoring stale record'
-                  )
-                  yield msg
-                  continue
+                if (newerThanField !== undefined) {
+                  const newerThanIdx = headers.indexOf(newerThanField)
+                  const incomingValue = row[newerThanIdx]
+                  const pendingValue = buffer[pendingIdx].row[newerThanIdx]
+                  if (incomingValue === undefined || pendingValue === undefined) {
+                    throw new Error(
+                      `stream "${stream}" record missing newer_than_field "${newerThanField}" (header index ${newerThanIdx}); source must stamp this field on every record per DDR-009`
+                    )
+                  }
+                  if (!isStrictlyNewer(incomingValue, pendingValue)) {
+                    log.debug(
+                      {
+                        stream,
+                        rowKey,
+                        newerThanField,
+                        incomingValue,
+                        pendingValue,
+                      },
+                      'in-batch dedup: ignoring stale record'
+                    )
+                    yield msg
+                    continue
+                  }
                 }
                 buffer[pendingIdx] = { row, rowKey }
               } else {

--- a/packages/destination-google-sheets/src/index.ts
+++ b/packages/destination-google-sheets/src/index.ts
@@ -95,11 +95,13 @@ function stringify(value: unknown): string {
   return JSON.stringify(value)
 }
 
-/** Check if an error looks transient (rate limit or server error). */
-function isTransient(err: unknown): boolean {
-  if (!(err instanceof Error) || !('code' in err)) return false
-  const code = (err as { code: number }).code
-  return code === 429 || code >= 500
+/** Stale-write check: numeric compare for finite numbers, else lex; empty `existing` always loses. */
+function isStrictlyNewer(incoming: string, existing: string | undefined | null): boolean {
+  if (existing === '' || existing == null) return true
+  const a = Number(incoming)
+  const b = Number(existing)
+  if (Number.isFinite(a) && Number.isFinite(b)) return a > b
+  return incoming > existing
 }
 
 function extendHeaders(
@@ -237,6 +239,10 @@ export function createDestination(
           configuredStream.stream.name,
           configuredStream.stream.primary_key,
         ])
+      )
+
+      const streamNewerThanField = new Map(
+        catalog.streams.map((cs) => [cs.stream.name, cs.stream.newer_than_field])
       )
 
       const spreadsheetId = config.spreadsheet_id
@@ -384,10 +390,10 @@ export function createDestination(
         for (const prep of prepInputs) {
           if (!prep.needsRead || !prep.primaryKey) continue
           const pkFields = prep.primaryKey.map((p) => p[0])
-          // Tail-swap donor rows need full row values, not just the PK slice;
-          // suppress narrow reads whenever a stream has deletes.
+          // Suppress narrow reads when deletes (need donor rows) or newer_than_field (need ts column) is in play.
           const pkIsFirstN =
             prep.bufferedDeletes.length === 0 &&
+            !streamNewerThanField.has(prep.streamName) &&
             pkFields.every((field, i) => prep.headers[i] === field)
           narrowByStream.set(prep.streamName, pkIsFirstN)
           streamsToRead.push({
@@ -444,11 +450,25 @@ export function createDestination(
               const freshMap = isNarrow
                 ? buildRowMapFromPkColumns(allRows, primaryKey)
                 : buildRowMapFromRows(allRows, headers, primaryKey)
+
+              const newerThanField = streamNewerThanField.get(streamName)
+              const newerThanIdx = newerThanField ? headers.indexOf(newerThanField) : -1
               const remaining: typeof appends = []
               let converted = 0
+              let staleSkipped = 0
               for (const entry of appends) {
                 const existing = entry.rowKey ? freshMap.get(entry.rowKey) : undefined
                 if (existing !== undefined) {
+                  if (newerThanIdx >= 0) {
+                    const existingRow = allRows[existing - 1] ?? []
+                    const existingCell = existingRow[newerThanIdx]
+                    const existingValue = existingCell == null ? '' : String(existingCell)
+                    const incomingValue = entry.row[newerThanIdx] ?? ''
+                    if (!isStrictlyNewer(incomingValue, existingValue)) {
+                      staleSkipped++
+                      continue
+                    }
+                  }
                   bufferedUpdates.push({ rowNumber: existing, values: entry.row })
                   converted++
                 } else {
@@ -456,13 +476,14 @@ export function createDestination(
                 }
               }
               appends = remaining
-              if (converted > 0) {
+              if (converted > 0 || staleSkipped > 0) {
                 log.debug(
                   {
                     streamName,
                     existingRows: existingRowCount,
                     keys: freshMap.size,
                     converted,
+                    staleSkipped,
                   },
                   'dedup: converted appends to updates'
                 )
@@ -648,7 +669,7 @@ export function createDestination(
           if (msg.type === 'record') {
             recordCount++
             const { stream, data } = msg.record
-            const cleanData = stripSystemFields(data)
+            const cleanData: Record<string, unknown> = stripSystemFields(data)
             const headers = await ensureHeadersForRecord(stream, cleanData)
             const row = headers.map((header) => stringify(cleanData[header]))
             const rowNumber =
@@ -673,6 +694,31 @@ export function createDestination(
               const keyIdx = appendKeyIndex.get(stream)!
               const pendingIdx = keyIdx.get(rowKey)
               if (pendingIdx !== undefined) {
+                // Keep whichever same-batch dupe is newer — matches PG's
+                // EXCLUDED.col > tbl.col staleness gate.
+                const newerThanField = streamNewerThanField.get(stream)!
+                const newerThanIdx = headers.indexOf(newerThanField)
+                const incomingValue = row[newerThanIdx]
+                const pendingValue = buffer[pendingIdx].row[newerThanIdx]
+                if (incomingValue === undefined || pendingValue === undefined) {
+                  throw new Error(
+                    `stream "${stream}" record missing newer_than_field "${newerThanField}" (header index ${newerThanIdx}); source must stamp this field on every record per DDR-009`
+                  )
+                }
+                if (!isStrictlyNewer(incomingValue, pendingValue)) {
+                  log.debug(
+                    {
+                      stream,
+                      rowKey,
+                      newerThanField,
+                      incomingValue,
+                      pendingValue,
+                    },
+                    'in-batch dedup: ignoring stale record'
+                  )
+                  yield msg
+                  continue
+                }
                 buffer[pendingIdx] = { row, rowKey }
               } else {
                 keyIdx.set(rowKey, buffer.length)

--- a/packages/destination-google-sheets/src/writer.ts
+++ b/packages/destination-google-sheets/src/writer.ts
@@ -489,8 +489,8 @@ export function buildRowMapFromRows(
 }
 
 /**
- * Like `buildRowMapFromRows` but for a header-less PK-only slice
- * (see `batchReadSheets` with `columnCount`). Row i → sheet row i + 2.
+ * Like `buildRowMapFromRows` but for a header-less leading-column slice.
+ * Primary key fields must be the first columns. Row i → sheet row i + 2.
  */
 export function buildRowMapFromPkColumns(
   pkRows: unknown[][],
@@ -566,7 +566,7 @@ export interface BatchReadRequest {
  * catalogs (otherwise blows the 300/min read limit). Missing tabs map to
  * empty arrays so callers can always `.get()` safely.
  *
- * With `columnCount` set: response is PK-only, header-less — use with
+ * With `columnCount` set: response is a leading-column, header-less slice — use with
  * {@link buildRowMapFromPkColumns}. Without: whole tab — use with
  * {@link buildRowMapFromRows}.
  */

--- a/packages/destination-postgres/src/index.test.ts
+++ b/packages/destination-postgres/src/index.test.ts
@@ -113,7 +113,12 @@ async function collectOutputs(
 const catalog: ConfiguredCatalog = {
   streams: [
     {
-      stream: { name: 'customers', primary_key: [['id']], metadata: {} },
+      stream: {
+        name: 'customers',
+        primary_key: [['id']],
+        newer_than_field: '_updated_at',
+        metadata: {},
+      },
       sync_mode: 'full_refresh',
       destination_sync_mode: 'overwrite',
     },
@@ -328,7 +333,7 @@ describe('_updated_at column write-through', () => {
   const updatedAtCatalog: ConfiguredCatalog = {
     streams: [
       {
-        stream: { name: 'customers', primary_key: [['id']] },
+        stream: { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
         sync_mode: 'full_refresh',
         destination_sync_mode: 'overwrite',
       },
@@ -402,6 +407,7 @@ describe('multi-org sync (two account IDs)', () => {
         stream: {
           name: 'customers',
           primary_key: [['id'], ['_account_id']],
+          newer_than_field: '_updated_at',
           metadata: {},
         },
         sync_mode: 'full_refresh',

--- a/packages/destination-postgres/src/index.test.ts
+++ b/packages/destination-postgres/src/index.test.ts
@@ -76,8 +76,18 @@ beforeEach(async () => {
 // Helpers
 // ---------------------------------------------------------------------------
 
+// Monotonically increasing seconds so consecutive `makeRecord` calls produce
+// strictly-newer `_updated_at` values; the staleness gate rejects equal stamps.
+let nextRecordTs = Math.floor(Date.now() / 1000)
 function makeRecord(stream: string, data: Record<string, unknown>): RecordMessage {
-  return { type: 'record', record: { stream, data, emitted_at: new Date().toISOString() } }
+  return {
+    type: 'record',
+    record: {
+      stream,
+      data: { _updated_at: nextRecordTs++, ...data },
+      emitted_at: new Date().toISOString(),
+    },
+  }
 }
 
 function makeState(stream: string, data: unknown): SourceStateMessage {
@@ -312,6 +322,79 @@ describe('newer_than_field stale write prevention', () => {
   })
 })
 
+describe('_updated_at column write-through', () => {
+  // `_updated_at` is the legacy hardcoded `timestamptz` column; upsertMany
+  // writes the source-stamped unix-seconds value into it (DDR-009).
+  const updatedAtCatalog: ConfiguredCatalog = {
+    streams: [
+      {
+        stream: { name: 'customers', primary_key: [['id']] },
+        sync_mode: 'full_refresh',
+        destination_sync_mode: 'overwrite',
+      },
+    ],
+  }
+
+  beforeEach(async () => {
+    await drain(destination.setup!({ config: makeConfig(), catalog: updatedAtCatalog }))
+  })
+
+  it('writes source-stamped _updated_at into the timestamptz column', async () => {
+    const ts = 1_700_000_000 // 2023-11-14T22:13:20Z
+    const batch = toAsyncIter([
+      makeRecord('customers', { id: 'cus_1', name: 'Alice', _updated_at: ts }),
+    ])
+    await collectOutputs(
+      destination.write({ config: makeConfig(), catalog: updatedAtCatalog }, batch)
+    )
+
+    const { rows } = await pool.query<{
+      raw: string
+      column_ts: Date
+    }>(
+      `SELECT _raw_data->>'_updated_at' AS raw, _updated_at AS column_ts
+       FROM "${SCHEMA}".customers WHERE id = 'cus_1'`
+    )
+    expect(rows[0].raw).toBe(String(ts))
+    // Column is timestamptz; verify the unix-seconds → Date conversion
+    // landed on the exact second we asked for (no millisecond drift).
+    expect(rows[0].column_ts.getTime()).toBe(ts * 1000)
+  })
+
+  it('blocks stale writes via the _updated_at gate for objects without native updated', async () => {
+    const newer = 1_700_000_200
+    const older = 1_700_000_100
+
+    await collectOutputs(
+      destination.write(
+        { config: makeConfig(), catalog: updatedAtCatalog },
+        toAsyncIter([
+          makeRecord('customers', { id: 'cus_1', name: 'Alice v2', _updated_at: newer }),
+        ])
+      )
+    )
+    await collectOutputs(
+      destination.write(
+        { config: makeConfig(), catalog: updatedAtCatalog },
+        toAsyncIter([
+          makeRecord('customers', {
+            id: 'cus_1',
+            name: 'Alice v1 (stale)',
+            _updated_at: older,
+          }),
+        ])
+      )
+    )
+
+    const { rows } = await pool.query<{ name: string; ts: Date }>(
+      `SELECT _raw_data->>'name' AS name, _updated_at AS ts
+       FROM "${SCHEMA}".customers WHERE id = 'cus_1'`
+    )
+    expect(rows[0].name).toBe('Alice v2')
+    expect(rows[0].ts.getTime()).toBe(newer * 1000)
+  })
+})
+
 describe('multi-org sync (two account IDs)', () => {
   const multiOrgCatalog: ConfiguredCatalog = {
     streams: [
@@ -408,10 +491,18 @@ describe('upsertMany standalone', () => {
   it('inserts records directly via pool', async () => {
     const testPool = new pg.Pool({ connectionString })
     try {
-      await upsertMany(testPool, SCHEMA, 'customers', [
-        { id: 'cus_10', name: 'Direct' },
-        { id: 'cus_11', name: 'Insert' },
-      ])
+      const ts = Math.floor(Date.now() / 1000)
+      await upsertMany(
+        testPool,
+        SCHEMA,
+        'customers',
+        [
+          { id: 'cus_10', name: 'Direct', _updated_at: ts },
+          { id: 'cus_11', name: 'Insert', _updated_at: ts },
+        ],
+        ['id'],
+        '_updated_at'
+      )
 
       const { rows } = await pool.query(`SELECT count(*)::int AS n FROM "${SCHEMA}".customers`)
       expect(rows[0].n).toBe(2)
@@ -423,7 +514,7 @@ describe('upsertMany standalone', () => {
   it('no-ops on empty array', async () => {
     const testPool = new pg.Pool({ connectionString })
     try {
-      await upsertMany(testPool, SCHEMA, 'customers', [])
+      await upsertMany(testPool, SCHEMA, 'customers', [], ['id'], '_updated_at')
       const { rows } = await pool.query(`SELECT count(*)::int AS n FROM "${SCHEMA}".customers`)
       expect(rows[0].n).toBe(0)
     } finally {

--- a/packages/destination-postgres/src/index.ts
+++ b/packages/destination-postgres/src/index.ts
@@ -88,7 +88,7 @@ export async function upsertMany(
   return await upsertWithStats(
     pool,
     records,
-    { schema, table, primaryKeyColumns, newerThanColumn: '_updated_at' },
+    { schema, table, primaryKeyColumns, newerThanColumn: newerThanField },
     `"_raw_data"->>'deleted' = 'true'`
   )
 }

--- a/packages/destination-postgres/src/index.ts
+++ b/packages/destination-postgres/src/index.ts
@@ -77,7 +77,7 @@ export async function upsertMany(
 
   const records = entries.map((e) => {
     const ts = e[newerThanField] as unknown
-    if (typeof ts !== 'number') {
+    if (typeof ts !== 'number' || !Number.isFinite(ts)) {
       throw new Error(
         `upsertMany: record missing source-stamped "${newerThanField}" (table=${schema}.${table}, id=${String(e.id)}). See DDR-009.`
       )

--- a/packages/destination-postgres/src/index.ts
+++ b/packages/destination-postgres/src/index.ts
@@ -60,9 +60,8 @@ export interface UpsertManyResult {
 }
 
 /**
- * Upsert records into a Postgres table using the _raw_data jsonb pattern.
- * Delegates to util-postgres `upsertWithStats()` which batches all rows into a
- * single multi-row INSERT ... ON CONFLICT statement and returns write stats.
+ * Upsert records into a Postgres table; lifts `[newer_than_field]` from the
+ * source-stamped record into the legacy `_updated_at` timestamptz column (DDR-009).
  */
 export async function upsertMany(
   pool: pg.Pool,
@@ -71,19 +70,25 @@ export async function upsertMany(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   entries: Record<string, any>[],
   primaryKeyColumns: string[] = ['id'],
-  newerThanField?: string
+  newerThanField: string
 ): Promise<UpsertManyResult> {
   if (!entries.length)
     return { created_count: 0, updated_count: 0, deleted_count: 0, skipped_count: 0 }
+
+  const records = entries.map((e) => {
+    const ts = e[newerThanField] as unknown
+    if (typeof ts !== 'number') {
+      throw new Error(
+        `upsertMany: record missing source-stamped "${newerThanField}" (table=${schema}.${table}, id=${String(e.id)}). See DDR-009.`
+      )
+    }
+    return { _raw_data: e, _updated_at: new Date(ts * 1000).toISOString() }
+  })
+
   return await upsertWithStats(
     pool,
-    entries.map((e) => ({ _raw_data: e })),
-    {
-      schema,
-      table,
-      primaryKeyColumns,
-      ...(newerThanField && { newerThanColumn: newerThanField }),
-    },
+    records,
+    { schema, table, primaryKeyColumns, newerThanColumn: '_updated_at' },
     `"_raw_data"->>'deleted' = 'true'`
   )
 }
@@ -223,20 +228,9 @@ const destination = {
       log.info(`Creating schema "${config.schema}" (${catalog.streams.length} streams)`)
       log.debug('dest setup: creating schema')
       await pool.query(sql`CREATE SCHEMA IF NOT EXISTS "${config.schema}"`)
-      log.debug('dest setup: creating trigger function')
-      await pool.query(sql`
-        CREATE OR REPLACE FUNCTION "${config.schema}".set_updated_at() RETURNS trigger
-            LANGUAGE plpgsql
-        AS $$
-        BEGIN
-          NEW := jsonb_populate_record(
-            NEW,
-            jsonb_build_object('updated_at', now(), '_updated_at', now())
-          );
-          RETURN NEW;
-        END;
-        $$;
-      `)
+      // Backward-compat: drop legacy `set_updated_at()` (CASCADE removes any orphan `handle_updated_at` triggers from older deployments).
+      log.debug('dest setup: dropping legacy set_updated_at() function')
+      await pool.query(sql`DROP FUNCTION IF EXISTS "${config.schema}".set_updated_at() CASCADE`)
       log.debug({ streamCount: catalog.streams.length }, 'dest setup: creating tables')
       await Promise.all(
         catalog.streams.map(async (cs) => {
@@ -282,9 +276,7 @@ const destination = {
       ])
     )
     const streamNewerThanField = new Map(
-      catalog.streams
-        .filter((cs) => cs.stream.newer_than_field)
-        .map((cs) => [cs.stream.name, cs.stream.newer_than_field!])
+      catalog.streams.map((cs) => [cs.stream.name, cs.stream.newer_than_field])
     )
 
     const failedStreams = new Set<string>()
@@ -295,7 +287,7 @@ const destination = {
       const buffer = streamBuffers.get(streamName)
       if (!buffer || buffer.length === 0) return undefined
       const pk = streamKeyColumns.get(streamName) ?? ['id']
-      const newerThan = streamNewerThanField.get(streamName)
+      const newerThan = streamNewerThanField.get(streamName)!
       const startedAt = Date.now()
       log.debug(
         {
@@ -328,7 +320,7 @@ const destination = {
       } catch (err) {
         const detail =
           `stream=${streamName} table=${config.schema}.${streamName} ` +
-          `pk=[${pk}] newerThan=${newerThan ?? 'none'} records=${buffer.length}`
+          `pk=[${pk}] newerThan=${newerThan} records=${buffer.length}`
         const errMsg = errorMessage(err)
         log.error(
           {

--- a/packages/destination-postgres/src/schemaProjection.test.ts
+++ b/packages/destination-postgres/src/schemaProjection.test.ts
@@ -50,6 +50,14 @@ describe('jsonSchemaToColumns', () => {
     expect(customerCol.expression).toContain('jsonb_typeof')
     expect(customerCol.expression).toContain("->>'id'")
   })
+
+  it('skips _updated_at (kept as a legacy hardcoded timestamptz column, not generated)', () => {
+    const schema = {
+      type: 'object',
+      properties: { _updated_at: { type: 'integer' } },
+    }
+    expect(jsonSchemaToColumns(schema).find((c) => c.name === '_updated_at')).toBeUndefined()
+  })
 })
 
 describe('buildCreateTableWithSchema', () => {
@@ -80,9 +88,14 @@ describe('buildCreateTableWithSchema', () => {
     // No indexes by default (no system_columns with index: true)
     expect(stmts.some((s) => s.includes('CREATE INDEX'))).toBe(false)
 
-    // Trigger
-    expect(stmts.some((s) => s.includes('handle_updated_at'))).toBe(true)
-    expect(stmts.some((s) => s.includes('set_updated_at()'))).toBe(true)
+    // _updated_at keeps its legacy timestamptz shape so existing
+    // deployments don't need a column migration. upsertMany writes the
+    // source-stamped value explicitly per row (DDR-009); the legacy
+    // trigger is dropped, and no new trigger is created.
+    expect(stmts[0]).toContain('"_updated_at" timestamptz NOT NULL DEFAULT now()')
+    expect(stmts.some((s) => s.includes('DROP TRIGGER IF EXISTS handle_updated_at'))).toBe(true)
+    expect(stmts.some((s) => s.includes('CREATE TRIGGER handle_updated_at'))).toBe(false)
+    expect(stmts.some((s) => s.includes('set_updated_at()'))).toBe(false)
   })
 
   it('adds system columns and indexes when system_columns is provided', () => {
@@ -145,6 +158,31 @@ describe('buildCreateTableWithSchema', () => {
     const second = buildCreateTableWithSchema('mydata', 'customers', SAMPLE_JSON_SCHEMA)
     expect(second).toEqual(first)
   })
+
+  it('emits a single _updated_at column even when declared in json_schema.properties', () => {
+    // DDR-009: source declares `_updated_at: {type: 'integer'}` (unix seconds)
+    // on the wire. The destination keeps the legacy hardcoded
+    // `timestamptz NOT NULL DEFAULT now()` shape for backward compat;
+    // jsonSchemaToColumns must skip it to avoid a duplicate generated column.
+    const schemaWithUpdatedAt: Record<string, unknown> = {
+      type: 'object',
+      properties: {
+        ...(SAMPLE_JSON_SCHEMA.properties as Record<string, unknown>),
+        _updated_at: { type: 'integer' },
+      },
+    }
+    const stmts = buildCreateTableWithSchema('stripe', 'customers', schemaWithUpdatedAt)
+
+    expect(stmts[0]).toContain('"_updated_at" timestamptz NOT NULL DEFAULT now()')
+    expect(stmts[0]).not.toContain('"_updated_at" bigint')
+    expect(stmts[0]).not.toContain('"_updated_at" timestamptz GENERATED ALWAYS')
+
+    const alter = stmts.find((s) => s.includes('ADD COLUMN IF NOT EXISTS')) ?? ''
+    expect(alter).not.toContain('"_updated_at"')
+
+    const occurrences = (stmts[0].match(/"_updated_at"/g) || []).length
+    expect(occurrences).toBe(1)
+  })
 })
 
 describe('buildCreateTableDDL', () => {
@@ -164,8 +202,9 @@ describe('buildCreateTableDDL', () => {
     expect(ddl).toContain('ADD COLUMN IF NOT EXISTS "metadata"')
     expect(ddl).toContain('ADD COLUMN IF NOT EXISTS "expires_at"')
 
+    expect(ddl).toContain('"_updated_at" timestamptz NOT NULL DEFAULT now()')
     expect(ddl).toContain('DROP TRIGGER IF EXISTS handle_updated_at')
-    expect(ddl).toContain('CREATE TRIGGER handle_updated_at')
+    expect(ddl).not.toContain('CREATE TRIGGER handle_updated_at')
   })
 
   it('wraps every DDL statement in exception handlers', () => {
@@ -177,9 +216,11 @@ describe('buildCreateTableDDL', () => {
     expect(ddl).toContain('CREATE INDEX')
     expect(ddl).toContain('"_account_id"')
 
-    // Count exception handlers: CREATE TABLE, ALTER, CREATE INDEX, CREATE TRIGGER = 4
+    // Count exception handlers: CREATE TABLE, ALTER, CREATE INDEX = 3.
+    // (DROP TRIGGER IF EXISTS is unwrapped — no CREATE TRIGGER anymore now
+    // that `_updated_at` is a generated column.)
     const exceptionCount = (ddl.match(/EXCEPTION WHEN/g) || []).length
-    expect(exceptionCount).toBe(4)
+    expect(exceptionCount).toBe(3)
   })
 
   it('contains every SQL statement from buildCreateTableWithSchema', () => {

--- a/packages/destination-postgres/src/schemaProjection.ts
+++ b/packages/destination-postgres/src/schemaProjection.ts
@@ -66,7 +66,9 @@ export function jsonSchemaToColumns(jsonSchema: Record<string, unknown>): Column
 
   const columns: ColumnDef[] = []
   for (const [name, prop] of Object.entries(properties)) {
-    if (name === 'id') continue // id is always generated from _raw_data
+    if (name === 'id') continue
+    // `_updated_at` is hardcoded below; upsertMany writes it (DDR-009).
+    if (name === '_updated_at') continue
 
     const isExpandableRef = prop['x-expandable-reference'] === true
     const pgType = isExpandableRef ? 'text' : jsonSchemaTypeToPg(prop)
@@ -133,7 +135,7 @@ export function buildCreateTableWithSchema(
     const escapedField = field.replace(/'/g, "''")
     return `${quoteIdent(field)} text GENERATED ALWAYS AS ((_raw_data->>'${escapedField}')::text) STORED`
   })
-
+  // `_updated_at` kept as legacy non-generated timestamptz for BC; upsertMany writes it (DDR-009).
   const columnDefs = [
     '"_raw_data" jsonb NOT NULL',
     '"_last_synced_at" timestamptz',
@@ -162,10 +164,8 @@ export function buildCreateTableWithSchema(
     }
   }
 
-  stmts.push(
-    `DROP TRIGGER IF EXISTS handle_updated_at ON ${quotedSchema}.${quotedTable};`,
-    `CREATE TRIGGER handle_updated_at BEFORE UPDATE ON ${quotedSchema}.${quotedTable} FOR EACH ROW EXECUTE FUNCTION ${quotedSchema}.set_updated_at();`
-  )
+  // Drop the legacy trigger; `_updated_at` is now written explicitly by upsertMany.
+  stmts.push(`DROP TRIGGER IF EXISTS handle_updated_at ON ${quotedSchema}.${quotedTable};`)
 
   return stmts
 }

--- a/packages/openapi/__tests__/listFnResolver.test.ts
+++ b/packages/openapi/__tests__/listFnResolver.test.ts
@@ -191,7 +191,7 @@ describe('discoverListEndpoints', () => {
             data: [{ id: 'evt_123' }],
             next_page_url: '/v2/core/events?page=cur_next&limit=1',
           }),
-          { status: 200 }
+          { status: 200, headers: { date: 'Wed, 01 Jan 2025 00:00:00 GMT' } }
         )
     )
     const list = buildListFn('sk_test_fake', '/v2/core/events', fetchMock)
@@ -209,6 +209,7 @@ describe('discoverListEndpoints', () => {
       data: [{ id: 'evt_123' }],
       has_more: true,
       pageCursor: 'cur_next',
+      responseAt: 1735689600,
     })
 
     expect(fetchMock).toHaveBeenCalledWith(

--- a/packages/openapi/listFnResolver.ts
+++ b/packages/openapi/listFnResolver.ts
@@ -10,7 +10,13 @@ export type ListParams = {
   created?: { gt?: number; gte?: number; lt?: number; lte?: number }
 }
 
-export type ListResult = { data: unknown[]; has_more: boolean; pageCursor?: string }
+export type ListResult = {
+  data: unknown[]
+  has_more: boolean
+  pageCursor?: string
+  /** Response timestamp in unix seconds: Stripe HTTP Date, falling back to local now(). */
+  responseAt: number
+}
 
 export type ListFn = (params: ListParams) => Promise<ListResult>
 
@@ -301,6 +307,15 @@ async function readJson(response: Response): Promise<unknown> {
   }
 }
 
+/** Parse HTTP Date into unix seconds, falling back to local now(). */
+export function parseHttpDateHeader(headers: Headers): number {
+  const raw = headers.get('date')
+  if (!raw) return Math.floor(Date.now() / 1000)
+  const ms = Date.parse(raw)
+  if (!Number.isFinite(ms)) return Math.floor(Date.now() / 1000)
+  return Math.floor(ms / 1000)
+}
+
 function assertOk(response: Response, body: unknown, method: string, path: string): void {
   if (!response.ok) {
     throw new StripeApiRequestError(
@@ -347,7 +362,13 @@ export function buildListFn(
       }
       assertOk(response, parsed, 'GET', apiPath)
       const pageCursor = extractPageToken(parsed.next_page_url)
-      return { data: parsed.data ?? [], has_more: !!parsed.next_page_url, pageCursor }
+      const responseAt = parseHttpDateHeader(response.headers)
+      return {
+        data: parsed.data ?? [],
+        has_more: !!parsed.next_page_url,
+        ...(pageCursor !== undefined ? { pageCursor } : {}),
+        responseAt,
+      }
     }
   }
 
@@ -368,7 +389,12 @@ export function buildListFn(
     const response = await fetch(`${base}${apiPath}?${qs}`, { headers })
     const body = (await readJson(response)) as { data: unknown[]; has_more: boolean }
     assertOk(response, body, 'GET', apiPath)
-    return { data: body.data ?? [], has_more: body.has_more }
+    const responseAt = parseHttpDateHeader(response.headers)
+    return {
+      data: body.data ?? [],
+      has_more: body.has_more,
+      responseAt,
+    }
   }
 }
 

--- a/packages/protocol/src/protocol.ts
+++ b/packages/protocol/src/protocol.ts
@@ -58,7 +58,6 @@ export const Stream = z
 
     newer_than_field: z
       .string()
-      .default('_updated_at')
       .describe(
         'Field whose value increases monotonically. Destination uses it to skip stale writes (e.g. "updated").'
       ),

--- a/packages/protocol/src/protocol.ts
+++ b/packages/protocol/src/protocol.ts
@@ -58,7 +58,7 @@ export const Stream = z
 
     newer_than_field: z
       .string()
-      .optional()
+      .default('_updated_at')
       .describe(
         'Field whose value increases monotonically. Destination uses it to skip stale writes (e.g. "updated").'
       ),

--- a/packages/protocol/src/utils/binary-subdivision.ts
+++ b/packages/protocol/src/utils/binary-subdivision.ts
@@ -115,8 +115,6 @@ export type PageResult<T> = {
   hasMore: boolean
   /** The oldest sort-key timestamp (unix seconds) seen on this page, if any. */
   lastObserved: number | null
-  /** Response timestamp in unix seconds, passed through for record stamping. */
-  responseAt: number
 }
 
 /** Yielded by streamingSubdivide for each completed page. */
@@ -128,8 +126,6 @@ export type SubdivisionEvent<T> = {
   exhausted: boolean
   /** Snapshot of all ranges still pending (in queue + in flight). For state checkpoints. */
   remaining: Range[]
-  /** Mirrors PageResult.responseAt — pass-through for record stamping. */
-  responseAt: number
 }
 
 /**
@@ -196,7 +192,7 @@ export async function* streamingSubdivide<T>(opts: {
       inflight.delete(id)
       inflightRanges.delete(id)
 
-      const { range, data, hasMore, lastObserved, responseAt } = result
+      const { range, data, hasMore, lastObserved } = result
 
       if (data.length === 0 && !hasMore) {
         // Empty range — fully exhausted
@@ -224,7 +220,6 @@ export async function* streamingSubdivide<T>(opts: {
         hasMore,
         exhausted: !hasMore,
         remaining: snapshotRemaining(),
-        responseAt,
       }
     }
   } finally {

--- a/packages/protocol/src/utils/binary-subdivision.ts
+++ b/packages/protocol/src/utils/binary-subdivision.ts
@@ -115,6 +115,8 @@ export type PageResult<T> = {
   hasMore: boolean
   /** The oldest sort-key timestamp (unix seconds) seen on this page, if any. */
   lastObserved: number | null
+  /** Response timestamp in unix seconds, passed through for record stamping. */
+  responseAt: number
 }
 
 /** Yielded by streamingSubdivide for each completed page. */
@@ -126,6 +128,8 @@ export type SubdivisionEvent<T> = {
   exhausted: boolean
   /** Snapshot of all ranges still pending (in queue + in flight). For state checkpoints. */
   remaining: Range[]
+  /** Mirrors PageResult.responseAt — pass-through for record stamping. */
+  responseAt: number
 }
 
 /**
@@ -192,7 +196,7 @@ export async function* streamingSubdivide<T>(opts: {
       inflight.delete(id)
       inflightRanges.delete(id)
 
-      const { range, data, hasMore, lastObserved } = result
+      const { range, data, hasMore, lastObserved, responseAt } = result
 
       if (data.length === 0 && !hasMore) {
         // Empty range — fully exhausted
@@ -220,6 +224,7 @@ export async function* streamingSubdivide<T>(opts: {
         hasMore,
         exhausted: !hasMore,
         remaining: snapshotRemaining(),
+        responseAt,
       }
     }
   } finally {

--- a/packages/source-stripe/src/__tests__/eventsPolling.integration.test.ts
+++ b/packages/source-stripe/src/__tests__/eventsPolling.integration.test.ts
@@ -39,7 +39,7 @@ describe('events polling (integration — stripe-mock)', () => {
   const catalog: ConfiguredCatalog = {
     streams: [
       {
-        stream: { name: 'customers', primary_key: [['id']] },
+        stream: { name: 'customers', primary_key: [['id']], newer_than_field: '_updated_at' },
         sync_mode: 'incremental',
         destination_sync_mode: 'append_dedup',
       },

--- a/packages/source-stripe/src/catalog.ts
+++ b/packages/source-stripe/src/catalog.ts
@@ -5,8 +5,7 @@ import { parsedTableToJsonSchema } from '@stripe/sync-openapi'
 
 /**
  * Derive a CatalogPayload by merging OpenAPI-parsed tables with registry metadata.
- * Each stream gets json_schema from the parsed OpenAPI spec, with `_account_id`
- * injected so downstream consumers see the full data shape.
+ * `_account_id` (PK) and `_updated_at` (staleness, see DDR-009) are injected into properties.
  */
 export function catalogFromOpenApi(
   tables: ParsedResourceTable[],
@@ -22,6 +21,7 @@ export function catalogFromOpenApi(
       const stream: Stream = {
         name: cfg.tableName,
         primary_key: [['id'], ['_account_id']],
+        newer_than_field: '_updated_at',
         metadata: { resource_name: name },
       }
 
@@ -30,19 +30,17 @@ export function catalogFromOpenApi(
         const properties = (jsonSchema.properties ?? {}) as Record<string, unknown>
         properties._account_id = { type: 'string' }
         jsonSchema.properties = properties
-
+        properties._updated_at = { type: 'integer' }
         const required = Array.isArray(jsonSchema.required) ? [...jsonSchema.required] : []
         if (!required.includes('_account_id')) {
           required.push('_account_id')
         }
+        if (!required.includes('_updated_at')) {
+          required.push('_updated_at')
+        }
         jsonSchema.required = required
 
         stream.json_schema = jsonSchema
-
-        // Only set newer_than_field if the column will actually be projected
-        if (cfg.supportsCreatedFilter && 'updated' in properties) {
-          stream.newer_than_field = 'updated'
-        }
       }
 
       return stream

--- a/packages/source-stripe/src/index.test.ts
+++ b/packages/source-stripe/src/index.test.ts
@@ -129,10 +129,20 @@ function makeConfig(
 }
 
 /** Build a ConfiguredCatalog from stream specs for tests. */
-function catalog(...streams: Array<{ name: string; primary_key?: string[][] }>): ConfiguredCatalog {
+function catalog(...streams: Array<{ name: string; primary_key?: string[][] }>): {
+  streams: Array<{
+    stream: { name: string; primary_key: string[][]; newer_than_field: string }
+    sync_mode: 'full_refresh'
+    destination_sync_mode: 'overwrite'
+  }>
+} {
   return {
     streams: streams.map((s) => ({
-      stream: { name: s.name, primary_key: s.primary_key },
+      stream: {
+        name: s.name,
+        primary_key: s.primary_key ?? [['id']],
+        newer_than_field: '_updated_at',
+      },
       sync_mode: 'full_refresh' as const,
       destination_sync_mode: 'overwrite' as const,
     })),
@@ -556,7 +566,7 @@ describe('StripeSource', () => {
         dataObject: { id: 'cus_1', object: 'customer', name: 'Alice' },
       })
 
-      const result = fromStripeEvent(event, registry)
+      const result = fromStripeEvent(event, registry, '_updated_at')
 
       expect(result).not.toBeNull()
       expect(result!.record.type).toBe('record')
@@ -585,7 +595,7 @@ describe('StripeSource', () => {
         dataObject: { id: 'unknown_1', object: 'unknown_type' },
       })
 
-      const result = fromStripeEvent(event, registry)
+      const result = fromStripeEvent(event, registry, '_updated_at')
       expect(result).toBeNull()
     })
 
@@ -599,7 +609,7 @@ describe('StripeSource', () => {
         dataObject: { object: 'invoice', amount_due: 5000 },
       })
 
-      const result = fromStripeEvent(event, registry)
+      const result = fromStripeEvent(event, registry, '_updated_at')
       expect(result).toBeNull()
     })
 
@@ -613,7 +623,7 @@ describe('StripeSource', () => {
         dataObject: { id: 'cus_1', object: 'customer', deleted: true },
       })
 
-      const result = fromStripeEvent(event, registry)
+      const result = fromStripeEvent(event, registry, '_updated_at')
 
       expect(result).not.toBeNull()
       expect(result!.record.record.data).toMatchObject({
@@ -632,7 +642,7 @@ describe('StripeSource', () => {
         dataObject: { id: 'cus_1' },
       })
 
-      const result = fromStripeEvent(event, registry)
+      const result = fromStripeEvent(event, registry, '_updated_at')
       expect(result).toBeNull()
     })
 
@@ -651,7 +661,7 @@ describe('StripeSource', () => {
         dataObject: { id: 'inv_1', object: 'invoice', amount_paid: 1000 },
       })
 
-      const result = fromStripeEvent(event, registry)
+      const result = fromStripeEvent(event, registry, '_updated_at')
 
       expect(result).not.toBeNull()
       expect(result!.record.record.stream).toBe('invoices')
@@ -879,12 +889,17 @@ describe('StripeSource', () => {
         '/v1/test_helpers/test_clocks',
         'only available in testmode',
       ],
-      ['testmode-only resource', 'This object is only available in testmode', '/v1/invoices', 'testmode'],
+      [
+        'testmode-only resource',
+        'This object is only available in testmode',
+        '/v1/invoices',
+        'testmode',
+      ],
       [
         'v2 core accounts in test mode',
         "Accounts v2 isn't available in test mode. Switch to a sandbox to test.",
         '/v2/core/accounts',
-        'isn\'t available in test mode',
+        "isn't available in test mode",
       ],
       [
         'sigma scheduled_query_runs testmode',
@@ -2447,7 +2462,7 @@ describe('StripeSource', () => {
           catalog: {
             streams: [
               {
-                stream: { name: 'customers' },
+                stream: { name: 'customers', newer_than_field: '_updated_at' },
                 time_range: { gte: TEST_RANGE_GTE, lt: TEST_RANGE_LT },
               },
             ],
@@ -2620,7 +2635,10 @@ describe('StripeSource', () => {
       const messages = await collect(
         listApiBackfill({
           catalog: {
-            streams: [{ stream: { name: 'customers' } }, { stream: { name: 'tax_ids' } }],
+            streams: [
+              { stream: { name: 'customers', newer_than_field: '_updated_at' } },
+              { stream: { name: 'tax_ids', newer_than_field: '_updated_at' } },
+            ],
           },
           state: undefined,
           registry,
@@ -2682,7 +2700,10 @@ describe('StripeSource', () => {
       const messagesPromise = collect(
         listApiBackfill({
           catalog: {
-            streams: [{ stream: { name: 'customers' } }, { stream: { name: 'invoices' } }],
+            streams: [
+              { stream: { name: 'customers', newer_than_field: '_updated_at' } },
+              { stream: { name: 'invoices', newer_than_field: '_updated_at' } },
+            ],
           },
           state: undefined,
           registry,

--- a/packages/source-stripe/src/process-event.ts
+++ b/packages/source-stripe/src/process-event.ts
@@ -43,11 +43,8 @@ function isDeleteEvent(event: StripeEvent): boolean {
  * This is the building block for live mode. The orchestrator/webhook server
  * pushes events in; this method converts them to protocol messages.
  *
- * `newerThanField` is the catalog-declared staleness column for the stream
- * (see catalog.ts). The record gets stamped with a unix-seconds timestamp
- * on this column so destinations can gate out-of-order writes: the
- * record's native `.updated` field is preferred when present, falling
- * back to `event.created` otherwise (see {@link pickRecordTimestamp}).
+ * `newerThanField` is the catalog-declared staleness column; records are
+ * stamped from native `.updated` when present, else `event.created`.
  */
 export function fromStripeEvent(
   event: StripeEvent,

--- a/packages/source-stripe/src/process-event.ts
+++ b/packages/source-stripe/src/process-event.ts
@@ -42,10 +42,17 @@ function isDeleteEvent(event: StripeEvent): boolean {
  *
  * This is the building block for live mode. The orchestrator/webhook server
  * pushes events in; this method converts them to protocol messages.
+ *
+ * `newerThanField` is the catalog-declared staleness column for the stream
+ * (see catalog.ts). The record gets stamped with a unix-seconds timestamp
+ * on this column so destinations can gate out-of-order writes: the
+ * record's native `.updated` field is preferred when present, falling
+ * back to `event.created` otherwise (see {@link pickRecordTimestamp}).
  */
 export function fromStripeEvent(
   event: StripeEvent,
   registry: Record<string, ResourceConfig>,
+  newerThanField: string,
   accountId?: string
 ): { record: RecordMessage; state: SourceStateMessage } | null {
   const dataObject = event.data?.object as unknown as
@@ -59,10 +66,14 @@ export function fromStripeEvent(
 
   // Skip objects without an id (preview/draft objects like invoice.upcoming)
   if (!dataObject.id) return null
-
-  const data = accountId
-    ? { ...(dataObject as Record<string, unknown>), _account_id: accountId }
-    : (dataObject as Record<string, unknown>)
+  const updated = dataObject.updated
+  const _updated_at = typeof updated === 'number' ? updated : event.created
+  const baseData = dataObject as Record<string, unknown>
+  const data: Record<string, unknown> = {
+    ...baseData,
+    [newerThanField]: _updated_at,
+    ...(accountId ? { _account_id: accountId } : {}),
+  }
   const record = msg.record({
     stream: config.tableName,
     data,
@@ -104,6 +115,9 @@ export async function* processStripeEvent(
     | undefined
   if (!dataObject?.object) return
 
+  const newerThanField = (streamName: string) =>
+    catalog.streams.find((cs) => cs.stream.name === streamName)!.stream.newer_than_field
+
   // 2. Entitlements special case — the summary object type doesn't map to a
   //    registry entry, so we must handle it before the registry lookup.
   if (event.type === 'entitlements.active_entitlement_summary.updated') {
@@ -117,6 +131,7 @@ export async function* processStripeEvent(
           feature: string | { id: string }
           livemode: boolean
           lookup_key: string
+          updated?: number
         }>
       }
     }
@@ -131,6 +146,8 @@ export async function* processStripeEvent(
           customer: summary.customer,
           livemode: e.livemode,
           lookup_key: e.lookup_key,
+          [newerThanField('active_entitlements')]:
+            typeof e.updated === 'number' ? e.updated : event.created,
           ...(accountId ? { _account_id: accountId } : {}),
         },
       })
@@ -150,6 +167,8 @@ export async function* processStripeEvent(
   if (!dataObject.id) return // skip preview/draft objects
   if (!streamNames.has(resourceConfig.tableName)) return
 
+  const _updated_at = typeof dataObject.updated === 'number' ? dataObject.updated : event.created
+
   // 4. Delete events — yield record with deleted: true
   if (isDeleteEvent(event)) {
     yield msg.record({
@@ -158,6 +177,7 @@ export async function* processStripeEvent(
       data: {
         ...dataObject,
         deleted: true,
+        [newerThanField(resourceConfig.tableName)]: _updated_at,
         ...(accountId ? { _account_id: accountId } : {}),
       },
     })
@@ -180,19 +200,28 @@ export async function* processStripeEvent(
   }
 
   // 6. Yield main record
-  const recordData = accountId ? { ...data, _account_id: accountId } : data
+  const recordData: Record<string, unknown> = {
+    ...data,
+    [newerThanField(resourceConfig.tableName)]: _updated_at,
+    ...(accountId ? { _account_id: accountId } : {}),
+  }
   yield msg.record({
     stream: resourceConfig.tableName,
     data: recordData,
     emitted_at: new Date().toISOString(),
   })
 
-  // 7. Yield subscription items if applicable
+  // 7. Yield subscription items if applicable.
+  // Reuse the parent's `newer_than_field` since subscription_items may not be in the catalog.
   if (objectType === 'subscriptions' && (data as { items?: { data?: unknown[] } }).items?.data) {
     for (const item of (data as { items: { data: Record<string, unknown>[] } }).items.data) {
       yield msg.record({
         stream: 'subscription_items',
-        data: accountId ? { ...item, _account_id: accountId } : item,
+        data: {
+          ...item,
+          [newerThanField(resourceConfig.tableName)]: _updated_at,
+          ...(accountId ? { _account_id: accountId } : {}),
+        },
         emitted_at: new Date().toISOString(),
       })
     }

--- a/packages/source-stripe/src/process-event.ts
+++ b/packages/source-stripe/src/process-event.ts
@@ -209,14 +209,16 @@ export async function* processStripeEvent(
   })
 
   // 7. Yield subscription items if applicable.
-  // Reuse the parent's `newer_than_field` since subscription_items may not be in the catalog.
   if (objectType === 'subscriptions' && (data as { items?: { data?: unknown[] } }).items?.data) {
+    const subscriptionItemsNewerThanField =
+      catalog.streams.find((cs) => cs.stream.name === 'subscription_items')?.stream
+        .newer_than_field ?? newerThanField(resourceConfig.tableName)
     for (const item of (data as { items: { data: Record<string, unknown>[] } }).items.data) {
       yield msg.record({
         stream: 'subscription_items',
         data: {
           ...item,
-          [newerThanField(resourceConfig.tableName)]: _updated_at,
+          [subscriptionItemsNewerThanField]: _updated_at,
           ...(accountId ? { _account_id: accountId } : {}),
         },
         emitted_at: new Date().toISOString(),

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -244,16 +244,18 @@ function isLegacyState(data: unknown): boolean {
 
 /**
  * Fetch one page for a time range — satisfies streamingSubdivide's fetchPage contract.
- * Mutates range.cursor in-place. Returns raw data + lastObserved for subdivision.
+ * Mutates range.cursor in-place. Returns stamped data + lastObserved.
  */
 async function fetchPageForRange(opts: {
   range: RemainingRange
   listFn: ListFn
   streamName: string
+  newerThanField: string
   supportsLimit: boolean
   supportsForwardPagination: boolean
 }): Promise<PageResult<Record<string, unknown>>> {
-  const { range, listFn, streamName, supportsLimit, supportsForwardPagination } = opts
+  const { range, listFn, streamName, newerThanField, supportsLimit, supportsForwardPagination } =
+    opts
 
   const created: Record<string, number> = {}
   if (range.gte) created.gte = toUnixSeconds(range.gte)
@@ -265,6 +267,8 @@ async function fetchPageForRange(opts: {
   if (supportsForwardPagination && range.cursor) params.starting_after = range.cursor
 
   const response = await listFn(params as Parameters<typeof listFn>[0])
+  const responseAt =
+    typeof response.responseAt === 'number' ? response.responseAt : Math.floor(Date.now() / 1000)
 
   const hasMore = supportsForwardPagination && response.has_more
   let nextCursor: string | null = null
@@ -277,9 +281,15 @@ async function fetchPageForRange(opts: {
   // lastObserved = oldest record's created timestamp on this page.
   // Stripe returns newest-first, so the last record is the oldest.
   let lastObserved: number | null = null
+  const data: Record<string, unknown>[] = []
   for (const item of response.data) {
-    const created = (item as Record<string, unknown>).created
+    const record = item as Record<string, unknown>
+    const created = record.created
     if (typeof created === 'number') lastObserved = created
+    data.push({
+      ...record,
+      [newerThanField]: typeof record.updated === 'number' ? record.updated : responseAt,
+    })
   }
 
   log.trace({
@@ -297,10 +307,9 @@ async function fetchPageForRange(opts: {
 
   return {
     range,
-    data: response.data as Record<string, unknown>[],
+    data,
     hasMore,
     lastObserved,
-    responseAt: response.responseAt,
   }
 }
 
@@ -353,8 +362,8 @@ async function* paginateSequential(opts: {
     const response = prefetchedResponse
       ? await prefetchedResponse
       : await listFn(params as Parameters<typeof listFn>[0])
-    // Use Stripe's HTTP Date as the per-page fallback timestamp, then local now().
-    const responseAt = response.responseAt
+    const responseAt =
+      typeof response.responseAt === 'number' ? response.responseAt : Math.floor(Date.now() / 1000)
     prefetchedResponse = null
     totalApiCalls.count++
 
@@ -387,12 +396,11 @@ async function* paginateSequential(opts: {
 
     for (const item of response.data) {
       const record = item as Record<string, unknown>
-      const _updated_at = typeof record.updated === 'number' ? record.updated : responseAt
       yield msg.record({
         stream: streamName,
         data: {
           ...record,
-          [newerThanField]: _updated_at,
+          [newerThanField]: typeof record.updated === 'number' ? record.updated : responseAt,
           _account_id: accountId,
         },
         emitted_at: new Date().toISOString(),
@@ -516,6 +524,7 @@ async function* iterateStream(opts: {
           range,
           listFn: rateLimitedListFn,
           streamName,
+          newerThanField,
           supportsLimit,
           supportsForwardPagination,
         }),
@@ -528,18 +537,10 @@ async function* iterateStream(opts: {
 
       if (drainQueue) yield* drainQueue()
 
-      // Use Stripe's HTTP Date as the per-page fallback timestamp,
-      // then local now().
-      const responseAt = event.responseAt
       for (const item of event.data) {
-        const _updated_at = typeof item.updated === 'number' ? item.updated : responseAt
         yield msg.record({
           stream: streamName,
-          data: {
-            ...item,
-            [newerThanField]: _updated_at,
-            _account_id: accountId,
-          },
+          data: { ...item, _account_id: accountId },
           emitted_at: new Date().toISOString(),
         })
         totalEmitted.count++

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -295,7 +295,13 @@ async function fetchPageForRange(opts: {
 
   range.cursor = hasMore ? nextCursor : null
 
-  return { range, data: response.data as Record<string, unknown>[], hasMore, lastObserved }
+  return {
+    range,
+    data: response.data as Record<string, unknown>[],
+    hasMore,
+    lastObserved,
+    responseAt: response.responseAt,
+  }
 }
 
 // MARK: - Sequential pagination (no subdivision)
@@ -309,6 +315,7 @@ async function* paginateSequential(opts: {
   accountedRange: { gte: string; lt: string }
   listFn: ListFn
   streamName: string
+  newerThanField: string
   accountId: string
   supportsLimit: boolean
   supportsForwardPagination: boolean
@@ -322,6 +329,7 @@ async function* paginateSequential(opts: {
     accountedRange,
     listFn,
     streamName,
+    newerThanField,
     accountId,
     supportsLimit,
     supportsForwardPagination,
@@ -345,6 +353,8 @@ async function* paginateSequential(opts: {
     const response = prefetchedResponse
       ? await prefetchedResponse
       : await listFn(params as Parameters<typeof listFn>[0])
+    // Use Stripe's HTTP Date as the per-page fallback timestamp, then local now().
+    const responseAt = response.responseAt
     prefetchedResponse = null
     totalApiCalls.count++
 
@@ -376,9 +386,15 @@ async function* paginateSequential(opts: {
     })
 
     for (const item of response.data) {
+      const record = item as Record<string, unknown>
+      const _updated_at = typeof record.updated === 'number' ? record.updated : responseAt
       yield msg.record({
         stream: streamName,
-        data: { ...(item as Record<string, unknown>), _account_id: accountId },
+        data: {
+          ...record,
+          [newerThanField]: _updated_at,
+          _account_id: accountId,
+        },
         emitted_at: new Date().toISOString(),
       })
       totalEmitted.count++
@@ -411,6 +427,8 @@ async function* paginateSequential(opts: {
 
 async function* iterateStream(opts: {
   streamName: string
+  /** Catalog-declared staleness column (cs.stream.newer_than_field). */
+  newerThanField: string
   timeRange: { gte: string; lt: string }
   streamState: StreamState | undefined
   resourceConfig: ResourceConfig & { listFn: ListFn }
@@ -423,6 +441,7 @@ async function* iterateStream(opts: {
 }): AsyncGenerator<Message> {
   const {
     streamName,
+    newerThanField,
     timeRange,
     resourceConfig,
     accountId,
@@ -509,10 +528,18 @@ async function* iterateStream(opts: {
 
       if (drainQueue) yield* drainQueue()
 
+      // Use Stripe's HTTP Date as the per-page fallback timestamp,
+      // then local now().
+      const responseAt = event.responseAt
       for (const item of event.data) {
+        const _updated_at = typeof item.updated === 'number' ? item.updated : responseAt
         yield msg.record({
           stream: streamName,
-          data: { ...item, _account_id: accountId },
+          data: {
+            ...item,
+            [newerThanField]: _updated_at,
+            _account_id: accountId,
+          },
           emitted_at: new Date().toISOString(),
         })
         totalEmitted.count++
@@ -558,6 +585,7 @@ async function* iterateStream(opts: {
       accountedRange,
       listFn: rateLimitedListFn,
       streamName,
+      newerThanField,
       accountId,
       supportsLimit,
       supportsForwardPagination,
@@ -596,7 +624,7 @@ async function* iterateStream(opts: {
 export async function* listApiBackfill(opts: {
   catalog: {
     streams: Array<{
-      stream: { name: string }
+      stream: { name: string; newer_than_field: string }
       backfill_limit?: number | undefined
       time_range?: { gte?: string; lt?: string } | undefined
     }>
@@ -670,6 +698,7 @@ export async function* listApiBackfill(opts: {
         try {
           yield* iterateStream({
             streamName: stream.name,
+            newerThanField: stream.newer_than_field,
             timeRange,
             streamState,
             resourceConfig: { ...resourceConfig, listFn: resourceConfig.listFn! },

--- a/packages/test-utils/src/db/storage.ts
+++ b/packages/test-utils/src/db/storage.ts
@@ -14,7 +14,7 @@ export async function ensureSchema(
 ): Promise<void> {
   const q = quoteIdentifier
   await pool.query(`CREATE SCHEMA IF NOT EXISTS ${q(schema)}`)
-  // No trigger needed — destination writes `_updated_at` explicitly (DDR-009).
+  // No trigger needed; tests either use defaults or destination upsertMany.
 }
 
 export async function ensureObjectTable(

--- a/packages/test-utils/src/db/storage.ts
+++ b/packages/test-utils/src/db/storage.ts
@@ -14,19 +14,7 @@ export async function ensureSchema(
 ): Promise<void> {
   const q = quoteIdentifier
   await pool.query(`CREATE SCHEMA IF NOT EXISTS ${q(schema)}`)
-  await pool.query(`
-    CREATE OR REPLACE FUNCTION ${q(schema)}.set_updated_at() RETURNS trigger
-        LANGUAGE plpgsql
-    AS $$
-    BEGIN
-      NEW := jsonb_populate_record(
-        NEW,
-        jsonb_build_object('updated_at', now(), '_updated_at', now())
-      );
-      RETURN NEW;
-    END;
-    $$;
-  `)
+  // No trigger needed — destination writes `_updated_at` explicitly (DDR-009).
 }
 
 export async function ensureObjectTable(
@@ -83,8 +71,7 @@ export async function upsertObjects(
       VALUES ${placeholders.join(', ')}
       ON CONFLICT ("id")
       DO UPDATE SET
-        "_raw_data" = EXCLUDED."_raw_data",
-        "_updated_at" = now()
+        "_raw_data" = EXCLUDED."_raw_data"
     `,
     values
   )

--- a/scripts/check-sync-efficiency.ts
+++ b/scripts/check-sync-efficiency.ts
@@ -66,6 +66,7 @@ function makeListFn(
     return {
       data,
       has_more: filtered.length > data.length,
+      responseAt: Math.floor(Date.now() / 1000),
     }
   }
 }
@@ -109,6 +110,7 @@ function buildSyntheticSource(counters: { requests: number }): Source<Record<str
           streams: streamNames.map((name) => ({
             name,
             primary_key: [['id']],
+            newer_than_field: '_updated_at',
           })),
         },
       }


### PR DESCRIPTION
## Summary

Adds source-owned `_updated_at` stamping across Stripe sync paths and makes destinations use that value for stale-write prevention.

- Stripe source now declares `_updated_at` as the default `newer_than_field` and stamps every emitted record from native `updated`, falling back to event/page response time.
- Postgres keeps the legacy non-generated `timestamptz` `_updated_at` column for zero-migration compatibility, but `upsertMany` now writes the source-stamped timestamp explicitly.
- Google Sheets now uses `_updated_at` for stale-write gating, including in-batch dedupe and existing-row comparisons.
- Documents the DDR-009 source-owned `_updated_at` contract and removes legacy destination-side `set_updated_at` trigger setup.

## Testing
- Added Stripe source tests that assert `_updated_at` is stamped on webhook/event-derived records, delete records, subscription item fan-out records, and list-API backfill records.
- Added Postgres destination tests for source-stamped `_updated_at` write-through, stale-write rejection for records without native `updated`, and schema projection avoiding duplicate `_updated_at` columns.
- Added Google Sheets destination tests for cross-batch stale-write gating, in-batch dedupe by `newer_than_field`, missing timestamp failure handling, and `_updated_at` passthrough behavior.
- Updated engine sync lifecycle tests so synthetic records are source-stamped with `_updated_at`.

## Notes

Postgres intentionally does not migrate `_updated_at` to a generated column. Existing tables keep the same `timestamptz NOT NULL DEFAULT now()` shape, and new writes overwrite the default with the source-stamped timestamp.
