### PR TITLE
Removes concurrency support temporarily to see if backfills complete with 100% accuracy

### DIFF
--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -530,7 +530,8 @@ async function* iterateStream(opts: {
           supportsLimit,
           supportsForwardPagination,
         }),
-      concurrency: 100, // rate limiter is the real bottleneck
+      //concurrency: 100, // rate limiter is the real bottleneck
+      concurrency: 1, // serialized for reliability; parallelism re-enabled if data gaps are due to parallelism 
       subdivisionFactor,
     })
 


### PR DESCRIPTION
## Summary

<!-- What changed in plain language -->

There could be a race condition when backfilling using the data bisect that is causing chunks of rows to not be processed and dropped silently.

This PR reduces the concurrency to 1 for each collection so that we process in series instead of parallel to mitigate the possibility of a race condition between fetches.

## How to test (optional)

<!-- Add steps only if useful -->


## Related

<!-- Link issue(s) if any -->

- Closes #

> Thanks for contributing ❤️
