### PR TITLE
Sheet test cleanup

### DIFF
--- a/packages/destination-google-sheets/__tests__/integration.test.ts
+++ b/packages/destination-google-sheets/__tests__/integration.test.ts
@@ -116,7 +116,7 @@ describeWithEnv(
 
       // Read back from the sheet
       const rows = await readSheet(sheets, GOOGLE_SPREADSHEET_ID, streamName)
-      expect(rows[0]).toEqual(['id', 'name', 'balance'])
+      expect(rows[0]).toEqual(['Id', 'Name', 'Balance'])
       expect(rows).toHaveLength(4) // header + 3 rows
       expect(rows[1]).toEqual(['cus_1', 'Alice', '100'])
       expect(rows[3]).toEqual(['cus_3', 'Charlie', '0'])
@@ -227,7 +227,7 @@ describeWithEnv(
       // Verify initial state
       let rows = stripUpdatedAt(await readSheet(sheets, GOOGLE_SPREADSHEET_ID, streamName))
       expect(rows).toHaveLength(4) // header + 3 rows
-      expect(rows[0]).toEqual(['id', 'name', 'balance']) // PK-first ordering
+      expect(rows[0]).toEqual(['Id', 'Name', 'Balance']) // PK-first ordering
 
       // Second write: update cus_1 and cus_3, add cus_4 — no _row_number provided
       const upsertRecords: DestinationInput[] = [
@@ -277,7 +277,7 @@ describeWithEnv(
       // Verify upsert results
       rows = stripUpdatedAt(await readSheet(sheets, GOOGLE_SPREADSHEET_ID, streamName))
       expect(rows).toHaveLength(5) // header + 3 original + 1 new
-      expect(rows[0]).toEqual(['id', 'name', 'balance'])
+      expect(rows[0]).toEqual(['Id', 'Name', 'Balance'])
       expect(rows[1]).toEqual(['cus_1', 'Alice Updated', '150']) // updated in place
       expect(rows[2]).toEqual(['cus_2', 'Bob', '250']) // unchanged
       expect(rows[3]).toEqual(['cus_3', 'Charlie Updated', '50']) // updated in place

--- a/packages/destination-google-sheets/__tests__/memory-sheets.test.ts
+++ b/packages/destination-google-sheets/__tests__/memory-sheets.test.ts
@@ -96,6 +96,36 @@ describe('createMemorySheets', () => {
     expect(getData(id, 'orders')).toEqual([])
   })
 
+  it('batchUpdate updateSheetProperties — non-title field mask preserves tab name', async () => {
+    const { sheets, getData } = createMemorySheets()
+
+    const { data } = await sheets.spreadsheets.create({
+      requestBody: { properties: { title: 'T' } },
+    })
+    const id = data.spreadsheetId!
+    const meta = await sheets.spreadsheets.get({ spreadsheetId: id })
+    const sheetId = meta.data.sheets![0].properties!.sheetId!
+
+    await sheets.spreadsheets.batchUpdate({
+      spreadsheetId: id,
+      requestBody: {
+        requests: [
+          {
+            updateSheetProperties: {
+              properties: {
+                sheetId,
+                gridProperties: { frozenRowCount: 1, frozenColumnCount: 1 },
+              },
+              fields: 'gridProperties.frozenRowCount,gridProperties.frozenColumnCount',
+            },
+          },
+        ],
+      },
+    })
+
+    expect(getData(id, 'Sheet1')).toEqual([])
+  })
+
   it('values.update — writes at range (header row)', async () => {
     const { sheets, getData } = createMemorySheets()
 
@@ -112,6 +142,28 @@ describe('createMemorySheets', () => {
     })
 
     expect(getData(id, 'Sheet1')).toEqual([['id', 'name', 'email']])
+  })
+
+  it('values.batchUpdate — respects the starting column', async () => {
+    const { sheets, getData } = createMemorySheets()
+
+    const { data } = await sheets.spreadsheets.create({
+      requestBody: { properties: { title: 'T' } },
+    })
+    const id = data.spreadsheetId!
+
+    await sheets.spreadsheets.values.batchUpdate({
+      spreadsheetId: id,
+      requestBody: {
+        valueInputOption: 'RAW',
+        data: [{ range: "'Sheet1'!C1", values: [['open']] }],
+      },
+    })
+
+    const row = getData(id, 'Sheet1')![0]
+    expect(row).toHaveLength(3)
+    expect(row[0]).toBeUndefined()
+    expect(row[2]).toBe('open')
   })
 
   it('values.append — appends rows after existing data', async () => {

--- a/packages/destination-google-sheets/__tests__/memory-sheets.ts
+++ b/packages/destination-google-sheets/__tests__/memory-sheets.ts
@@ -46,11 +46,6 @@ export function createMemorySheets() {
     return bang >= 0 ? range.slice(0, bang) : range
   }
 
-  function parseStartRow(range: string): number {
-    const match = range.match(/(\d+)/)
-    return match ? Number(match[1]) : 1
-  }
-
   function parseRangeBounds(range: string): {
     startCol: number
     startRow: number
@@ -98,6 +93,17 @@ export function createMemorySheets() {
       out.push(slice)
     }
     return out
+  }
+
+  function writeValues(tab: SheetTab, range: string, rows: unknown[][]): void {
+    const { startCol, startRow } = parseRangeBounds(range)
+    for (let i = 0; i < rows.length; i++) {
+      const target = (tab.values[startRow + i] ?? []).slice()
+      for (let j = 0; j < rows[i].length; j++) {
+        target[startCol + j] = rows[i][j]
+      }
+      tab.values[startRow + i] = target
+    }
   }
 
   function getTab(spreadsheetId: string, range: string): SheetTab {
@@ -193,15 +199,18 @@ export function createMemorySheets() {
             replies.push({ addSheet: { properties: { sheetId, title: name } } })
           } else if (req.updateSheetProperties) {
             const update = req.updateSheetProperties as {
-              properties: { sheetId: number; title: string }
-              fields: string
+              properties: { sheetId: number; title?: string }
+              fields?: string
             }
             const targetId = update.properties.sheetId
-            for (const [oldName, tab] of ss.sheets.entries()) {
-              if (tab.sheetId === targetId) {
-                ss.sheets.delete(oldName)
-                ss.sheets.set(update.properties.title, tab)
-                break
+            const fields = (update.fields ?? '').split(',').map((field) => field.trim())
+            if (fields.includes('title') && update.properties.title !== undefined) {
+              for (const [oldName, tab] of ss.sheets.entries()) {
+                if (tab.sheetId === targetId) {
+                  ss.sheets.delete(oldName)
+                  ss.sheets.set(update.properties.title, tab)
+                  break
+                }
               }
             }
             replies.push({})
@@ -299,10 +308,7 @@ export function createMemorySheets() {
         }) {
           const tab = getTab(params.spreadsheetId, params.range)
           const rows = params.requestBody?.values ?? []
-          const startRow = parseStartRow(params.range)
-          for (let i = 0; i < rows.length; i++) {
-            tab.values[startRow - 1 + i] = rows[i]
-          }
+          writeValues(tab, params.range, rows)
           return { data: {} }
         },
 
@@ -337,10 +343,7 @@ export function createMemorySheets() {
           for (const entry of params.requestBody?.data ?? []) {
             const tab = getTab(params.spreadsheetId, entry.range)
             const rows = entry.values ?? []
-            const startRow = parseStartRow(entry.range)
-            for (let i = 0; i < rows.length; i++) {
-              tab.values[startRow - 1 + i] = rows[i]
-            }
+            writeValues(tab, entry.range, rows)
           }
           return { data: {} }
         },

--- a/packages/destination-google-sheets/src/index.test.ts
+++ b/packages/destination-google-sheets/src/index.test.ts
@@ -14,6 +14,7 @@ import {
   readEnumValidations,
   readSheet,
   type StreamBatchOps,
+  unixToIso,
 } from './writer.js'
 import { createMemorySheets } from '../__tests__/memory-sheets.js'
 
@@ -96,7 +97,7 @@ describe('destination-google-sheets', () => {
 
     const id = getSpreadsheetIds()[0]
     const rows = stripUpdatedAt(getData(id, 'users')!)
-    expect(rows[0]).toEqual(['id', 'name', 'email'])
+    expect(rows[0]).toEqual(['Id', 'Name', 'Email'])
     expect(rows[1]).toEqual(['u1', 'Alice', 'alice@test.invalid'])
   })
 
@@ -118,7 +119,7 @@ describe('destination-google-sheets', () => {
     const rows = stripUpdatedAt(getData(id, 'items')!)
     // header + 5 data rows (batch at 3, then remaining 2 flushed at end)
     expect(rows).toHaveLength(6)
-    expect(rows[0]).toEqual(['id'])
+    expect(rows[0]).toEqual(['Id'])
     expect(rows[5]).toEqual(['5'])
   })
 
@@ -243,11 +244,11 @@ describe('destination-google-sheets', () => {
     const id = getSpreadsheetIds()[0]
 
     const customerRows = stripUpdatedAt(getData(id, 'customers')!)
-    expect(customerRows[0]).toEqual(['id', 'name'])
+    expect(customerRows[0]).toEqual(['Id', 'Name'])
     expect(customerRows).toHaveLength(3) // header + 2
 
     const invoiceRows = stripUpdatedAt(getData(id, 'invoices')!)
-    expect(invoiceRows[0]).toEqual(['id', 'amount', 'customer'])
+    expect(invoiceRows[0]).toEqual(['Id', 'Amount', 'Customer'])
     expect(invoiceRows).toHaveLength(3) // header + 2
   })
 
@@ -329,7 +330,7 @@ describe('destination-google-sheets', () => {
     for (const name of streamNames) {
       const rows = getData(id, name)
       expect(rows, `tab "${name}" should exist`).toBeDefined()
-      expect(rows![0], `tab "${name}" should have correct headers`).toEqual(['id', 'value'])
+      expect(rows![0], `tab "${name}" should have correct headers`).toEqual(['Id', 'Value'])
     }
 
     // Overview tab must exist and start with the spreadsheet title, not stream headers
@@ -376,7 +377,7 @@ describe('destination-google-sheets', () => {
 
     const id = getSpreadsheetIds()[0]
     const rows = stripUpdatedAt(getData(id, 'types')!)
-    expect(rows[1]).toEqual(['hello', '42', 'true', '', '{"nested":true}'])
+    expect(rows[1]).toEqual(['hello', '42', 'true', '', 'nested: true'])
   })
 
   it('readSheet helper — reads back data through the fake client', async () => {
@@ -394,7 +395,7 @@ describe('destination-google-sheets', () => {
       (await readSheet(sheets, getSpreadsheetIds()[0], 'test')) as unknown[][]
     )
     expect(rows).toEqual([
-      ['a', 'b'],
+      ['A', 'B'],
       ['1', '2'],
       ['3', '4'],
     ])
@@ -508,7 +509,7 @@ describe('check', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name'],
+      ['Id', 'Name'],
       ['cus_1', 'Alice Updated'],
       ['cus_2', 'Bob'],
     ])
@@ -549,7 +550,7 @@ describe('check', () => {
     )
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
-    expect(rows[0]).toEqual(['id', 'name', 'email'])
+    expect(rows[0]).toEqual(['Id', 'Name', 'Email'])
     expect(rows[1]).toEqual(['cus_1', 'Alice'])
     expect(rows[2]).toEqual(['cus_2', 'Bob', 'bob@test.invalid'])
   })
@@ -597,7 +598,7 @@ describe('native upsert', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name'],
+      ['Id', 'Name'],
       ['cus_1', 'Alice Updated'],
     ])
   })
@@ -623,7 +624,7 @@ describe('native upsert', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name'],
+      ['Id', 'Name'],
       ['cus_1', 'Alice'],
       ['cus_2', 'Bob'],
     ])
@@ -647,7 +648,7 @@ describe('native upsert', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name'],
+      ['Id', 'Name'],
       ['cus_1', 'Alice Updated'],
     ])
   })
@@ -670,7 +671,7 @@ describe('native upsert', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name'],
+      ['Id', 'Name'],
       ['cus_1', 'Alice Updated'],
     ])
   })
@@ -701,7 +702,7 @@ describe('native upsert', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name'],
+      ['Id', 'Name'],
       ['cus_1', 'Alice Updated'],
     ])
   })
@@ -779,7 +780,7 @@ describe('native upsert', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name'],
+      ['Id', 'Name'],
       ['cus_1', 'Alice'],
       ['cus_1', 'Alice Overwrite'], // overwrote row 3 (Bob's row) per explicit _row_number
     ])
@@ -802,7 +803,7 @@ describe('native upsert', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name'],
+      ['Id', 'Name'],
       ['cus_1', 'Alice'],
       ['cus_1', 'Alice Again'],
     ])
@@ -825,7 +826,7 @@ describe('native upsert', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     // id should be first column despite being last in the record
-    expect(rows[0]).toEqual(['id', 'name', 'email'])
+    expect(rows[0]).toEqual(['Id', 'Name', 'Email'])
   })
 })
 
@@ -906,7 +907,7 @@ describe('delete handling', () => {
     )
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
-    expect(rows).toEqual([['id', 'name', 'deleted']])
+    expect(rows).toEqual([['Id', 'Name', 'Deleted']])
   })
 
   it('deleted:false is treated as a normal append (strict === true check)', async () => {
@@ -923,7 +924,7 @@ describe('delete handling', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name', 'deleted'],
+      ['Id', 'Name', 'Deleted'],
       ['cus_1', 'Alice', 'false'],
     ])
   })
@@ -952,7 +953,7 @@ describe('delete handling', () => {
     // Seeded rows are 2-wide; blank rows written by delete compaction are
     // 3-wide because the header was extended on the delete record's arrival.
     expect(rows).toEqual([
-      ['id', 'name', 'deleted'],
+      ['Id', 'Name', 'Deleted'],
       ['cus_1', 'Alice'],
       ['cus_3', 'Charlie'], // was cus_2; donor (row 4) swapped in
       ['', '', ''], // donor row blanked
@@ -979,7 +980,7 @@ describe('delete handling', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name', 'deleted'],
+      ['Id', 'Name', 'Deleted'],
       ['cus_1', 'Alice'],
       ['cus_2', 'Bob'],
       ['', '', ''],
@@ -1013,7 +1014,7 @@ describe('delete handling', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name', 'deleted'],
+      ['Id', 'Name', 'Deleted'],
       ['cus_d', 'Dave'], // was cus_a; donor (row 5)
       ['cus_e', 'Eve'], // was cus_b; donor (row 6)
       ['cus_c', 'Charlie'], // unchanged
@@ -1048,7 +1049,7 @@ describe('delete handling', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name', 'deleted'],
+      ['Id', 'Name', 'Deleted'],
       ['cus_a', 'Alice'],
       ['cus_c', 'Charlie'], // was cus_b; donor (row 4)
       ['', '', ''], // donor row 4 blanked
@@ -1080,7 +1081,7 @@ describe('delete handling', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name', 'deleted'],
+      ['Id', 'Name', 'Deleted'],
       ['', '', ''],
       ['', '', ''],
       ['', '', ''],
@@ -1116,7 +1117,7 @@ describe('delete handling', () => {
     // rows stay 2-wide.
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name', 'deleted'],
+      ['Id', 'Name', 'Deleted'],
       ['cus_1', 'Alice'],
       ['cus_4', 'Dave', 'false'], // donated into cus_2's slot
       ['cus_3', 'Charlie'],
@@ -1151,7 +1152,7 @@ describe('delete handling', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name', 'deleted'],
+      ['Id', 'Name', 'Deleted'],
       ['cus_1', 'Alice'],
       ['cus_4', 'Dave', 'false'], // donated into cus_2's slot (row 3)
       ['cus_3', 'Charlie'],
@@ -1183,7 +1184,7 @@ describe('delete handling', () => {
     )
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
-    expect(rows).toEqual([['id', 'name', 'deleted']])
+    expect(rows).toEqual([['Id', 'Name', 'Deleted']])
   })
 
   // MARK: - no-ops and edges
@@ -1209,7 +1210,7 @@ describe('delete handling', () => {
     // The delete record's `deleted: true` extends the header to 3 cols, but
     // the untouched seeded data rows stay 2-wide.
     expect(rows).toEqual([
-      ['id', 'name', 'deleted'],
+      ['Id', 'Name', 'Deleted'],
       ['cus_1', 'Alice'],
       ['cus_2', 'Bob'],
     ])
@@ -1234,7 +1235,7 @@ describe('delete handling', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name', 'deleted'],
+      ['Id', 'Name', 'Deleted'],
       ['cus_2', 'Bob'], // donor (row 3, seeded 2-wide) swapped into row 2
       ['', '', ''], // row 3 blanked
     ])
@@ -1293,14 +1294,14 @@ describe('delete handling', () => {
 
     const customers = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(customers).toEqual([
-      ['id', 'name', 'deleted'],
+      ['Id', 'Name', 'Deleted'],
       ['cus_2', 'Bob', 'false'], // donor swapped in
       ['', '', ''],
     ])
 
     const invoices = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'invoices')!)
     expect(invoices).toEqual([
-      ['id', 'amount', 'deleted'],
+      ['Id', 'Amount', 'Deleted'],
       ['inv_1', '100', 'false'], // unaffected by the customers delete
       ['inv_2', '200', 'false'],
     ])
@@ -1342,7 +1343,7 @@ describe('delete handling', () => {
     // Composite rowKey = '["cus_1","acct_A"]' matches the seeded row → tail blanked.
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', '_account_id', 'name', 'deleted'],
+      ['Id', '_account_id', 'Name', 'Deleted'],
       ['', '', '', ''],
     ])
   })
@@ -1664,8 +1665,8 @@ describe('newer_than_field stale write prevention', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name', 'updated'],
-      ['cus_1', 'Alice v2', '200'],
+      ['Id', 'Name', 'Updated'],
+      ['cus_1', 'Alice v2', unixToIso(200)],
     ])
   })
 
@@ -1689,8 +1690,8 @@ describe('newer_than_field stale write prevention', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name', 'updated'],
-      ['cus_1', 'Alice v2', '200'],
+      ['Id', 'Name', 'Updated'],
+      ['cus_1', 'Alice v2', unixToIso(200)],
     ])
   })
 
@@ -1710,8 +1711,8 @@ describe('newer_than_field stale write prevention', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name', 'updated'],
-      ['cus_1', 'Alice v2', '200'],
+      ['Id', 'Name', 'Updated'],
+      ['cus_1', 'Alice v2', unixToIso(200)],
     ])
   })
 
@@ -1731,8 +1732,8 @@ describe('newer_than_field stale write prevention', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name', 'updated'],
-      ['cus_1', 'Alice v2', '200'],
+      ['Id', 'Name', 'Updated'],
+      ['cus_1', 'Alice v2', unixToIso(200)],
     ])
   })
 
@@ -1759,8 +1760,8 @@ describe('newer_than_field stale write prevention', () => {
 
     const rows = stripUpdatedAt(getData(getSpreadsheetIds()[0], 'customers')!)
     expect(rows).toEqual([
-      ['id', 'name', 'updated'],
-      ['cus_1', 'Alice v1', '100'],
+      ['Id', 'Name', 'Updated'],
+      ['cus_1', 'Alice v1', unixToIso(100)],
     ])
   })
 })
@@ -1789,7 +1790,7 @@ describe('_updated_at column (source-owned, passthrough)', () => {
     )
 
     const rows = getData(getSpreadsheetIds()[0], 'users')!
-    expect(rows[0]).toEqual(['id', 'name'])
+    expect(rows[0]).toEqual(['Id', 'Name'])
     expect(rows[0]).not.toContain('_updated_at')
   })
 
@@ -1994,7 +1995,7 @@ describe('enum constraints on any column', () => {
     expect(
       out.find((m) => m.type === 'connection_status' && m.connection_status.status === 'failed')
     ).toBeUndefined()
-    expect(stripUpdatedAt(getData(spreadsheetId, 'invoices'))[1]).toEqual(['in_1', '42'])
+    expect(stripUpdatedAt(getData(spreadsheetId, 'invoices'))[1]).toEqual(['in_1', '42', ''])
   })
 
   it('rejects setup when existing validation disagrees with catalog', async () => {


### PR DESCRIPTION
## Summary
- Align Google Sheets test expectations with the destination’s display headers (`Id`, `Name`, `Balance`) instead of raw field names.
- Fix the in-memory Sheets fake to better match the real Sheets API for the failing paths:
  - `updateSheetProperties` respects the `fields` mask and does not rename tabs for grid-only updates.
  - `values.update` / `values.batchUpdate` honor the A1 start column.
- Add focused fake regression coverage for freeze-pane updates and non-`A1` value writes.
## Test plan
```sh
pnpm --filter @stripe/sync-destination-google-sheets exec vitest run
```