### PR TITLE
make climate error skippable

### DIFF
--- a/packages/source-stripe/src/src-list-api.test.ts
+++ b/packages/source-stripe/src/src-list-api.test.ts
@@ -131,6 +131,11 @@ describe('isSkippableError', () => {
       'Accounts v2 is not enabled for your livemode merchant acct_1NIFdXLd02PKGbD5. Please visit https://docs.stripe.com/connect/use-accounts-as-customers to enable Accounts v2. [GET /v2/core/accounts (400)] {request-id=req_v2yowYQ7yMNDkuvFi, stripe-should-retry=false}',
       true,
     ],
+    [
+      'climate_order',
+      'This account is not eligible for Climate Orders. [GET /v1/climate/orders (400)]',
+      true,
+    ],
     ['unrecognized error', 'Something went wrong', false],
     ['non-StripeApiRequestError', null, false],
   ])('%s', (_label, message, expected) => {

--- a/packages/source-stripe/src/src-list-api.ts
+++ b/packages/source-stripe/src/src-list-api.ts
@@ -157,6 +157,11 @@ const SKIPPABLE_ERROR_MESSAGES = [
   //  https://dashboard.stripe.com/identity to get started.
   //  [GET /v1/identity/verification_reports (400)]"
   'Your account is not set up to use Identity',
+
+  // climate_order
+  // "This account is not eligible for Climate Orders.
+  //  [GET /v1/climate/orders (400)]"
+  'This account is not eligible for Climate Orders',
 ]
 
 export function isSkippableError(err: unknown): boolean {


### PR DESCRIPTION
## Summary

<!-- What changed in plain language -->

- Fixes: `Account not eligible for Climate Orders`

## How to test (optional)

<!-- Add steps only if useful -->

-

## Related

<!-- Link issue(s) if any -->

- Closes #

> Thanks for contributing ❤️
