### PR TITLE
E2E: add concurrency guard + make Sigma validation non-fatal

### DIFF
--- a/.github/workflows/prod-e2e-test.yml
+++ b/.github/workflows/prod-e2e-test.yml
@@ -10,6 +10,11 @@ on:
 permissions:
   contents: read
 
+# Each matrix leg gets its own concurrency slot so runs don't cancel each other.
+concurrency:
+  group: e2e-monitor-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: false
+
 jobs:
   monitor:
     name: E2E — ${{ matrix.env }}
@@ -97,6 +102,8 @@ jobs:
           STRIPE_API_BASE: ${{ matrix.api_base }}
         run: ./scripts/monitor-sync-progress.sh
 
+      # TODO: Make Sigma validation a hard failure once selective sync is available
+      # and the DB consistently reaches ready state.
       - name: Sigma validation
         env:
           DATABASE_URL: ${{ steps.create-db.outputs.db_string }}
@@ -106,7 +113,6 @@ jobs:
           STATUS=$?
           if [ "$STATUS" -ne 0 ]; then
             echo "::warning title=Sigma reconciliation::Postgres is missing rows that exist in Sigma. See the job log for the per-table diff and the list of missing IDs with their created timestamps."
-            exit "$STATUS"
           fi
 
       - name: Delete Stripe database


### PR DESCRIPTION
## Summary

Follow-up to #325.

- **Concurrency group** — Prevent E2E runs from cancelling each other when a new push/schedule/dispatch triggers while a run is in progress.
- **Sigma validation non-fatal** — Until selective sync is available and DBs consistently reach ready state, Sigma reconciliation failures are warnings, not hard failures.

## Test plan

- [x] Prod E2E: monitor step passes (accepts error state)
- [x] QA E2E: passes
- [ ] Verify Sigma step no longer fails the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)