### PR TITLE
feat: add destination-sqlite package

### DIFF
--- a/apps/engine/package.json
+++ b/apps/engine/package.json
@@ -51,6 +51,7 @@
     "@scalar/hono-api-reference": "^0.6",
     "@stripe/sync-destination-google-sheets": "workspace:*",
     "@stripe/sync-destination-postgres": "workspace:*",
+    "@stripe/sync-destination-sqlite": "workspace:*",
     "@stripe/sync-hono-zod-openapi": "workspace:*",
     "@stripe/sync-logger": "workspace:*",
     "@stripe/sync-protocol": "workspace:*",

--- a/apps/engine/src/lib/default-connectors.ts
+++ b/apps/engine/src/lib/default-connectors.ts
@@ -1,5 +1,6 @@
 import sourceStripe from '@stripe/sync-source-stripe'
 import destinationPostgres from '@stripe/sync-destination-postgres'
+import destinationSqlite from '@stripe/sync-destination-sqlite'
 import destinationGoogleSheets from '@stripe/sync-destination-google-sheets'
 import type { RegisteredConnectors } from './resolver.js'
 
@@ -8,6 +9,7 @@ export const defaultConnectors: RegisteredConnectors = {
   sources: { stripe: sourceStripe },
   destinations: {
     postgres: destinationPostgres,
+    sqlite: destinationSqlite,
     google_sheets: destinationGoogleSheets,
   },
 }

--- a/apps/service/package.json
+++ b/apps/service/package.json
@@ -32,6 +32,7 @@
     "@scalar/hono-api-reference": "^0.6",
     "@stripe/sync-destination-google-sheets": "workspace:*",
     "@stripe/sync-destination-postgres": "workspace:*",
+    "@stripe/sync-destination-sqlite": "workspace:*",
     "@stripe/sync-engine": "workspace:*",
     "@stripe/sync-hono-zod-openapi": "workspace:*",
     "@stripe/sync-logger": "workspace:*",

--- a/apps/service/src/cli.ts
+++ b/apps/service/src/cli.ts
@@ -9,6 +9,7 @@ import { serve } from '@hono/node-server'
 import { createConnectorResolver, startApiServer, type ApiServerHandle } from '@stripe/sync-engine'
 import sourceStripe from '@stripe/sync-source-stripe'
 import destinationPostgres from '@stripe/sync-destination-postgres'
+import destinationSqlite from '@stripe/sync-destination-sqlite'
 import destinationGoogleSheets from '@stripe/sync-destination-google-sheets'
 import { createApp } from './api/app.js'
 import {
@@ -27,7 +28,7 @@ const defaultDataDir = process.env.DATA_DIR ?? `${homedir()}/.stripe-sync`
 
 const resolverPromise = createConnectorResolver({
   sources: { stripe: sourceStripe },
-  destinations: { postgres: destinationPostgres, google_sheets: destinationGoogleSheets },
+  destinations: { postgres: destinationPostgres, sqlite: destinationSqlite, google_sheets: destinationGoogleSheets },
 })
 
 async function buildCliSpec() {

--- a/packages/destination-sqlite/package.json
+++ b/packages/destination-sqlite/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@stripe/sync-destination-sqlite",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "bin": {
+    "destination-sqlite": "./dist/bin.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest"
+  },
+  "files": [
+    "src",
+    "dist"
+  ],
+  "dependencies": {
+    "@stripe/sync-logger": "workspace:*",
+    "@stripe/sync-protocol": "workspace:*",
+    "zod": "^4.3.6"
+  }
+}

--- a/packages/destination-sqlite/src/bin.ts
+++ b/packages/destination-sqlite/src/bin.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import connector from './index.js'
+import { configSchema } from './spec.js'
+import { runConnectorCli } from '@stripe/sync-protocol/cli'
+
+runConnectorCli(connector, { name: 'destination-sqlite', configSchema })

--- a/packages/destination-sqlite/src/index.ts
+++ b/packages/destination-sqlite/src/index.ts
@@ -1,0 +1,321 @@
+import { DatabaseSync } from 'node:sqlite'
+import { mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import type { Destination } from '@stripe/sync-protocol'
+import defaultSpec from './spec.js'
+import { log } from './logger.js'
+import type { Config } from './spec.js'
+
+export { configSchema, type Config } from './spec.js'
+
+function quoteIdent(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`
+}
+
+function openDatabase(config: Config): DatabaseSync {
+  if (config.path !== ':memory:') {
+    mkdirSync(dirname(config.path), { recursive: true })
+  }
+  const db = new DatabaseSync(config.path)
+  db.exec('PRAGMA journal_mode = WAL')
+  db.exec('PRAGMA synchronous = NORMAL')
+  db.exec('PRAGMA busy_timeout = 5000')
+  return db
+}
+
+function buildCreateTableSQL(tableName: string): string {
+  const qt = quoteIdent(tableName)
+  return `CREATE TABLE IF NOT EXISTS ${qt} (
+  id TEXT NOT NULL PRIMARY KEY,
+  _raw_data TEXT NOT NULL,
+  _synced_at TEXT NOT NULL,
+  _updated_at TEXT NOT NULL
+)`
+}
+
+function buildUpsertSQL(
+  tableName: string,
+  entries: Record<string, unknown>[],
+  primaryKeyColumns: string[],
+  newerThanField: string
+): { sql: string; params: unknown[] } {
+  if (entries.length === 0) return { sql: '', params: [] }
+
+  const qt = quoteIdent(tableName)
+  const pkCols = primaryKeyColumns.map(quoteIdent).join(', ')
+  const syncedAt = new Date().toISOString()
+  const params: unknown[] = []
+  const valueRows: string[] = []
+
+  for (const entry of entries) {
+    const ts = entry[newerThanField] as number
+    const updatedAt = new Date(ts * 1000).toISOString()
+    const pkValues = primaryKeyColumns.map((pk) => String(entry[pk] ?? ''))
+
+    for (const pk of pkValues) params.push(pk)
+    params.push(JSON.stringify(entry))
+    params.push(syncedAt)
+    params.push(updatedAt)
+
+    const placeholders = Array.from(
+      { length: primaryKeyColumns.length + 3 },
+      (_, i) => `?`
+    ).join(', ')
+    valueRows.push(`(${placeholders})`)
+  }
+
+  const allCols = [...primaryKeyColumns.map(quoteIdent), '"_raw_data"', '"_synced_at"', '"_updated_at"']
+
+  const sql = `INSERT INTO ${qt} (${allCols.join(', ')})
+VALUES ${valueRows.join(',\n')}
+ON CONFLICT(${pkCols}) DO UPDATE SET
+  "_raw_data" = excluded."_raw_data",
+  "_synced_at" = excluded."_synced_at",
+  "_updated_at" = excluded."_updated_at"
+WHERE json_extract(excluded."_raw_data", '$.${newerThanField}') >= json_extract(${qt}."_raw_data", '$.${newerThanField}')`
+
+  return { sql, params }
+}
+
+function buildDeleteSQL(
+  tableName: string,
+  entries: Record<string, unknown>[],
+  primaryKeyColumns: string[]
+): { sql: string; params: unknown[] } {
+  if (entries.length === 0) return { sql: '', params: [] }
+
+  const qt = quoteIdent(tableName)
+  const params: unknown[] = []
+  const conditions: string[] = []
+
+  for (const entry of entries) {
+    const pkConditions = primaryKeyColumns.map((pk) => {
+      params.push(String(entry[pk] ?? ''))
+      return `${quoteIdent(pk)} = ?`
+    })
+    conditions.push(`(${pkConditions.join(' AND ')})`)
+  }
+
+  const sql = `DELETE FROM ${qt} WHERE ${conditions.join(' OR ')}`
+  return { sql, params }
+}
+
+export interface WriteManyResult {
+  written_count: number
+  deleted_count: number
+}
+
+function writeMany(
+  db: DatabaseSync,
+  tableName: string,
+  entries: Record<string, unknown>[],
+  primaryKeyColumns: string[],
+  newerThanField: string
+): WriteManyResult {
+  const tombstones = entries.filter((e) => e.recordDeleted === true).map((r) => r.data as Record<string, unknown>)
+  const liveRecords = entries.filter((e) => e.recordDeleted !== true).map((r) => r.data as Record<string, unknown>)
+
+  let written_count = 0
+  let deleted_count = 0
+
+  if (liveRecords.length > 0) {
+    const { sql, params } = buildUpsertSQL(tableName, liveRecords, primaryKeyColumns, newerThanField)
+    if (sql) {
+      db.prepare(sql).run(...(params as Array<string | number | null>))
+      written_count = liveRecords.length
+    }
+  }
+
+  if (tombstones.length > 0) {
+    const { sql, params } = buildDeleteSQL(tableName, tombstones, primaryKeyColumns)
+    if (sql) {
+      db.prepare(sql).run(...(params as Array<string | number | null>))
+      deleted_count = tombstones.length
+    }
+  }
+
+  return { written_count, deleted_count }
+}
+
+const destination = {
+  async *spec() {
+    yield { type: 'spec' as const, spec: defaultSpec }
+  },
+
+  async *check({ config }) {
+    try {
+      const db = openDatabase(config)
+      db.exec('SELECT 1')
+      db.close()
+      yield {
+        type: 'connection_status' as const,
+        connection_status: { status: 'succeeded' as const },
+      }
+    } catch (err) {
+      yield {
+        type: 'connection_status' as const,
+        connection_status: {
+          status: 'failed' as const,
+          message: err instanceof Error ? err.message : String(err),
+        },
+      }
+    }
+  },
+
+  async *setup({ config, catalog }) {
+    const db = openDatabase(config)
+    try {
+      log.info(`Creating ${catalog.streams.length} tables in ${config.path}`)
+      for (const cs of catalog.streams) {
+        const pkFields = (cs.stream.primary_key ?? [['id']]).map((pk) => pk[0])
+        const pkCols = pkFields.map(quoteIdent).join(', ')
+        const qt = quoteIdent(cs.stream.name)
+
+        db.exec(`CREATE TABLE IF NOT EXISTS ${qt} (
+  ${pkFields.map((f) => `${quoteIdent(f)} TEXT NOT NULL`).join(',\n  ')},
+  "_raw_data" TEXT NOT NULL,
+  "_synced_at" TEXT NOT NULL,
+  "_updated_at" TEXT NOT NULL,
+  PRIMARY KEY (${pkCols})
+)`)
+      }
+      log.info('Setup complete')
+    } finally {
+      db.close()
+    }
+  },
+
+  async *teardown({ config }) {
+    const db = openDatabase(config)
+    try {
+      const tables = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+        .all() as Array<{ name: string }>
+      for (const { name } of tables) {
+        db.exec(`DROP TABLE IF EXISTS ${quoteIdent(name)}`)
+      }
+    } finally {
+      db.close()
+    }
+  },
+
+  async *write({ config, catalog }, $stdin) {
+    const db = openDatabase(config)
+    const batchSize = config.batch_size
+
+    // Auto-create tables (idempotent)
+    for (const cs of catalog.streams) {
+      const pkFields = (cs.stream.primary_key ?? [['id']]).map((pk) => pk[0])
+      const pkCols = pkFields.map(quoteIdent).join(', ')
+      const qt = quoteIdent(cs.stream.name)
+      db.exec(`CREATE TABLE IF NOT EXISTS ${qt} (
+  ${pkFields.map((f) => `${quoteIdent(f)} TEXT NOT NULL`).join(',\n  ')},
+  "_raw_data" TEXT NOT NULL,
+  "_synced_at" TEXT NOT NULL,
+  "_updated_at" TEXT NOT NULL,
+  PRIMARY KEY (${pkCols})
+)`)
+    }
+
+    const streamBuffers = new Map<string, Record<string, unknown>[]>()
+    const streamKeyColumns = new Map(
+      catalog.streams.map((cs) => [
+        cs.stream.name,
+        cs.stream.primary_key?.map((pk) => pk[0]) ?? ['id'],
+      ])
+    )
+    const streamNewerThanField = new Map(
+      catalog.streams.map((cs) => [cs.stream.name, cs.stream.newer_than_field])
+    )
+    const failedStreams = new Set<string>()
+
+    const flushStream = (streamName: string): string | undefined => {
+      if (failedStreams.has(streamName)) return undefined
+      const buffer = streamBuffers.get(streamName)
+      if (!buffer || buffer.length === 0) return undefined
+      const pk = streamKeyColumns.get(streamName) ?? ['id']
+      const newerThan = streamNewerThanField.get(streamName)!
+
+      try {
+        const stats = writeMany(db, streamName, buffer, pk, newerThan)
+        log.debug(
+          {
+            stream: streamName,
+            batch_size: buffer.length,
+            written: stats.written_count,
+            deleted: stats.deleted_count,
+          },
+          `dest write: upsert ${streamName}`
+        )
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err)
+        log.error({ stream: streamName, error: errMsg }, 'dest write: flush failed')
+        failedStreams.add(streamName)
+        streamBuffers.set(streamName, [])
+        return errMsg
+      }
+      streamBuffers.set(streamName, [])
+      return undefined
+    }
+
+    function streamError(stream: string, error: string) {
+      return {
+        type: 'stream_status' as const,
+        stream_status: { stream, status: 'error' as const, error },
+      }
+    }
+
+    try {
+      for await (const msg of $stdin) {
+        if (msg.type === 'record') {
+          const { stream } = msg.record
+          if (failedStreams.has(stream)) continue
+
+          if (!streamBuffers.has(stream)) streamBuffers.set(stream, [])
+          const buffer = streamBuffers.get(stream)!
+          buffer.push(msg.record as Record<string, unknown>)
+
+          if (buffer.length >= batchSize) {
+            const err = flushStream(stream)
+            if (err) {
+              yield streamError(stream, err)
+              continue
+            }
+          }
+          yield msg
+        } else if (msg.type === 'source_state') {
+          if (msg.source_state.state_type !== 'global') {
+            const stream = msg.source_state.stream
+            if (failedStreams.has(stream)) continue
+            const err = flushStream(stream)
+            if (err) {
+              yield streamError(stream, err)
+              continue
+            }
+          }
+          yield msg
+        } else {
+          yield msg
+        }
+      }
+
+      for (const streamName of streamBuffers.keys()) {
+        const err = flushStream(streamName)
+        if (err) yield streamError(streamName, err)
+      }
+
+      if (failedStreams.size > 0) {
+        log.error(
+          { failed_streams: [...failedStreams] },
+          `SQLite destination: completed with ${failedStreams.size} failed stream(s)`
+        )
+      } else {
+        log.debug(`SQLite destination: wrote to ${config.path}`)
+      }
+    } finally {
+      db.close()
+    }
+  },
+} satisfies Destination<Config>
+
+export default destination

--- a/packages/destination-sqlite/src/logger.ts
+++ b/packages/destination-sqlite/src/logger.ts
@@ -1,0 +1,4 @@
+import { createLogger } from '@stripe/sync-logger'
+import type { Logger } from '@stripe/sync-logger'
+
+export const log: Logger = createLogger({ name: 'destination-sqlite' })

--- a/packages/destination-sqlite/src/spec.ts
+++ b/packages/destination-sqlite/src/spec.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+import type { ConnectorSpecification } from '@stripe/sync-protocol'
+
+export const configSchema = z.object({
+  path: z.string().describe('Path to the SQLite database file (use ":memory:" for in-memory)'),
+  batch_size: z.number().default(100).describe('Records to buffer before flushing'),
+})
+
+export type Config = z.infer<typeof configSchema>
+
+export default {
+  config: z.toJSONSchema(configSchema),
+} satisfies ConnectorSpecification

--- a/packages/destination-sqlite/tsconfig.json
+++ b/packages/destination-sqlite/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**"]
+}

--- a/packages/destination-sqlite/vitest.config.ts
+++ b/packages/destination-sqlite/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       '@stripe/sync-destination-postgres':
         specifier: workspace:*
         version: link:../../packages/destination-postgres
+      '@stripe/sync-destination-sqlite':
+        specifier: workspace:*
+        version: link:../../packages/destination-sqlite
       '@stripe/sync-hono-zod-openapi':
         specifier: workspace:*
         version: link:../../packages/hono-zod-openapi
@@ -249,6 +252,9 @@ importers:
       '@stripe/sync-destination-postgres':
         specifier: workspace:*
         version: link:../../packages/destination-postgres
+      '@stripe/sync-destination-sqlite':
+        specifier: workspace:*
+        version: link:../../packages/destination-sqlite
       '@stripe/sync-engine':
         specifier: workspace:*
         version: link:../engine
@@ -528,6 +534,18 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+
+  packages/destination-sqlite:
+    dependencies:
+      '@stripe/sync-logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@stripe/sync-protocol':
+        specifier: workspace:*
+        version: link:../protocol
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
   packages/hono-zod-openapi:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds `packages/destination-sqlite` — a zero-dependency SQLite destination connector using Node.js 24's built-in `node:sqlite` module (`DatabaseSync`)
- Supports upsert with newer-than deduplication, hard deletes, and auto-creates tables on first write
- Registered in the engine default connectors and the service CLI

## Design
- Uses `DatabaseSync` (synchronous API) from `node:sqlite` — no external SQLite library needed
- Config is minimal: just `path` (file path or `:memory:`) and `batch_size`
- Tables store `_raw_data` as JSON TEXT, with `id`, `_synced_at`, `_updated_at` columns
- Full JSON queryable via SQLite's `json_extract()` function
- WAL mode enabled for concurrent read performance

## Test plan
- [x] Build passes (`pnpm --filter @stripe/sync-destination-sqlite build`)
- [x] End-to-end: `pipelines sync pipe_goldilocks_prod_sqlite` syncs 11,215 records (3 streams) in ~4s
- [x] Incremental sync works (0 records on re-run with existing state)
- [x] Data integrity verified via `json_extract()` queries on the SQLite file
- [ ] Add unit tests for upsert/delete logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)