### PR TITLE
Set api_version when creating webhooks in stripe accounts

### DIFF
--- a/packages/source-stripe/src/client.ts
+++ b/packages/source-stripe/src/client.ts
@@ -136,8 +136,9 @@ export function makeClient(
 
     async createWebhookEndpoint(params: {
       url: string
-      enabled_events: string[]
-      metadata?: Record<string, string>
+      enabled_events: string[],
+      api_version: string,
+      metadata?: Record<string, string>,
     }): Promise<StripeWebhookEndpoint> {
       const json = await requestWithRetry('POST', '/v1/webhook_endpoints', params)
       return StripeWebhookEndpointSchema.parse(json)

--- a/packages/source-stripe/src/index.ts
+++ b/packages/source-stripe/src/index.ts
@@ -237,6 +237,7 @@ export function createStripeSource(
             url: config.webhook_url,
             enabled_events: ['*'],
             metadata: { managed_by: 'stripe-sync' },
+            api_version: config.api_version ?? BUNDLED_API_VERSION
           })
           // Secret is only available at creation time — not on list/retrieve
           if (!config.webhook_secret && created.secret) {


### PR DESCRIPTION
## Summary
We are creating webhooks in the users stripe account w/o setting the API version of the webhook itself: https://docs.stripe.com/api/webhook_endpoints/create?lang=curl#create_webhook_endpoint-api_version

This means we can have webhooks sending payloads to sync-engine in an API version that doesn't match the synced data.

<!-- What changed in plain language -->

-

## How to test (optional)

<!-- Add steps only if useful -->

-

## Related

<!-- Link issue(s) if any -->

- Closes #

> Thanks for contributing ❤️
