### PR TITLE
fix: skip v2_core_accounts when Accounts v2 is not enabled for merchant

### DIFF
--- a/packages/source-stripe/src/src-list-api.test.ts
+++ b/packages/source-stripe/src/src-list-api.test.ts
@@ -120,23 +120,23 @@ describe('isSkippableError', () => {
     return new StripeApiRequestError(400, { error: { message } }, 'GET', '/v2/core/accounts')
   }
 
-  it('skips v2_core_accounts when Accounts v2 is not enabled for a platform', () => {
-    const err = makeError(
-      'Accounts v2 is not enabled for your platform. If you\'re interested in using this API with your integration, please visit https://dashboard.stripe.com/acct_1DfwS2ClCIKljWvs/settings/connect/platform-setup. [GET /v2/core/accounts (400)] {request-id=req_v2HaQWYCiDgV6xQZ7, stripe-should-retry=false}'
-    )
-    expect(isSkippableError(err)).toBe(true)
-  })
-
-  it('skips v2_core_accounts when Accounts v2 is not enabled for a livemode merchant', () => {
-    const err = makeError(
-      'Accounts v2 is not enabled for your livemode merchant acct_1NIFdXLd02PKGbD5. Please visit https://docs.stripe.com/connect/use-accounts-as-customers to enable Accounts v2. [GET /v2/core/accounts (400)] {request-id=req_v2yowYQ7yMNDkuvFi, stripe-should-retry=false}'
-    )
-    expect(isSkippableError(err)).toBe(true)
+  describe.each([
+    [
+      'platform',
+      'Accounts v2 is not enabled for your platform. If you\'re interested in using this API with your integration, please visit https://dashboard.stripe.com/acct_1DfwS2ClCIKljWvs/settings/connect/platform-setup. [GET /v2/core/accounts (400)] {request-id=req_v2HaQWYCiDgV6xQZ7, stripe-should-retry=false}',
+    ],
+    [
+      'livemode merchant',
+      'Accounts v2 is not enabled for your livemode merchant acct_1NIFdXLd02PKGbD5. Please visit https://docs.stripe.com/connect/use-accounts-as-customers to enable Accounts v2. [GET /v2/core/accounts (400)] {request-id=req_v2yowYQ7yMNDkuvFi, stripe-should-retry=false}',
+    ],
+  ])('v2_core_accounts (%s)', (_label, message) => {
+    it('is skipped', () => {
+      expect(isSkippableError(makeError(message))).toBe(true)
+    })
   })
 
   it('does not skip unrecognized errors', () => {
-    const err = makeError('Something went wrong')
-    expect(isSkippableError(err)).toBe(false)
+    expect(isSkippableError(makeError('Something went wrong'))).toBe(false)
   })
 
   it('does not skip non-StripeApiRequestError errors', () => {

--- a/packages/source-stripe/src/src-list-api.test.ts
+++ b/packages/source-stripe/src/src-list-api.test.ts
@@ -122,25 +122,22 @@ describe('isSkippableError', () => {
 
   describe.each([
     [
-      'platform',
+      'v2_core_accounts (platform)',
       'Accounts v2 is not enabled for your platform. If you\'re interested in using this API with your integration, please visit https://dashboard.stripe.com/acct_1DfwS2ClCIKljWvs/settings/connect/platform-setup. [GET /v2/core/accounts (400)] {request-id=req_v2HaQWYCiDgV6xQZ7, stripe-should-retry=false}',
+      true,
     ],
     [
-      'livemode merchant',
+      'v2_core_accounts (livemode merchant)',
       'Accounts v2 is not enabled for your livemode merchant acct_1NIFdXLd02PKGbD5. Please visit https://docs.stripe.com/connect/use-accounts-as-customers to enable Accounts v2. [GET /v2/core/accounts (400)] {request-id=req_v2yowYQ7yMNDkuvFi, stripe-should-retry=false}',
+      true,
     ],
-  ])('v2_core_accounts (%s)', (_label, message) => {
-    it('is skipped', () => {
-      expect(isSkippableError(makeError(message))).toBe(true)
+    ['unrecognized error', 'Something went wrong', false],
+    ['non-StripeApiRequestError', null, false],
+  ])('%s', (_label, message, expected) => {
+    it(`isSkippableError → ${expected}`, () => {
+      const err = message === null ? new Error('Accounts v2 is not enabled') : makeError(message)
+      expect(isSkippableError(err)).toBe(expected)
     })
-  })
-
-  it('does not skip unrecognized errors', () => {
-    expect(isSkippableError(makeError('Something went wrong'))).toBe(false)
-  })
-
-  it('does not skip non-StripeApiRequestError errors', () => {
-    expect(isSkippableError(new Error('Accounts v2 is not enabled'))).toBe(false)
   })
 })
 

--- a/packages/source-stripe/src/src-list-api.test.ts
+++ b/packages/source-stripe/src/src-list-api.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { RemainingRange } from './index.js'
-import { reconcileRanges, withRateLimit } from './src-list-api.js'
+import { isSkippableError, reconcileRanges, withRateLimit } from './src-list-api.js'
+import { StripeApiRequestError } from '@stripe/sync-openapi'
 import type { ListFn } from '@stripe/sync-openapi'
 
 describe('reconcileRanges', () => {
@@ -111,6 +112,35 @@ describe('reconcileRanges', () => {
       { gte: '2018', lt: '2024' }
     )
     expect(result).toEqual([])
+  })
+})
+
+describe('isSkippableError', () => {
+  function makeError(message: string) {
+    return new StripeApiRequestError(400, { error: { message } }, 'GET', '/v2/core/accounts')
+  }
+
+  it('skips v2_core_accounts when Accounts v2 is not enabled for a platform', () => {
+    const err = makeError(
+      'Accounts v2 is not enabled for your platform. If you\'re interested in using this API with your integration, please visit https://dashboard.stripe.com/acct_1DfwS2ClCIKljWvs/settings/connect/platform-setup. [GET /v2/core/accounts (400)] {request-id=req_v2HaQWYCiDgV6xQZ7, stripe-should-retry=false}'
+    )
+    expect(isSkippableError(err)).toBe(true)
+  })
+
+  it('skips v2_core_accounts when Accounts v2 is not enabled for a livemode merchant', () => {
+    const err = makeError(
+      'Accounts v2 is not enabled for your livemode merchant acct_1NIFdXLd02PKGbD5. Please visit https://docs.stripe.com/connect/use-accounts-as-customers to enable Accounts v2. [GET /v2/core/accounts (400)] {request-id=req_v2yowYQ7yMNDkuvFi, stripe-should-retry=false}'
+    )
+    expect(isSkippableError(err)).toBe(true)
+  })
+
+  it('does not skip unrecognized errors', () => {
+    const err = makeError('Something went wrong')
+    expect(isSkippableError(err)).toBe(false)
+  })
+
+  it('does not skip non-StripeApiRequestError errors', () => {
+    expect(isSkippableError(new Error('Accounts v2 is not enabled'))).toBe(false)
   })
 })
 

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -129,12 +129,14 @@ const SKIPPABLE_ERROR_MESSAGES = [
   'Unrecognized request URL (GET: /v1/treasury/financial_accounts)',
 
   // v2_core_accounts
-  // Variant 1:
   // "Accounts v2 is not enabled for your platform. If you're interested in using this API with
   //  your integration, please visit
   //  https://dashboard.stripe.com/acct_1DfwS2ClCIKljWvs/settings/connect/platform-setup.
   //  [GET /v2/core/accounts (400)] {request-id=req_v2HaQWYCiDgV6xQZ7, stripe-should-retry=false}"
-  'Accounts v2 is not enabled for your platform',
+  // "Accounts v2 is not enabled for your livemode merchant acct_1NIFdXLd02PKGbD5. Please visit
+  //  https://docs.stripe.com/connect/use-accounts-as-customers to enable Accounts v2.
+  //  [GET /v2/core/accounts (400)] {request-id=req_v2yowYQ7yMNDkuvFi, stripe-should-retry=false}"
+  'Accounts v2 is not enabled',
   // Variant 2 (test mode / sandbox):
   // "Accounts v2 isn't available in test mode. Switch to a sandbox to test.
   //  [GET /v2/core/accounts (400)] {request-id=..., stripe-should-retry=false}"

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -159,7 +159,7 @@ const SKIPPABLE_ERROR_MESSAGES = [
   'Your account is not set up to use Identity',
 ]
 
-function isSkippableError(err: unknown): boolean {
+export function isSkippableError(err: unknown): boolean {
   if (!(err instanceof StripeApiRequestError)) return false
   const body = err.body as { error?: { message?: string } } | undefined
   const message = (body?.error?.message ?? '').toLowerCase()


### PR DESCRIPTION
Broadens the skippable error match from "Accounts v2 is not enabled for your platform" to "Accounts v2 is not enabled" to also cover the livemode merchant variant.


Committed-By-Agent: claude

## Summary

<!-- What changed in plain language -->

-

## How to test (optional)

<!-- Add steps only if useful -->

-

## Related

<!-- Link issue(s) if any -->

- Closes #

> Thanks for contributing ❤️
