### PR TITLE
fix(source-stripe): accept string `request` field in stripeEventSchema

### DIFF
--- a/packages/source-stripe/src/spec.test.ts
+++ b/packages/source-stripe/src/spec.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { z } from 'zod'
-import spec, { configSchema, streamStateSpec } from './spec.js'
+import spec, { configSchema, stripeEventSchema, streamStateSpec } from './spec.js'
 import { BUNDLED_API_VERSION, SUPPORTED_API_VERSIONS } from '@stripe/sync-openapi'
 
 describe('configSchema api_version field', () => {
@@ -31,6 +31,34 @@ describe('configSchema api_version field', () => {
 
     expect(versions).toContain(BUNDLED_API_VERSION)
     expect(versions.length).toBeGreaterThan(0)
+  })
+})
+
+describe('stripeEventSchema', () => {
+  const baseEvent = {
+    id: 'evt_123',
+    object: 'event' as const,
+    api_version: '2024-06-20',
+    created: 1715500000,
+    type: 'invoice.created',
+    livemode: true,
+    pending_webhooks: 0,
+    data: { object: { id: 'in_123', object: 'invoice' } },
+  }
+
+  it('accepts request as a plain string (older API versions)', () => {
+    const event = { ...baseEvent, request: 'req_xxxxx' }
+    expect(stripeEventSchema.safeParse(event).success).toBe(true)
+  })
+
+  it('accepts request as an object (modern API versions)', () => {
+    const event = { ...baseEvent, request: { id: 'req_xxxxx', idempotency_key: null } }
+    expect(stripeEventSchema.safeParse(event).success).toBe(true)
+  })
+
+  it('accepts request as null', () => {
+    const event = { ...baseEvent, request: null }
+    expect(stripeEventSchema.safeParse(event).success).toBe(true)
   })
 })
 

--- a/packages/source-stripe/src/spec.ts
+++ b/packages/source-stripe/src/spec.ts
@@ -113,10 +113,13 @@ export const stripeEventSchema = z.object({
       "Number of webhooks that haven't been successfully delivered (for example, to return a 20x response) to the URLs you specify."
     ),
   request: z
-    .object({
-      id: z.string().nullable(),
-      idempotency_key: z.string().nullable(),
-    })
+    .union([
+      z.string(),
+      z.object({
+        id: z.string().nullable(),
+        idempotency_key: z.string().nullable(),
+      }),
+    ])
     .nullable()
     .describe('Information on the API request that triggers the event.'),
   type: z


### PR DESCRIPTION
Older Stripe API versions send `event.request` as a plain string (the request ID), not the `{ id, idempotency_key }` object used by modern versions. When sdb-webhook-srv forwards these raw events as source_input messages, Zod rejects the string at parse time, silently dropping the record from the sync pipeline.

Widen the schema to accept both formats via z.union.


Committed-By-Agent: claude

## Summary

<!-- What changed in plain language -->

-

## How to test (optional)

<!-- Add steps only if useful -->

-

## Related

<!-- Link issue(s) if any -->

- Closes #

> Thanks for contributing ❤️
