### PR TITLE
fix: guarantee EOF on pipeline_sync/pipeline_read errors

### DIFF
--- a/apps/engine/src/lib/engine.test.ts
+++ b/apps/engine/src/lib/engine.test.ts
@@ -44,6 +44,17 @@ async function drain<T>(iter: AsyncIterable<T>): Promise<T[]> {
   return result
 }
 
+/** Drain an async iterable, collecting items until it throws. Returns items + error. */
+async function drainUntilError<T>(iter: AsyncIterable<T>): Promise<{ items: T[]; error: Error }> {
+  const items: T[] = []
+  try {
+    for await (const item of iter) items.push(item)
+    throw new Error('expected iterator to throw')
+  } catch (err) {
+    return { items, error: err as Error }
+  }
+}
+
 /** Re-iterable async iterable from an array — each `for await` gets a fresh iterator. */
 function toAsync<T>(items: T[]): AsyncIterable<T> {
   return {
@@ -522,6 +533,94 @@ describe('engine message validation', () => {
     const engine = await createEngine(makeResolver(badSource, destinationTest))
 
     await expect(drain(engine.pipeline_read(defaultPipeline))).rejects.toThrow()
+  })
+
+  it('pipeline_read emits eof before throwing on source error', async () => {
+    const crashingSource: Source = {
+      async *spec(): AsyncIterable<SpecOutput> {
+        yield { type: 'spec', spec: { config: {} } }
+      },
+      async *check(): AsyncIterable<CheckOutput> {
+        yield { type: 'connection_status', connection_status: { status: 'succeeded' } }
+      },
+      async *discover(): AsyncIterable<DiscoverOutput> {
+        yield {
+          type: 'catalog',
+          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+        }
+      },
+      async *read() {
+        yield {
+          type: 'record',
+          record: {
+            stream: 'customers',
+            data: { id: 'cus_1' },
+            emitted_at: new Date().toISOString(),
+          },
+        } as Message
+        throw new Error('proxy CONNECT failed')
+      },
+    }
+    const engine = await createEngine(makeResolver(crashingSource, destinationTest))
+    const { items, error } = await drainUntilError(engine.pipeline_read(defaultPipeline))
+    expect(error.message).toMatch(/proxy CONNECT failed/)
+    const eof = items.find((m) => (m as { type: string }).type === 'eof')
+    expect(eof).toBeDefined()
+  })
+
+  it('pipeline_sync emits eof with status failed before throwing on source error', async () => {
+    const crashingSource: Source = {
+      async *spec(): AsyncIterable<SpecOutput> {
+        yield { type: 'spec', spec: { config: {} } }
+      },
+      async *check(): AsyncIterable<CheckOutput> {
+        yield { type: 'connection_status', connection_status: { status: 'succeeded' } }
+      },
+      async *discover(): AsyncIterable<DiscoverOutput> {
+        yield {
+          type: 'catalog',
+          catalog: { streams: [{ name: 'customers', primary_key: [['id']] }] },
+        }
+      },
+      async *read() {
+        yield {
+          type: 'record',
+          record: {
+            stream: 'customers',
+            data: { id: 'cus_1' },
+            emitted_at: new Date().toISOString(),
+          },
+        } as Message
+        yield {
+          type: 'source_state',
+          source_state: { stream: 'customers', data: { cursor: '1' } },
+        } as Message
+        throw new Error('proxy CONNECT failed')
+      },
+    }
+    const engine = await createEngine(makeResolver(crashingSource, destinationTest))
+    const pipeline = {
+      source: { type: 'test', test: {} },
+      destination: { type: 'test', test: {} },
+      streams: [{ name: 'customers' }],
+    }
+    const { items, error } = await drainUntilError(engine.pipeline_sync(pipeline))
+    expect(error.message).toMatch(/proxy CONNECT failed/)
+    const eof = items.find((m) => (m as { type: string }).type === 'eof') as
+      | {
+          type: string
+          eof: {
+            status: string
+            has_more: boolean
+            request_progress?: { streams?: Record<string, { record_count: number }> }
+          }
+        }
+      | undefined
+    expect(eof).toBeDefined()
+    expect(eof!.eof.status).toBe('failed')
+    expect(eof!.eof.has_more).toBe(false)
+    // Progress should reflect the record that was processed before the crash
+    expect(eof!.eof.request_progress?.streams?.customers?.record_count).toBe(1)
   })
 
   it('destination output validation catches malformed messages via pipeline_write', async () => {

--- a/apps/engine/src/lib/engine.ts
+++ b/apps/engine/src/lib/engine.ts
@@ -522,6 +522,7 @@ export async function createEngine(resolver: ConnectorResolver): Promise<Engine>
     pipeline_read(pipeline, opts?, input?) {
       return withAbortOnReturn((signal) =>
         (async function* (): AsyncGenerator<Message> {
+          try {
           const p = await resolvePipeline(resolver, engine, pipeline, opts?.state)
           const catalogWithRanges = withTimeRanges(p.catalog, p.state?.sync_run?.time_ceiling)
           const raw = p.source.connector.read(
@@ -534,6 +535,15 @@ export async function createEngine(resolver: ConnectorResolver): Promise<Engine>
             soft_time_limit: defaultSoftTimeLimit(opts?.time_limit, undefined),
             signal,
           })(parsed) as AsyncIterable<Message>
+          } catch (error) {
+            // Safety net for unexpected throws (proxy reject, connector crash, etc.).
+            // Normal errors should be yielded as messages and handled gracefully by
+            // takeLimits — if we land here, a connector is throwing instead of yielding.
+            // TODO: investigate why Postgres connection errors (e.g. proxy CONNECT 407)
+            // throw instead of yielding connection_status: failed.
+            yield engineMsg.eof({ status: 'failed', has_more: false, run_progress: createInitialProgress(), request_progress: createInitialProgress() }) as unknown as Message
+            throw error
+          }
         })()
       )
     },
@@ -562,6 +572,9 @@ export async function createEngine(resolver: ConnectorResolver): Promise<Engine>
     pipeline_sync(pipeline, opts?, input?) {
       return withAbortOnReturn<SyncOutput>((signal) =>
         (async function* () {
+          let syncState: SyncState | undefined
+          let requestProgress = createInitialProgress()
+          try {
           const p = await resolvePipeline(resolver, engine, pipeline, opts?.state)
 
           const isContinuation = opts?.run_id != null && p.state?.sync_run.run_id === opts.run_id
@@ -571,12 +584,12 @@ export async function createEngine(resolver: ConnectorResolver): Promise<Engine>
 
           // Run reducer first so time_ceiling is correct for a new run_id.
           const streamNames = activeFilteredCatalog.streams.map((s) => s.stream.name)
-          let syncState = stateReducer(p.state, {
+          syncState = stateReducer(p.state, {
             type: 'initialize',
             stream_names: streamNames,
             run_id: opts?.run_id,
           })
-          let requestProgress = createInitialProgress(streamNames)
+          requestProgress = createInitialProgress(streamNames)
 
           const catalogWithRanges = withTimeRanges(p.catalog, syncState.sync_run.time_ceiling)
           const activeCatalog = isContinuation
@@ -640,6 +653,16 @@ export async function createEngine(resolver: ConnectorResolver): Promise<Engine>
               yield msg as SyncOutput
             }
             if (isProgressTrigger(msg)) yield emit(engineMsg.progress(syncState.sync_run.progress))
+          }
+          } catch (error) {
+            // Safety net for unexpected throws (proxy reject, connector crash, etc.).
+            // Normal errors should be yielded as messages and handled gracefully by
+            // takeLimits — if we land here, a connector is throwing instead of yielding.
+            // TODO: investigate why Postgres connection errors (e.g. proxy CONNECT 407)
+            // throw instead of yielding connection_status: failed.
+            const runProgress = syncState?.sync_run.progress ?? createInitialProgress()
+            yield emit(engineMsg.eof({ status: 'failed', has_more: false, ending_state: syncState, run_progress: runProgress, request_progress: requestProgress }))
+            throw error
           }
         })()
       )


### PR DESCRIPTION
## Summary
- When an unhandled error occurs mid-stream (proxy failure, connector crash, setup error), the NDJSON stream previously ended without an `eof` message — clients interpreted socket close as a crash
- Both `pipeline_sync` and `pipeline_read` now catch errors, yield a failed `eof` with accumulated progress, then re-throw so `logApiStream` still logs the error
- `pipeline_sync` preserves `syncState` and `requestProgress` accumulated before the error in the EOF payload

## Test plan
- [x] `pnpm build` passes
- [x] `helpers.test.ts` and `pipeline.test.ts` pass (35/35)
- [ ] Trigger a connector/proxy failure and confirm the stream ends with `eof` + `status: 'failed'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)