### PR TITLE
Persist Sheets enum constraints in native validation rules

### DIFF
--- a/e2e/service-docker.test.ts
+++ b/e2e/service-docker.test.ts
@@ -133,7 +133,11 @@ describeWithEnv(
               api_key: STRIPE_API_KEY,
               api_version: BUNDLED_API_VERSION,
               ...(stripeMockUrl
-                ? { base_url: stripeMockUrl, account_id: 'acct_mock', account_created: 1_700_000_000 }
+                ? {
+                    base_url: stripeMockUrl,
+                    account_id: 'acct_mock',
+                    account_created: 1_700_000_000,
+                  }
                 : {}),
             },
           },

--- a/packages/destination-google-sheets/__tests__/memory-sheets.ts
+++ b/packages/destination-google-sheets/__tests__/memory-sheets.ts
@@ -9,6 +9,7 @@ import type { sheets_v4 } from 'googleapis'
 interface SheetTab {
   sheetId: number
   values: unknown[][]
+  dataValidations: Map<number, unknown>
 }
 
 interface Spreadsheet {
@@ -50,6 +51,25 @@ export function createMemorySheets() {
     return match ? Number(match[1]) : 1
   }
 
+  function parseRangeBounds(range: string): {
+    startCol: number
+    startRow: number
+    endCol: number
+    endRow: number
+  } {
+    const bang = range.indexOf('!')
+    const a1 = bang >= 0 ? range.slice(bang + 1) : range
+    const match = a1.match(/^([A-Z]+)(\d+)?(?::([A-Z]+)(\d+)?)?$/)
+    if (!match) {
+      return { startCol: 0, startRow: 0, endCol: 0, endRow: 0 }
+    }
+    const startCol = columnIndex(match[1])
+    const startRow = match[2] ? Number(match[2]) - 1 : 0
+    const endCol = match[3] !== undefined ? columnIndex(match[3]) : startCol
+    const endRow = match[4] !== undefined ? Number(match[4]) - 1 : startRow
+    return { startCol, startRow, endCol, endRow }
+  }
+
   function columnLabel(index: number): string {
     let value = index
     let label = ''
@@ -61,17 +81,15 @@ export function createMemorySheets() {
     return label || 'A'
   }
 
+  function columnIndex(label: string): number {
+    return [...label].reduce((value, ch) => value * 26 + (ch.charCodeAt(0) - 64), 0) - 1
+  }
+
   // Slice `values` to an A1 range. `'Name'` → whole tab; `'Name'!A2:C[100]` → bounded.
   function sliceByRange(values: unknown[][], range: string): unknown[][] {
     const bang = range.indexOf('!')
     if (bang < 0) return values
-    const m = range.slice(bang + 1).match(/^([A-Z]+)(\d+)?(?::([A-Z]+)(\d+)?)?$/)
-    if (!m) return values
-    const colIdx = (s: string) => [...s].reduce((v, ch) => v * 26 + (ch.charCodeAt(0) - 64), 0) - 1
-    const startCol = colIdx(m[1])
-    const startRow = m[2] ? Number(m[2]) - 1 : 0
-    const endCol = m[3] !== undefined ? colIdx(m[3]) : Infinity
-    const endRow = m[4] !== undefined ? Number(m[4]) - 1 : values.length - 1
+    const { startCol, startRow, endCol, endRow } = parseRangeBounds(range)
     const out: unknown[][] = []
     for (let r = startRow; r <= Math.min(endRow, values.length - 1); r++) {
       const src = values[r] ?? []
@@ -111,14 +129,42 @@ export function createMemorySheets() {
       async create(params: { requestBody?: { properties?: { title?: string } }; fields?: string }) {
         const title = params.requestBody?.properties?.title ?? 'Untitled'
         const id = `mem_ss_${nextSpreadsheetId++}`
-        const defaultTab: SheetTab = { sheetId: nextSheetId++, values: [] }
+        const defaultTab: SheetTab = {
+          sheetId: nextSheetId++,
+          values: [],
+          dataValidations: new Map(),
+        }
         const ss: Spreadsheet = { title, sheets: new Map([['Sheet1', defaultTab]]) }
         store.set(id, ss)
         return { data: { spreadsheetId: id } }
       },
 
-      async get(params: { spreadsheetId: string; fields?: string }) {
+      async get(params: { spreadsheetId: string; fields?: string; ranges?: string[] }) {
         const ss = getSpreadsheet(params.spreadsheetId)
+        if (params.ranges && params.ranges.length > 0) {
+          const sheetsData = params.ranges.map((range) => {
+            const tab = getTab(params.spreadsheetId, range)
+            const name = parseSheetName(range)
+            const { startCol, startRow, endCol, endRow } = parseRangeBounds(range)
+            const rowData: Array<{ values: Array<{ dataValidation?: unknown }> }> = []
+            for (let row = startRow; row <= endRow; row++) {
+              const values: Array<{ dataValidation?: unknown }> = []
+              for (let col = startCol; col <= endCol; col++) {
+                values.push({ dataValidation: row >= 1 ? tab.dataValidations.get(col) : undefined })
+              }
+              rowData.push({ values })
+            }
+            return {
+              properties: {
+                sheetId: tab.sheetId,
+                title: name,
+                gridProperties: { rowCount: 1000, columnCount: 26 },
+              },
+              data: [{ rowData }],
+            }
+          })
+          return { data: { sheets: sheetsData } }
+        }
         const sheetsMeta = Array.from(ss.sheets.entries()).map(([name, tab]) => ({
           properties: {
             sheetId: tab.sheetId,
@@ -143,7 +189,7 @@ export function createMemorySheets() {
               throw Object.assign(new Error(`Sheet already exists: ${name}`), { code: 400 })
             }
             const sheetId = nextSheetId++
-            ss.sheets.set(name, { sheetId, values: [] })
+            ss.sheets.set(name, { sheetId, values: [], dataValidations: new Map() })
             replies.push({ addSheet: { properties: { sheetId, title: name } } })
           } else if (req.updateSheetProperties) {
             const update = req.updateSheetProperties as {
@@ -156,6 +202,29 @@ export function createMemorySheets() {
                 ss.sheets.delete(oldName)
                 ss.sheets.set(update.properties.title, tab)
                 break
+              }
+            }
+            replies.push({})
+          } else if (req.setDataValidation) {
+            const sdv = req.setDataValidation as {
+              range?: {
+                sheetId?: number
+                startColumnIndex?: number
+                endColumnIndex?: number
+              }
+              rule?: unknown
+            }
+            const sheetId = sdv.range?.sheetId
+            if (sheetId != null) {
+              const tab = getTabBySheetId(params.spreadsheetId, sheetId)
+              const startColumnIndex = sdv.range?.startColumnIndex ?? 0
+              const endColumnIndex = sdv.range?.endColumnIndex ?? startColumnIndex + 1
+              for (let col = startColumnIndex; col < endColumnIndex; col++) {
+                if (sdv.rule === undefined) {
+                  tab.dataValidations.delete(col)
+                } else {
+                  tab.dataValidations.set(col, structuredClone(sdv.rule))
+                }
               }
             }
             replies.push({})

--- a/packages/destination-google-sheets/src/index.test.ts
+++ b/packages/destination-google-sheets/src/index.test.ts
@@ -11,7 +11,7 @@ import {
 import {
   applyBatch,
   MAX_CELLS_PER_SPREADSHEET,
-  readEnumConstraints,
+  readEnumValidations,
   readSheet,
   type StreamBatchOps,
 } from './writer.js'
@@ -1855,12 +1855,17 @@ describe('_updated_at column (source-owned, passthrough)', () => {
 })
 
 describe('enum constraints on any column', () => {
-  function catalogWith(enumValues: string[], column = '_account_id'): ConfiguredCatalog {
+  function catalogWith(
+    enumValues: string[],
+    column = '_account_id',
+    options: { streamName?: string; required?: boolean } = {}
+  ): ConfiguredCatalog {
+    const required = options.required ? [column] : undefined
     return {
       streams: [
         {
           stream: {
-            name: 'charges',
+            name: options.streamName ?? 'charges',
             primary_key: [['id']],
             newer_than_field: '_updated_at',
             json_schema: {
@@ -1869,6 +1874,7 @@ describe('enum constraints on any column', () => {
                 id: { type: 'string' },
                 [column]: { type: 'string', enum: enumValues },
               },
+              ...(required ? { required: ['id', ...required] } : {}),
             },
           },
           sync_mode: 'full_refresh',
@@ -1878,7 +1884,14 @@ describe('enum constraints on any column', () => {
     }
   }
 
-  it('setup writes enum constraints to Overview; write rejects mismatches', async () => {
+  function streamHeaders(catalog: ConfiguredCatalog) {
+    return catalog.streams.map(({ stream }) => ({
+      streamName: stream.name,
+      headers: Object.keys((stream.json_schema?.properties as Record<string, unknown>) ?? {}),
+    }))
+  }
+
+  it('setup writes enum constraints to sheet validation; write rejects mismatches', async () => {
     const { sheets, getSpreadsheetIds } = createMemorySheets()
     const dest = createDestination(sheets)
     const catalog = catalogWith(['acct_123', 'acct_456'])
@@ -1887,9 +1900,10 @@ describe('enum constraints on any column', () => {
     }
     const spreadsheetId = getSpreadsheetIds()[0]
 
-    expect(await readSheet(sheets, spreadsheetId, 'Overview')).toContainEqual([
-      'Allowed values for _account_id',
-      'acct_123,acct_456',
+    const validations = await readEnumValidations(sheets, spreadsheetId, streamHeaders(catalog))
+    expect(validations.get('charges')?.get('_account_id')?.allowedValues).toEqual([
+      'acct_123',
+      'acct_456',
     ])
 
     const out = await collect(
@@ -1912,7 +1926,7 @@ describe('enum constraints on any column', () => {
     ).toMatch(/_account_id.*acct_999/)
   })
 
-  it('round-trips enum values via Overview sheet', async () => {
+  it('round-trips enum values via sheet validation', async () => {
     const { sheets, getSpreadsheetIds } = createMemorySheets()
     const dest = createDestination(sheets)
     const catalog = catalogWith(['val_a', 'val_b', 'val_c'], 'status')
@@ -1920,7 +1934,82 @@ describe('enum constraints on any column', () => {
       void msg
     }
 
-    const constraints = await readEnumConstraints(sheets, getSpreadsheetIds()[0])
-    expect([...(constraints.get('status') ?? [])]).toEqual(['val_a', 'val_b', 'val_c'])
+    const validations = await readEnumValidations(
+      sheets,
+      getSpreadsheetIds()[0],
+      streamHeaders(catalog)
+    )
+    expect(validations.get('charges')?.get('status')?.allowedValues).toEqual([
+      'val_a',
+      'val_b',
+      'val_c',
+    ])
+  })
+
+  it('scopes enum validation per stream', async () => {
+    const { sheets, getSpreadsheetIds, getData } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const catalog: ConfiguredCatalog = {
+      streams: [
+        ...catalogWith(['paid', 'void'], 'status', { streamName: 'charges' }).streams,
+        {
+          stream: {
+            name: 'invoices',
+            primary_key: [['id']],
+            newer_than_field: '_updated_at',
+            json_schema: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                amount: { type: 'integer' },
+              },
+            },
+          },
+          sync_mode: 'full_refresh',
+          destination_sync_mode: 'append',
+        },
+      ],
+    }
+
+    for await (const msg of dest.setup!({ config: cfg(), catalog })) {
+      void msg
+    }
+    const spreadsheetId = getSpreadsheetIds()[0]
+
+    const out = await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: spreadsheetId }), catalog },
+        toAsyncIter([
+          record('charges', { id: 'ch_1', status: 'paid' }),
+          record('invoices', { id: 'in_1', amount: 42 }),
+        ])
+      )
+    )
+
+    expect(
+      out.find((m) => m.type === 'connection_status' && m.connection_status.status === 'failed')
+    ).toBeUndefined()
+    expect(stripUpdatedAt(getData(spreadsheetId, 'invoices'))[1]).toEqual(['in_1', '42'])
+  })
+
+  it('allows optional enum fields to be omitted', async () => {
+    const { sheets, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+    const catalog = catalogWith(['draft', 'open'], 'status')
+    for await (const msg of dest.setup!({ config: cfg(), catalog })) {
+      void msg
+    }
+    const spreadsheetId = getSpreadsheetIds()[0]
+
+    const out = await collect(
+      dest.write(
+        { config: cfg({ spreadsheet_id: spreadsheetId }), catalog },
+        toAsyncIter([record('charges', { id: 'ch_1' })])
+      )
+    )
+
+    expect(
+      out.find((m) => m.type === 'connection_status' && m.connection_status.status === 'failed')
+    ).toBeUndefined()
   })
 })

--- a/packages/destination-google-sheets/src/index.test.ts
+++ b/packages/destination-google-sheets/src/index.test.ts
@@ -1992,6 +1992,38 @@ describe('enum constraints on any column', () => {
     expect(stripUpdatedAt(getData(spreadsheetId, 'invoices'))[1]).toEqual(['in_1', '42'])
   })
 
+  it('rejects setup when existing validation disagrees with catalog', async () => {
+    const { sheets, getSpreadsheetIds } = createMemorySheets()
+    const dest = createDestination(sheets)
+
+    // First setup with one set of values
+    const catalog1 = catalogWith(['acct_a', 'acct_b'])
+    for await (const msg of dest.setup!({ config: cfg(), catalog: catalog1 })) {
+      void msg
+    }
+    const spreadsheetId = getSpreadsheetIds()[0]
+
+    // Same values, different order — should be idempotent
+    const catalog1b = catalogWith(['acct_b', 'acct_a'])
+    for await (const msg of dest.setup!({
+      config: cfg({ spreadsheet_id: spreadsheetId }),
+      catalog: catalog1b,
+    })) {
+      void msg
+    }
+
+    // Different values — should throw
+    const catalog2 = catalogWith(['acct_a'])
+    await expect(async () => {
+      for await (const msg of dest.setup!({
+        config: cfg({ spreadsheet_id: spreadsheetId }),
+        catalog: catalog2,
+      })) {
+        void msg
+      }
+    }).rejects.toThrow(/enum values changed.*_account_id.*acct_a, acct_b.*acct_a/s)
+  })
+
   it('allows optional enum fields to be omitted', async () => {
     const { sheets, getSpreadsheetIds } = createMemorySheets()
     const dest = createDestination(sheets)

--- a/packages/destination-google-sheets/src/index.ts
+++ b/packages/destination-google-sheets/src/index.ts
@@ -22,6 +22,7 @@ import {
   batchReadSheets,
   buildRowMapFromPkColumns,
   buildRowMapFromRows,
+  type EnumValidationRule,
   ensureIntroSheet,
   deleteSpreadsheet,
   ensureSheet,
@@ -30,9 +31,11 @@ import {
   createSpreadsheet,
   findSheetId,
   protectSheets,
-  readEnumConstraints,
+  readEnumValidations,
   readHeaderRow,
+  setEnumValidations,
   type BatchReadRequest,
+  type StreamEnumValidationRules,
   type StreamBatchOps,
 } from './writer.js'
 
@@ -120,6 +123,40 @@ function extendHeaders(
   return { headers, changed }
 }
 
+function extractDesiredEnumRules(catalog: {
+  streams: Array<{ stream: { name: string; json_schema?: Record<string, unknown> } }>
+}): StreamEnumValidationRules {
+  const out: StreamEnumValidationRules = new Map()
+  for (const { stream } of catalog.streams) {
+    const properties = stream.json_schema?.properties as
+      | Record<string, { enum?: string[] }>
+      | undefined
+    if (!properties) continue
+    const streamRules = new Map<string, EnumValidationRule>()
+    for (const [columnName, property] of Object.entries(properties)) {
+      if (!Array.isArray(property?.enum) || property.enum.length === 0) continue
+      streamRules.set(columnName, { allowedValues: [...property.enum] })
+    }
+    if (streamRules.size > 0) out.set(stream.name, streamRules)
+  }
+  return out
+}
+
+function extractRequiredFields(catalog: {
+  streams: Array<{ stream: { name: string; json_schema?: Record<string, unknown> } }>
+}): Map<string, Set<string>> {
+  const out = new Map<string, Set<string>>()
+  for (const { stream } of catalog.streams) {
+    const required = stream.json_schema?.required
+    if (!Array.isArray(required) || required.length === 0) continue
+    out.set(
+      stream.name,
+      new Set(required.filter((value): value is string => typeof value === 'string'))
+    )
+  }
+  return out
+}
+
 // MARK: - Destination
 
 /** Runs flushAll, yielding heartbeat logs while it runs; returns any flush error via `yield*`. */
@@ -194,45 +231,9 @@ export function createDestination(
 
       const streamNames = catalog.streams.map((s) => s.stream.name)
       const metaAfterEnsure = await getSpreadsheetMeta(sheets, spreadsheetId)
-
-      // Collect all enum constraints from stream schemas. The source stamps
-      // the same enums on every stream, so the first one is representative.
-      const enumConstraints = new Map<string, string[]>()
-      const firstSchema = catalog.streams[0]?.stream.json_schema
-      const properties = firstSchema?.properties as Record<string, { enum?: string[] }> | undefined
-      if (properties) {
-        for (const [col, prop] of Object.entries(properties)) {
-          if (Array.isArray(prop?.enum) && prop.enum.length > 0) {
-            enumConstraints.set(col, prop.enum)
-          }
-        }
-      }
-
-      // Fail loud on changed enum lists; silent overwrites would mask misconfig.
-      if (enumConstraints.size > 0) {
-        const existing = await readEnumConstraints(sheets, spreadsheetId)
-        for (const [col, newVals] of enumConstraints) {
-          const existingVals = existing.get(col)
-          if (!existingVals) continue
-          const nextSet = new Set(newVals)
-          if (existingVals.size === nextSet.size && [...existingVals].every((v) => nextSet.has(v)))
-            continue
-          const fmt = (s: Set<string> | string[]) => [...s].sort().join(', ')
-          throw new Error(
-            `Google Sheets destination: enum values changed for "${col}" in spreadsheet ${spreadsheetId}. ` +
-              `Existing Overview row allows [${fmt(existingVals)}]; new catalog wants [${fmt(newVals)}]. ` +
-              `Edit the ${col} enum row in Overview (or remove it) before re-running setup.`
-          )
-        }
-      }
-
-      await ensureIntroSheet(
-        sheets,
-        spreadsheetId,
-        metaAfterEnsure,
-        streamNames,
-        enumConstraints.size > 0 ? enumConstraints : undefined
-      )
+      const desiredEnumRules = extractDesiredEnumRules(catalog)
+      await setEnumValidations(sheets, spreadsheetId, sheetIdMap, streamHeaders, desiredEnumRules)
+      await ensureIntroSheet(sheets, spreadsheetId, metaAfterEnsure, streamNames)
 
       await protectSheets(sheets, spreadsheetId, metaAfterEnsure, sheetIds)
 
@@ -288,10 +289,19 @@ export function createDestination(
         ? config.spreadsheet_id
         : await createSpreadsheet(sheets, config.spreadsheet_title)
 
-      // Read enum constraints from the Overview sheet (written during setup).
-      // The JSON Schema enum is the source of truth but we keep the existing
-      // read-back validation for defense-in-depth.
-      const enumConstraints = await readEnumConstraints(sheets, spreadsheetId)
+      const streamHeadersFromCatalog = catalog.streams.map(({ stream }) => {
+        const properties = stream.json_schema?.properties as Record<string, unknown> | undefined
+        return { streamName: stream.name, headers: properties ? Object.keys(properties) : [] }
+      })
+      const existingSheetNames = new Set(
+        (await getSpreadsheetMeta(sheets, spreadsheetId)).sheets.map((sheet) => sheet.title)
+      )
+      const enumValidations = await readEnumValidations(
+        sheets,
+        spreadsheetId,
+        streamHeadersFromCatalog.filter(({ streamName }) => existingSheetNames.has(streamName))
+      )
+      const requiredFields = extractRequiredFields(catalog)
 
       // Per-stream state: column headers plus buffered appends/updates/deletes.
       const streamHeaders = new Map<string, string[]>()
@@ -729,14 +739,23 @@ export function createDestination(
               )
             }
 
-            for (const [col, allowed] of enumConstraints) {
+            const streamEnumRules = enumValidations.get(stream)
+            for (const [col, rule] of streamEnumRules ?? []) {
               const value =
                 Object.prototype.hasOwnProperty.call(cleanData, col) && cleanData[col] !== undefined
                   ? String(cleanData[col] ?? '')
                   : undefined
-              if (value === undefined || !allowed.has(value)) {
+              if (value === undefined) {
+                if (requiredFields.get(stream)?.has(col)) {
+                  throw new Error(
+                    `Sheets rejected ${stream}.${col}=undefined (required enum; allowed ${rule.allowedValues.join(',')})`
+                  )
+                }
+                continue
+              }
+              if (!rule.allowedValues.includes(value)) {
                 throw new Error(
-                  `Sheets rejected ${stream}.${col}=${JSON.stringify(value)} (not in ${[...allowed].join(',')})`
+                  `Sheets rejected ${stream}.${col}=${JSON.stringify(value)} (not in ${rule.allowedValues.join(',')})`
                 )
               }
             }

--- a/packages/destination-google-sheets/src/index.ts
+++ b/packages/destination-google-sheets/src/index.ts
@@ -232,6 +232,37 @@ export function createDestination(
       const streamNames = catalog.streams.map((s) => s.stream.name)
       const metaAfterEnsure = await getSpreadsheetMeta(sheets, spreadsheetId)
       const desiredEnumRules = extractDesiredEnumRules(catalog)
+
+      // Fail loud on changed enum lists — silent overwrites would mask misconfig.
+      // Read existing validations before writing so we can detect mismatches.
+      const existingSheetNames = new Set(metaAfterEnsure.sheets.map((s) => s.title))
+      const existingValidations = await readEnumValidations(
+        sheets,
+        spreadsheetId,
+        streamHeaders.filter(({ streamName }) => existingSheetNames.has(streamName))
+      )
+      for (const [streamName, desiredStreamRules] of desiredEnumRules) {
+        const existingStreamRules = existingValidations.get(streamName)
+        if (!existingStreamRules) continue
+        for (const [col, desired] of desiredStreamRules) {
+          const existing = existingStreamRules.get(col)
+          if (!existing) continue
+          const desiredSet = new Set(desired.allowedValues)
+          const existingSet = new Set(existing.allowedValues)
+          if (
+            desiredSet.size === existingSet.size &&
+            [...desiredSet].every((v) => existingSet.has(v))
+          )
+            continue
+          const fmt = (vals: string[]) => [...vals].sort().join(', ')
+          throw new Error(
+            `Google Sheets destination: enum values changed for "${col}" on sheet "${streamName}" in spreadsheet ${spreadsheetId}. ` +
+              `Existing validation allows [${fmt(existing.allowedValues)}]; new catalog wants [${fmt(desired.allowedValues)}]. ` +
+              `Remove the data validation on the ${col} column before re-running setup.`
+          )
+        }
+      }
+
       await setEnumValidations(sheets, spreadsheetId, sheetIdMap, streamHeaders, desiredEnumRules)
       await ensureIntroSheet(sheets, spreadsheetId, metaAfterEnsure, streamNames)
 

--- a/packages/destination-google-sheets/src/writer.ts
+++ b/packages/destination-google-sheets/src/writer.ts
@@ -104,6 +104,12 @@ export interface SpreadsheetMeta {
   }>
 }
 
+export interface EnumValidationRule {
+  allowedValues: string[]
+}
+
+export type StreamEnumValidationRules = Map<string, Map<string, EnumValidationRule>>
+
 /** Fetch spreadsheet metadata once for reuse by ensureSheets, ensureIntroSheet, protectSheets. */
 export async function getSpreadsheetMeta(
   sheets: sheets_v4.Sheets,
@@ -268,6 +274,131 @@ export async function readHeaderRow(
   return Array.isArray(headerRow) ? headerRow.map((value) => String(value)) : []
 }
 
+function columnLabel(index: number): string {
+  let value = index
+  let label = ''
+  while (value > 0) {
+    const remainder = (value - 1) % 26
+    label = String.fromCharCode(65 + remainder) + label
+    value = Math.floor((value - 1) / 26)
+  }
+  return label || 'A'
+}
+
+function cloneEnumValidationRule(rule: EnumValidationRule): EnumValidationRule {
+  return { allowedValues: [...rule.allowedValues] }
+}
+
+function toDataValidationRule(rule: EnumValidationRule): Record<string, unknown> {
+  return {
+    condition: {
+      type: 'ONE_OF_LIST',
+      values: rule.allowedValues.map((value) => ({ userEnteredValue: value })),
+    },
+    strict: true,
+    showCustomUi: true,
+  }
+}
+
+function parseEnumValidationRule(dataValidation: unknown): EnumValidationRule | undefined {
+  const condition = (dataValidation as { condition?: { type?: string; values?: unknown[] } })
+    ?.condition
+  if (condition?.type !== 'ONE_OF_LIST') return undefined
+  const allowedValues = (condition.values ?? [])
+    .map((value) => (value as { userEnteredValue?: string })?.userEnteredValue)
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+  return allowedValues.length > 0 ? { allowedValues } : undefined
+}
+
+function validationReadRange(streamName: string, columnCount: number): string {
+  return `'${streamName}'!A2:${columnLabel(columnCount)}2`
+}
+
+export async function setEnumValidations(
+  sheets: sheets_v4.Sheets,
+  spreadsheetId: string,
+  sheetIds: Map<string, number>,
+  streamHeaders: Array<{ streamName: string; headers: string[] }>,
+  desiredRules: StreamEnumValidationRules
+): Promise<void> {
+  const requests: sheets_v4.Schema$Request[] = []
+
+  for (const { streamName, headers } of streamHeaders) {
+    const sheetId = sheetIds.get(streamName)
+    if (sheetId === undefined) {
+      throw new Error(`Missing sheetId for "${streamName}" while applying enum validations`)
+    }
+    const streamRules = desiredRules.get(streamName)
+    for (let columnIndex = 0; columnIndex < headers.length; columnIndex++) {
+      const header = headers[columnIndex]
+      const rule = streamRules?.get(header)
+      requests.push({
+        setDataValidation: {
+          range: {
+            sheetId,
+            startRowIndex: 1,
+            startColumnIndex: columnIndex,
+            endColumnIndex: columnIndex + 1,
+          },
+          ...(rule ? { rule: toDataValidationRule(rule) } : {}),
+        },
+      })
+    }
+  }
+
+  if (requests.length === 0) return
+
+  await withRetry(
+    () =>
+      sheets.spreadsheets.batchUpdate({
+        spreadsheetId,
+        requestBody: { requests },
+      }),
+    'setEnumValidations'
+  )
+}
+
+export async function readEnumValidations(
+  sheets: sheets_v4.Sheets,
+  spreadsheetId: string,
+  streamHeaders: Array<{ streamName: string; headers: string[] }>
+): Promise<StreamEnumValidationRules> {
+  const targets = streamHeaders.filter(({ headers }) => headers.length > 0)
+  if (targets.length === 0) return new Map()
+
+  const response = await withRetry(
+    () =>
+      sheets.spreadsheets.get({
+        spreadsheetId,
+        ranges: targets.map(({ streamName, headers }) =>
+          validationReadRange(streamName, headers.length)
+        ),
+        fields: 'sheets(properties(title,sheetId),data(rowData(values(dataValidation))))',
+      }),
+    'readEnumValidations'
+  )
+
+  const headersByStream = new Map(targets.map(({ streamName, headers }) => [streamName, headers]))
+  const out: StreamEnumValidationRules = new Map()
+
+  for (const sheet of response.data.sheets ?? []) {
+    const streamName = sheet.properties?.title
+    if (!streamName) continue
+    const headers = headersByStream.get(streamName)
+    if (!headers) continue
+    const cells = sheet.data?.[0]?.rowData?.[0]?.values ?? []
+    const streamRules = new Map<string, EnumValidationRule>()
+    for (let index = 0; index < headers.length; index++) {
+      const header = headers[index]
+      const rule = parseEnumValidationRule(cells[index]?.dataValidation)
+      if (rule) streamRules.set(header, cloneEnumValidationRule(rule))
+    }
+    if (streamRules.size > 0) out.set(streamName, streamRules)
+  }
+
+  return out
+}
+
 /** Look up the numeric sheetId for a tab by name. Returns undefined if not found. */
 export async function findSheetId(
   sheets: sheets_v4.Sheets,
@@ -290,23 +421,6 @@ function parseUpdatedRows(updatedRange: string): { startRow: number; endRow: num
   }
 }
 
-/** Marker prefix for enum constraint rows in the Overview sheet. */
-const ENUM_MARKER_PREFIX = '__enum_'
-const ENUM_MARKER_SUFFIX = '__'
-
-function enumMarker(columnName: string): string {
-  return `${ENUM_MARKER_PREFIX}${columnName}${ENUM_MARKER_SUFFIX}`
-}
-
-function isSheetNotFound(err: unknown): boolean {
-  if (!(err instanceof Error)) return false
-  const code = (err as { code?: number | string }).code
-  // Sheets API returns 400 + "Unable to parse range" when the tab is missing.
-  // Auth (401/403), quota (429), server (5xx) and network errors must propagate.
-  if (code !== 400) return false
-  return /unable to parse range|sheet (tab )?not found/i.test(err.message)
-}
-
 /**
  * Create or update an "Overview" intro tab at index 0.
  * Lists the synced streams and warns users not to edit data tabs.
@@ -315,8 +429,7 @@ export async function ensureIntroSheet(
   sheets: sheets_v4.Sheets,
   spreadsheetId: string,
   meta: SpreadsheetMeta,
-  streamNames: string[],
-  enumConstraints?: Map<string, string[]>
+  streamNames: string[]
 ): Promise<void> {
   const TITLE = 'Overview'
   const hasOverview = meta.sheets.some((s) => s.title === TITLE)
@@ -372,13 +485,6 @@ export async function ensureIntroSheet(
     ['⚠️  Do not edit data in the synced tabs. Changes will be overwritten on the next sync.'],
   ]
 
-  if (enumConstraints && enumConstraints.size > 0) {
-    rows.push([''])
-    for (const [col, values] of enumConstraints) {
-      rows.push([enumMarker(col)], [`Allowed values for ${col}`, values.join(',')])
-    }
-  }
-
   await withRetry(() =>
     sheets.spreadsheets.values.update({
       spreadsheetId,
@@ -387,45 +493,6 @@ export async function ensureIntroSheet(
       requestBody: { values: rows },
     })
   )
-}
-
-/**
- * Read all enum allow-lists from the Overview sheet.
- * Returns a Map<columnName, Set<allowedValues>>. Empty map when none written.
- */
-export async function readEnumConstraints(
-  sheets: sheets_v4.Sheets,
-  spreadsheetId: string
-): Promise<Map<string, Set<string>>> {
-  const out = new Map<string, Set<string>>()
-  // Treat "Overview tab not present yet" as no constraints. Any other
-  // error (auth, network, quota) must propagate so callers can fail loud.
-  const res = await sheets.spreadsheets.values
-    .get({ spreadsheetId, range: `'Overview'!A:B` })
-    .catch((err: unknown) => {
-      if (isSheetNotFound(err)) return undefined
-      throw err
-    })
-  const values = (res?.data.values ?? []) as unknown[][]
-  for (let i = 0; i < values.length; i++) {
-    const cell = values[i]?.[0]
-    if (
-      typeof cell !== 'string' ||
-      !cell.startsWith(ENUM_MARKER_PREFIX) ||
-      !cell.endsWith(ENUM_MARKER_SUFFIX)
-    )
-      continue
-    const col = cell.slice(ENUM_MARKER_PREFIX.length, -ENUM_MARKER_SUFFIX.length)
-    if (!col) continue
-    const row = values[i + 1] ?? []
-    const joined = typeof row[1] === 'string' ? row[1] : ''
-    const vals = joined
-      .split(',')
-      .map((v) => v.trim())
-      .filter(Boolean)
-    if (vals.length > 0) out.set(col, new Set(vals))
-  }
-  return out
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace the Google Sheets Overview-tab enum markers with per-column data validation rules on synced tabs
- read validation rules back from existing tabs and use them as the persisted enum source for API-write enforcement, scoped per stream
- extend the in-memory Sheets fake and destination tests to cover validation read/write behavior, optional enum fields, and cross-stream isolation
- keep the branch format-clean by normalizing the touched service-docker e2e file

## Why
The sheet itself is now the persisted source of enum allow-lists. This removes the separate Overview metadata encoding and keeps the UX aligned with the machine-enforced constraint surface.

## Base branch
This PR is based on `account_id_constraint`.

## Verification
- `pnpm --filter ./packages/destination-google-sheets test -- --runInBand`
- `pnpm --filter ./packages/destination-google-sheets build`
- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- GitHub Actions for PR head `bc6aca22` are green

## Notes
- enum persistence now lives in native Google Sheets validation rules; the Overview sheet is no longer used as a machine-readable enum store
- required-field behavior still comes from the catalog at write time; this change only makes enum allow-lists persist in the sheet itself